### PR TITLE
build: give task 1GB of memory

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -49,5 +49,5 @@
   "executionRoleArn": "ecsTaskExecutionRole",
   "networkMode": "awsvpc",
   "cpu": "256",
-  "memory": "512"
+  "memory": "1024"
 }


### PR DESCRIPTION
512mb is not enough to start the service, assigned 1GB of memory to the ECS task.

TIS21-5056
TIS21-5055