### PR TITLE
feat: send templated email when COJ received

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -5,8 +5,20 @@
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-notifications:latest",
       "secrets": [
         {
+          "name": "APP_DOMAIN",
+          "valueFrom": "/tis/trainee/${environment}/app-domain"
+        },
+        {
           "name": "AWS_XRAY_DAEMON_ADDRESS",
           "valueFrom": "/tis/monitoring/xray/daemon-host"
+        },
+        {
+          "name": "COJ_RECEIVED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/coj/received"
+        },
+        {
+          "name": "EMAIL_SENDER",
+          "valueFrom": "/tis/trainee/${environment}/email-sender"
         },
         {
           "name": "SENTRY_DSN",
@@ -47,6 +59,7 @@
     "FARGATE"
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
+  "taskRoleArn": "tis-trainee-notifications_task-role_${environment}",
   "networkMode": "awsvpc",
   "cpu": "256",
   "memory": "1024"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name                              | Description                                                                                                             | Default     |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------|
-| AWS_XRAY_DAEMON_ADDRESS           | The AWS XRay daemon host.                                                                                               |             |
-| ENVIRONMENT                       | The environment to log events against.                                                                                  | local       |
-| SENTRY_DSN                        | A Sentry error monitoring Data Source Name.                                                                             |             |
+| Name                    | Description                                                        | Default |
+|-------------------------|--------------------------------------------------------------------|---------|
+| APP_DOMAIN              | The domain to be used for links in email notifications. (Optional) |         |
+| AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host. (Optional)                               |         |
+| COJ_RECEIVED_QUEUE      | The queue URL for Conditions of Joining received events.           |         |
+| ENVIRONMENT             | The environment to log events against.                             | local   |
+| EMAIL_SENDER            | Where email notifications are to be sent from.                     |         |
+| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional)             |         |
 
 #### Usage Examples
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.0.2"
+version = "0.1.0"
 
 configurations {
   compileOnly {
@@ -22,11 +22,22 @@ repositories {
   mavenCentral()
 }
 
+dependencyManagement {
+  imports {
+    mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2"
+  }
+}
+
 dependencies {
   // Spring Boot starters
   implementation "org.springframework.boot:spring-boot-starter-actuator"
+  implementation "org.springframework.boot:spring-boot-starter-mail"
+  implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
   implementation "org.springframework.boot:spring-boot-starter-web"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
+
+  implementation "io.awspring.cloud:spring-cloud-aws-starter-ses"
+  implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/ProgrammeMembershipEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/ProgrammeMembershipEvent.java
@@ -21,21 +21,17 @@
 
 package uk.nhs.tis.trainee.notifications.dto;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import java.time.Instant;
 
 /**
  * A Programme Membership event.
  *
- * @param traineeId           The trainee associated with the Programme membership.
+ * @param personId            The person associated with the Programme membership.
  * @param managingDeanery     The programme owner.
  * @param conditionsOfJoining The Programme Membership's Conditions of Joining.
  */
-public record ProgrammeMembershipEvent(
-    @JsonAlias("traineeTisId")
-    String traineeId,
-    String managingDeanery,
-    ConditionsOfJoining conditionsOfJoining) {
+public record ProgrammeMembershipEvent(String personId, String managingDeanery,
+                                       ConditionsOfJoining conditionsOfJoining) {
 
   /**
    * A Programme Membership's Conditions of Joining details.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/ProgrammeMembershipEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/ProgrammeMembershipEvent.java
@@ -19,18 +19,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications;
+package uk.nhs.tis.trainee.notifications.dto;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import java.time.Instant;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeNotificationsApplicationTest {
+/**
+ * A Programme Membership event.
+ *
+ * @param traineeId           The trainee associated with the Programme membership.
+ * @param managingDeanery     The programme owner.
+ * @param conditionsOfJoining The Programme Membership's Conditions of Joining.
+ */
+public record ProgrammeMembershipEvent(
+    @JsonAlias("traineeTisId")
+    String traineeId,
+    String managingDeanery,
+    ConditionsOfJoining conditionsOfJoining) {
 
-  @Test
-  void contextLoads() {
+  /**
+   * A Programme Membership's Conditions of Joining details.
+   *
+   * @param syncedAt The timestamp for the signed Conditions of Joining being received.
+   */
+  public record ConditionsOfJoining(Instant syncedAt) {
 
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -85,7 +85,7 @@ public class ConditionsOfJoiningListener {
     }
 
     // Get the doctor's name.
-    String traineeId = event.traineeId();
+    String traineeId = event.personId();
     String destination = null;
     if (traineeId != null) {
       // TODO: get name and email from trainee ID.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -34,17 +34,27 @@ import org.springframework.stereotype.Component;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.service.EmailService;
 
+/**
+ * A listener for Conditions of Joining events.
+ */
 @Slf4j
 @Component
 public class ConditionsOfJoiningListener {
 
-  private static final String COJ_CONFIRMATION_SUBJECT = "We've received your Conditions of Joining";
-  private static final String COJ_CONFIRMATION_TEMPLATE = "email/coj-confirmation";
+  private static final String CONFIRMATION_SUBJECT = "We've received your Conditions of Joining";
+  private static final String CONFIRMATION_TEMPLATE = "email/coj-confirmation";
 
   private final EmailService emailService;
   private final URI appDomain;
   private final String timezone;
 
+  /**
+   * Construct a listener for conditions of joining events.
+   *
+   * @param emailService The service to use for sending emails.
+   * @param appDomain    The application domain to link to.
+   * @param timezone     The timezone to base event times on.
+   */
   public ConditionsOfJoiningListener(EmailService emailService,
       @Value("${application.domain}") URI appDomain,
       @Value("${application.timezone}") String timezone) {
@@ -53,6 +63,12 @@ public class ConditionsOfJoiningListener {
     this.timezone = timezone;
   }
 
+  /**
+   * Handle Conditions of Joining received events.
+   *
+   * @param event The program membership event.
+   * @throws MessagingException If the message could not be sent.
+   */
   @SqsListener("${application.queues.coj-received}")
   public void handleConditionsOfJoiningReceived(ProgrammeMembershipEvent event)
       throws MessagingException {
@@ -78,8 +94,8 @@ public class ConditionsOfJoiningListener {
     }
 
     if (destination != null) {
-      emailService.sendMessage(destination, COJ_CONFIRMATION_SUBJECT,
-          COJ_CONFIRMATION_TEMPLATE, templateVariables);
+      emailService.sendMessage(destination, CONFIRMATION_SUBJECT,
+          CONFIRMATION_TEMPLATE, templateVariables);
       log.info("COJ received notification sent to {}.", destination);
     } else {
       String message = "Could not find email address for user '%s'".formatted(traineeId);

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import jakarta.mail.MessagingException;
+import java.net.URI;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
+import uk.nhs.tis.trainee.notifications.service.EmailService;
+
+@Slf4j
+@Component
+public class ConditionsOfJoiningListener {
+
+  private static final String COJ_CONFIRMATION_SUBJECT = "We've received your Conditions of Joining";
+  private static final String COJ_CONFIRMATION_TEMPLATE = "email/coj-confirmation";
+
+  private final EmailService emailService;
+  private final URI appDomain;
+  private final String timezone;
+
+  public ConditionsOfJoiningListener(EmailService emailService,
+      @Value("${application.domain}") URI appDomain,
+      @Value("${application.timezone}") String timezone) {
+    this.emailService = emailService;
+    this.appDomain = appDomain;
+    this.timezone = timezone;
+  }
+
+  @SqsListener("${application.queues.coj-received}")
+  public void handleConditionsOfJoiningReceived(ProgrammeMembershipEvent event)
+      throws MessagingException {
+    log.info("Handling COJ received event {}.", event);
+    Map<String, Object> templateVariables = new HashMap<>();
+    templateVariables.put("domain", appDomain);
+    templateVariables.put("managingDeanery", event.managingDeanery());
+
+    // Convert the UTC timestamp to the receiver's timezone.
+    if (event.conditionsOfJoining() != null && event.conditionsOfJoining().syncedAt() != null) {
+      ZonedDateTime syncedAt = ZonedDateTime.ofInstant(event.conditionsOfJoining().syncedAt(),
+          ZoneId.of(timezone));
+      templateVariables.put("syncedAt", syncedAt);
+    }
+
+    // Get the doctor's name.
+    String traineeId = event.traineeId();
+    String destination = null;
+    if (traineeId != null) {
+      // TODO: get name and email from trainee ID.
+      templateVariables.put("name", "Dr Gilliam");
+      destination = "anthony.gilliam@tis.nhs.uk";
+    }
+
+    if (destination != null) {
+      emailService.sendMessage(destination, COJ_CONFIRMATION_SUBJECT,
+          COJ_CONFIRMATION_TEMPLATE, templateVariables);
+      log.info("COJ received notification sent to {}.", destination);
+    } else {
+      String message = "Could not find email address for user '%s'".formatted(traineeId);
+      throw new IllegalArgumentException(message);
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+/**
+ * A service for sending emails.
+ */
+@Slf4j
+@Service
+public class EmailService {
+
+  private final JavaMailSender mailSender;
+  private final TemplateEngine templateEngine;
+  private final String sender;
+
+  EmailService(JavaMailSender mailSender, TemplateEngine templateEngine,
+      @Value("${application.email.sender}") String sender) {
+    this.mailSender = mailSender;
+    this.templateEngine = templateEngine;
+    this.sender = sender;
+  }
+
+  /***
+   * Send an email message using a given template.
+   *
+   * @param recipient Where the email should be sent.
+   * @param subject The email subject line.
+   * @param templateName The email template to use.
+   * @param templateVariables The variables to pass to the template.
+   * @throws MessagingException When the message could not be sent.
+   */
+  public void sendMessage(String recipient, String subject, String templateName,
+      Map<String, Object> templateVariables) throws MessagingException {
+    log.info("Sending template {} to {}.", templateName, recipient);
+    Context templateContext = new Context();
+    templateContext.setVariables(templateVariables);
+    String text = templateEngine.process(templateName, templateContext);
+
+    MimeMessage mimeMessage = mailSender.createMimeMessage();
+    MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, StandardCharsets.UTF_8.name());
+    helper.setTo(recipient);
+    helper.setFrom(sender);
+    helper.setSubject(subject);
+    helper.setText(text, true);
+
+    mailSender.send(helper.getMimeMessage());
+    log.info("Sent template {} to {}.", templateName, recipient);
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -51,12 +51,12 @@ public class EmailService {
     this.sender = sender;
   }
 
-  /***
+  /**
    * Send an email message using a given template.
    *
-   * @param recipient Where the email should be sent.
-   * @param subject The email subject line.
-   * @param templateName The email template to use.
+   * @param recipient         Where the email should be sent.
+   * @param subject           The email subject line.
+   * @param templateName      The email template to use.
    * @param templateVariables The variables to pass to the template.
    * @throws MessagingException When the message could not be sent.
    */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,14 @@ server:
     context-path: /notifications
 
 application:
+  domain: ${APP_DOMAIN:}
+  email:
+      sender: ${EMAIL_SENDER}
   environment: ${ENVIRONMENT:local}
+  queues:
+      coj-received: ${COJ_RECEIVED_QUEUE}
+  timezone: Europe/London
+
 
 com:
   amazonaws:

--- a/src/main/resources/templates/email/coj-confirmation.html
+++ b/src/main/resources/templates/email/coj-confirmation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body>
+    <p>Dear <span data-th-text="${name} ?: _">Doctor</span>,</p>
+    <p>
+      We want to inform you that your local deanery office
+      <span th:text="${managingDeanery}? | (${managingDeanery}) | : _"></span>
+      has received your signed Conditions of Joining
+      <span th:text="${syncedAt}? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"></span>.
+    </p>
+    <p>
+      You can access a PDF of your signed Conditions of Joining by visiting
+      <a th:href="${not #strings.isEmpty(host)}? @{{host}/programmes(host=${host})} : _">TIS Self-Service</a>.
+    </p>
+  </body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -1,0 +1,186 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import jakarta.mail.MessagingException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
+import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.service.EmailService;
+
+class ConditionsOfJoiningListenerTest {
+
+  private static final URI APP_DOMAIN = URI.create("https://local.notifications.com");
+  private static final String TIMEZONE = "Europe/London";
+
+  private static final String TRAINEE_ID = "40";
+  private static final String MANAGING_DEANERY = "deanery1";
+  private static final Instant SYNCED_AT = Instant.now();
+
+  private ConditionsOfJoiningListener listener;
+  private EmailService emailService;
+
+  @BeforeEach
+  void setUp() {
+    emailService = mock(EmailService.class);
+    listener = new ConditionsOfJoiningListener(emailService, APP_DOMAIN, TIMEZONE);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCojReceivedWithoutTraineeId() {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(null, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> listener.handleConditionsOfJoiningReceived(event));
+  }
+
+  @Test
+  void shouldSetDestinationWhenCojReceived() throws MessagingException {
+    // TODO: rewrite for Cognito lookup.
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    verify(emailService).sendMessage(eq("anthony.gilliam@tis.nhs.uk"), any(), any(), any());
+  }
+
+  @Test
+  void shouldSetSubjectWhenCojReceived() throws MessagingException {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    verify(emailService).sendMessage(any(), eq("We've received your Conditions of Joining"), any(),
+        any());
+  }
+
+  @Test
+  void shouldSetTemplateWhenCojReceived() throws MessagingException {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    verify(emailService).sendMessage(any(), any(), eq("email/coj-confirmation"), any());
+  }
+
+  @Test
+  void shouldIncludeDomainWhenCojReceived() throws MessagingException {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+
+    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
+    assertThat("Unexpected domain.", templateVariables.get("domain"), is(APP_DOMAIN));
+  }
+
+  @Test
+  void shouldIncludeDeaneryWhenCojReceived() throws MessagingException {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+
+    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
+    assertThat("Unexpected managing deanery.", templateVariables.get("managingDeanery"),
+        is(MANAGING_DEANERY));
+  }
+
+  @Test
+  void shouldIncludeGmtSyncedAtWhenCojReceived() throws MessagingException {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(Instant.parse("2021-02-03T04:05:06Z")));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+
+    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
+    ZonedDateTime syncedAt = (ZonedDateTime) templateVariables.get("syncedAt");
+
+    assertThat("Unexpected synced at day.", syncedAt.getDayOfMonth(), is(3));
+    assertThat("Unexpected synced at month.", syncedAt.getMonth(), is(Month.FEBRUARY));
+    assertThat("Unexpected synced at year.", syncedAt.getYear(), is(2021));
+    assertThat("Unexpected synced at zone.", syncedAt.getZone(), is(ZoneId.of(TIMEZONE)));
+  }
+
+  @Test
+  void shouldIncludeBstSyncedAtWhenCojReceived() throws MessagingException {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(Instant.parse("2021-08-03T23:05:06Z")));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+
+    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
+    ZonedDateTime syncedAt = (ZonedDateTime) templateVariables.get("syncedAt");
+
+    assertThat("Unexpected synced at day.", syncedAt.getDayOfMonth(), is(4));
+    assertThat("Unexpected synced at month.", syncedAt.getMonth(), is(Month.AUGUST));
+    assertThat("Unexpected synced at year.", syncedAt.getYear(), is(2021));
+    assertThat("Unexpected synced at zone.", syncedAt.getZone(), is(ZoneId.of(TIMEZONE)));
+  }
+
+  @Test
+  void shouldIncludeNameWhenCojReceived() throws MessagingException {
+    // TODO: rewrite for Cognito lookup.
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+
+    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
+    assertThat("Unexpected name.", templateVariables.get("name"), is("Dr Gilliam"));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -48,7 +48,7 @@ class ConditionsOfJoiningListenerTest {
   private static final URI APP_DOMAIN = URI.create("https://local.notifications.com");
   private static final String TIMEZONE = "Europe/London";
 
-  private static final String TRAINEE_ID = "40";
+  private static final String PERSON_ID = "40";
   private static final String MANAGING_DEANERY = "deanery1";
   private static final Instant SYNCED_AT = Instant.now();
 
@@ -73,7 +73,7 @@ class ConditionsOfJoiningListenerTest {
   @Test
   void shouldSetDestinationWhenCojReceived() throws MessagingException {
     // TODO: rewrite for Cognito lookup.
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -83,7 +83,7 @@ class ConditionsOfJoiningListenerTest {
 
   @Test
   void shouldSetSubjectWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -94,7 +94,7 @@ class ConditionsOfJoiningListenerTest {
 
   @Test
   void shouldSetTemplateWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -104,7 +104,7 @@ class ConditionsOfJoiningListenerTest {
 
   @Test
   void shouldIncludeDomainWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -118,7 +118,7 @@ class ConditionsOfJoiningListenerTest {
 
   @Test
   void shouldIncludeDeaneryWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -133,7 +133,7 @@ class ConditionsOfJoiningListenerTest {
 
   @Test
   void shouldIncludeGmtSyncedAtWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(Instant.parse("2021-02-03T04:05:06Z")));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -152,7 +152,7 @@ class ConditionsOfJoiningListenerTest {
 
   @Test
   void shouldIncludeBstSyncedAtWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(Instant.parse("2021-08-03T23:05:06Z")));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -172,7 +172,7 @@ class ConditionsOfJoiningListenerTest {
   @Test
   void shouldIncludeNameWhenCojReceived() throws MessagingException {
     // TODO: rewrite for Cognito lookup.
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TRAINEE_ID, MANAGING_DEANERY,
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -1,0 +1,150 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.activation.DataHandler;
+import jakarta.mail.Address;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage.RecipientType;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+class EmailServiceTest {
+
+  private static final String RECIPIENT = "anthony.gilliam@tis.nhs.uk";
+  private static final String SENDER = "sender@test.email";
+
+  private EmailService service;
+  private JavaMailSender mailSender;
+  private TemplateEngine templateEngine;
+
+  @BeforeEach
+  void setUp() {
+    mailSender = mock(JavaMailSender.class);
+    when(mailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
+
+    templateEngine = mock(TemplateEngine.class);
+    when(templateEngine.process(any(String.class), any(Context.class))).thenReturn("");
+
+    service = new EmailService(mailSender, templateEngine, SENDER);
+  }
+
+  @Test
+  void shouldSendMessageToRecipient() throws MessagingException {
+    service.sendMessage(RECIPIENT, "", "", Map.of());
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Address[] toRecipients = message.getRecipients(RecipientType.TO);
+    assertThat("Unexpected recipient count.", toRecipients.length, is(1));
+    assertThat("Unexpected recipient.", toRecipients[0].toString(), is(RECIPIENT));
+
+    Address[] allRecipients = message.getAllRecipients();
+    assertThat("Unexpected recipient count.", allRecipients.length, is(1));
+  }
+
+  @Test
+  void shouldSendMessageFromSender() throws MessagingException {
+    service.sendMessage(RECIPIENT, "", "", Map.of());
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Address[] senders = message.getFrom();
+    assertThat("Unexpected sender count.", senders.length, is(1));
+    assertThat("Unexpected sender.", senders[0].toString(), is(SENDER));
+  }
+
+  @Test
+  void shouldSendMessageWithSubject() throws MessagingException {
+    String subject = "Test Notification";
+
+    service.sendMessage(RECIPIENT, subject, "", Map.of());
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    assertThat("Unexpected subject.", message.getSubject(), is(subject));
+  }
+
+  @Test
+  void shouldSendMessageWithBody() throws MessagingException, IOException {
+    String body = """
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+          </head>
+          <body>
+            <div>Test message body</div>
+          </body>
+        </html>
+        """;
+    when(templateEngine.process(any(String.class), any())).thenReturn(body);
+
+    service.sendMessage(RECIPIENT, "", "email/test.html", Map.of("key1", "value1"));
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    assertThat("Unexpected content.", message.getContent(), is(body));
+
+    DataHandler dataHandler = message.getDataHandler();
+    assertThat("Unexpected content type.", dataHandler.getContentType(),
+        is("text/html;charset=UTF-8"));
+  }
+
+  @Test
+  void shouldProcessTheTemplateWhenSendingMessage() throws MessagingException, IOException {
+    String templateName = "email/test.html";
+
+    service.sendMessage(RECIPIENT, "", templateName, Map.of("key1", "value1"));
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine).process(eq(templateName), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+    assertThat("Unexpected template variable count.", context.getVariableNames().size(), is(1));
+    assertThat("Unexpected template variable.", context.getVariable("key1"), is("value1"));
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+application:
+  email:
+    sender: dummy-value
+  queues:
+    coj-received: dummy-value
+
+spring:
+  cloud:
+    aws:
+      region:
+        static: eu-west-2
+      sqs:
+        enabled: false


### PR DESCRIPTION
When a COJ is received an event will be emitted containing the details of the programme membership and signed COJ.
Listen for COJ received events and send a personalised email to notification the user that their COJ was received.

The email should address `Dr <Surname>` when possible, otherwise `Dear Doctor` should be used.
If available, the LO and received date should be included in the email. A link should be provided to give easy access to TSS for download of PDF copies - it is not possible to route them directly to the COJ view due to application state, so they will be sent to the programmes tab instead.

TIS21-5058
TIS21-5055