### PR TITLE
feat: get user details from Cognito account

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -13,12 +13,36 @@
           "valueFrom": "/tis/monitoring/xray/daemon-host"
         },
         {
+          "name": "COGNITO_USER_POOL_ID",
+          "valueFrom": "trainee-cognito-pool-id-${environment}-v4"
+        },
+        {
           "name": "COJ_RECEIVED_QUEUE",
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/coj/received"
         },
         {
           "name": "EMAIL_SENDER",
           "valueFrom": "/tis/trainee/${environment}/email-sender"
+        },
+        {
+          "name": "REDIS_HOST",
+          "valueFrom": "/tis/trainee/${environment}/redis/host"
+        },
+        {
+          "name": "REDIS_PASSWORD",
+          "valueFrom": "/tis/trainee/${environment}/redis/password"
+        },
+        {
+          "name": "REDIS_PORT",
+          "valueFrom": "/tis/trainee/${environment}/redis/port"
+        },
+        {
+          "name": "REDIS_SSL",
+          "valueFrom": "/tis/trainee/${environment}/redis/ssl"
+        },
+        {
+          "name": "REDIS_USERNAME",
+          "valueFrom": "/tis/trainee/${environment}/redis/user"
         },
         {
           "name": "SENTRY_DSN",

--- a/README.md
+++ b/README.md
@@ -14,18 +14,58 @@ gradlew bootRun
 
 #### Pre-Requisites
 
+ - A Redis instance for caching Person ID to User ID mappings.
+ - A running instance of localstack or access to Amazon SQS, to retrieve
+   messages from the queue given as `COJ_RECEIVED_QUEUE`.
+ - `COJ_RECEIVED_QUEUE` should have a visibility timeout longer than the user
+   cache takes to build, failure to do so may lead to duplicate emails being
+   sent. See log message `Total time taken to cache all user accounts was:
+   <num>s` for time taken.
+ - Access to an Amazon Cognito User Pool to get user details.
+
+##### AWS Credentials
+
+AWS credentials are retrieved using the [DefaultCredentialsProvider], see the
+associated documentation for details of how to provide credentials.
+
+##### AWS Region
+
+The AWS region is retrieved using the [DefaultAwsRegionProviderChain], see the
+associated document for details of how to provide the region.
+
 #### Environmental Variables
 
-| Name                    | Description                                                        | Default |
-|-------------------------|--------------------------------------------------------------------|---------|
-| APP_DOMAIN              | The domain to be used for links in email notifications. (Optional) |         |
-| AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host. (Optional)                               |         |
-| COJ_RECEIVED_QUEUE      | The queue URL for Conditions of Joining received events.           |         |
-| ENVIRONMENT             | The environment to log events against.                             | local   |
-| EMAIL_SENDER            | Where email notifications are to be sent from.                     |         |
-| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional)             |         |
+| Name                    | Description                                                        | Default   |
+|-------------------------|--------------------------------------------------------------------|-----------|
+| APP_DOMAIN              | The domain to be used for links in email notifications. (Optional) |           |
+| AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host. (Optional)                               |           |
+| COGNITO_USER_POOL_ID    | The user pool to get user details from.                            |           |
+| COJ_RECEIVED_QUEUE      | The queue URL for Conditions of Joining received events.           |           |
+| ENVIRONMENT             | The environment to log events against.                             | local     |
+| EMAIL_SENDER            | Where email notifications are to be sent from.                     |           |
+| REDIS_HOST              | Redis server host                                                  | localhost |
+| REDIS_PASSWORD          | Login password of the redis server.                                | password  |
+| REDIS_PORT              | Redis server port.                                                 | 6379      |
+| REDIS_SSL               | Whether to enable SSL support.                                     | false     |
+| REDIS_USERNAME          | Login username of the redis server                                 | default   |
+| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional)             |           |
 
 #### Usage Examples
+
+##### Conditions of Joining Received
+
+The Conditions of Joining event should be sent to the `COJ_RECEIVED_QUEUE`, with
+the following structure.
+
+```json
+{
+  "personId": "47165",
+  "managingDeanery": "Health Education England North West",
+  "conditionsOfJoining": {
+    "syncedAt": "2022-08-01T22:01:02Z"
+  }
+}
+```
 
 #### Service Health
 
@@ -57,3 +97,6 @@ This project uses [Semantic Versioning](semver.org).
 
 ## License
 This project is license under [The MIT License (MIT)](LICENSE).
+
+[DefaultCredentialsProvider]:(https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html)
+[DefaultAwsRegionProviderChain]:(https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/regions/providers/DefaultAwsRegionProviderChain.html)

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.1.0"
+version = "0.2.0"
 
 configurations {
   compileOnly {
@@ -24,6 +24,7 @@ repositories {
 
 dependencyManagement {
   imports {
+    mavenBom "org.springframework.cloud:spring-cloud-dependencies:2022.0.4"
     mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2"
   }
 }
@@ -31,6 +32,7 @@ dependencyManagement {
 dependencies {
   // Spring Boot starters
   implementation "org.springframework.boot:spring-boot-starter-actuator"
+  implementation "org.springframework.boot:spring-boot-starter-data-redis"
   implementation "org.springframework.boot:spring-boot-starter-mail"
   implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
   implementation "org.springframework.boot:spring-boot-starter-web"
@@ -38,6 +40,8 @@ dependencies {
 
   implementation "io.awspring.cloud:spring-cloud-aws-starter-ses"
   implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs"
+  implementation "software.amazon.awssdk:cognitoidentityprovider"
+  implementation "com.amazonaws:aws-xray-recorder-sdk-spring:2.14.0"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"
@@ -54,7 +58,9 @@ dependencies {
   implementation "io.sentry:sentry-spring-boot-starter:$sentryVersion"
   implementation "io.sentry:sentry-logback:$sentryVersion"
 
-  implementation "com.amazonaws:aws-xray-recorder-sdk-spring:2.14.0"
+  testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
+  testImplementation "com.playtika.testcontainers:embedded-redis:3.0.1"
+  testImplementation "org.testcontainers:junit-jupiter:1.19.0"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/CacheConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/CacheConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Configuration for caching behaviour.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+
+  private final String prefix;
+  private final Duration ttl;
+
+  /**
+   * Configuration for caching behaviour.
+   *
+   * @param prefix The cache key prefix.
+   * @param ttl    The time-to-live for cached data.
+   */
+  CacheConfiguration(@Value("${application.cache.key-prefix}") String prefix,
+      @Value("${application.cache.time-to-live}") Duration ttl) {
+    this.prefix = prefix;
+    this.ttl = ttl;
+  }
+
+  /**
+   * Create a cache manager with configured TTL and Prefix.
+   *
+   * @param factory The connection factory to use.
+   * @return The built cache manager.
+   */
+  @Bean
+  public CacheManager cacheManager(RedisConnectionFactory factory) {
+    RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(ttl)
+        .prefixCacheNameWith(prefix + CacheKeyPrefix.SEPARATOR);
+
+    return RedisCacheManagerBuilder.fromConnectionFactory(factory)
+        .cacheDefaults(configuration)
+        .build();
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/CognitoConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/CognitoConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+
+/**
+ * Configuration for Amazon Cognito.
+ */
+@Configuration
+public class CognitoConfiguration {
+
+  /**
+   * Get a default Cognito IDP client.
+   *
+   * @return The built client.
+   */
+  @Bean
+  public CognitoIdentityProviderClient getCognitoIdentityProviderClient(
+      AwsRegionProvider regionProvider, AwsCredentialsProvider credentialsProvider) {
+    return CognitoIdentityProviderClient.builder()
+        .region(regionProvider.getRegion())
+        .credentialsProvider(credentialsProvider)
+        .build();
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/UserAccountDetails.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/UserAccountDetails.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.dto;
+
+/**
+ * Account details for an individual user.
+ *
+ * @param email      The account's registered email.
+ * @param familyName The user's family name.
+ */
+public record UserAccountDetails(String email, String familyName) {
+
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StopWatch;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminGetUserRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminGetUserResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
+import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+
+/**
+ * A service providing user account data.
+ */
+@Slf4j
+@Service
+public class UserAccountService {
+
+  private static final String USER_ID_CACHE = "UserId";
+
+  private static final String ATTRIBUTE_EMAIL = "email";
+  private static final String ATTRIBUTE_FAMILY_NAME = "family_name";
+
+  private final CognitoIdentityProviderClient cognitoClient;
+  private final String userPoolId;
+  private final Cache cache;
+
+  UserAccountService(CognitoIdentityProviderClient cognitoClient,
+      @Value("${application.cognito.user-pool-id}") String userPoolId, CacheManager cacheManager) {
+    this.cognitoClient = cognitoClient;
+    this.userPoolId = userPoolId;
+    cache = cacheManager.getCache(USER_ID_CACHE);
+  }
+
+  /**
+   * Get all user account IDs associated with the given person ID.
+   *
+   * @param personId The person ID to get the user IDs for.
+   * @return The found user IDs.
+   */
+  @Cacheable(USER_ID_CACHE)
+  public Set<String> getUserAccountIds(String personId) {
+    log.info("User account not found in the cache.");
+    cacheAllUserAccountIds();
+    return cache.get(personId, Set.class);
+  }
+
+  /**
+   * Retrieve and cache a mapping of all person IDs to user IDs.
+   */
+  private void cacheAllUserAccountIds() {
+    log.info("Caching all user account ids from Cognito.");
+    StopWatch cacheTimer = new StopWatch();
+    cacheTimer.start();
+
+    ListUsersRequest request = ListUsersRequest.builder()
+        .userPoolId(userPoolId)
+        .build();
+    ListUsersIterable responses = cognitoClient.listUsersPaginator(request);
+    responses.users().stream()
+        .map(UserType::attributes)
+        .map(attributes -> attributes.stream()
+            .collect(Collectors.toMap(AttributeType::name, AttributeType::value)))
+        .forEach(attr -> {
+          String tisId = attr.get("custom:tisId");
+          Set<String> ids = cache.get(tisId, Set.class);
+
+          if (ids == null) {
+            ids = new HashSet<>();
+          }
+
+          ids.add(attr.get("sub"));
+          cache.put(tisId, ids);
+        });
+
+    cacheTimer.stop();
+    log.info("Total time taken to cache all user accounts was: {}s",
+        cacheTimer.getTotalTimeSeconds());
+  }
+
+  /**
+   * Get the user account details for a given user ID.
+   *
+   * @param userAccountId The user ID to get the details of.
+   * @return The found user account details.
+   */
+  public UserAccountDetails getUserDetails(String userAccountId) {
+    log.info("Getting user details for account {}", userAccountId);
+    AdminGetUserRequest request = AdminGetUserRequest.builder()
+        .userPoolId(userPoolId)
+        .username(userAccountId)
+        .build();
+    AdminGetUserResponse response = cognitoClient.adminGetUser(request);
+    Map<String, String> attributes = response.userAttributes().stream()
+        .collect(Collectors.toMap(AttributeType::name, AttributeType::value));
+
+    return new UserAccountDetails(attributes.get(ATTRIBUTE_EMAIL),
+        attributes.get(ATTRIBUTE_FAMILY_NAME));
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ server:
     context-path: /notifications
 
 application:
+  cache:
+    key-prefix: Notifications
+    time-to-live: PT24H
+  cognito:
+    user-pool-id: ${COGNITO_USER_POOL_ID}
   domain: ${APP_DOMAIN:}
   email:
       sender: ${EMAIL_SENDER}
@@ -22,3 +27,13 @@ com:
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: application.environment
+
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      ssl:
+        enabled: ${REDIS_SSL:false}
+      username: ${REDIS_USERNAME:default}
+      password: ${REDIS_PASSWORD:password}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/CacheConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/CacheConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+class CacheConfigurationTest {
+
+  private CacheConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    this.configuration = new CacheConfiguration("CachePrefix", Duration.ofMinutes(5));
+  }
+
+  @Test
+  void cacheManager() {
+    CacheManager cacheManager = configuration.cacheManager(new LettuceConnectionFactory());
+
+    assertThat("Unexpected cache manager.", cacheManager, notNullValue());
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/CognitoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/CognitoConfigurationTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+
+class CognitoConfigurationTest {
+
+  private CognitoConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new CognitoConfiguration();
+  }
+
+  @Test
+  void getAwsCognitoIdentityProvider() {
+    AwsRegionProvider regionProvider = mock(AwsRegionProvider.class);
+    AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
+
+    CognitoIdentityProviderClient cognitoIdp = configuration.getCognitoIdentityProviderClient(
+        regionProvider, credentialsProvider);
+    assertThat("Unexpected provider.", cognitoIdp, notNullValue());
+
+    verify(regionProvider).getRegion();
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/CognitoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/CognitoConfigurationTest.java
@@ -25,10 +25,12 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 
@@ -44,6 +46,7 @@ class CognitoConfigurationTest {
   @Test
   void getAwsCognitoIdentityProvider() {
     AwsRegionProvider regionProvider = mock(AwsRegionProvider.class);
+    when(regionProvider.getRegion()).thenReturn(Region.AWS_GLOBAL);
     AwsCredentialsProvider credentialsProvider = mock(AwsCredentialsProvider.class);
 
     CognitoIdentityProviderClient cognitoIdp = configuration.getCognitoIdentityProviderClient(

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -26,8 +26,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import jakarta.mail.MessagingException;
 import java.net.URI;
@@ -36,12 +38,17 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 import uk.nhs.tis.trainee.notifications.service.EmailService;
+import uk.nhs.tis.trainee.notifications.service.UserAccountService;
 
 class ConditionsOfJoiningListenerTest {
 
@@ -49,20 +56,27 @@ class ConditionsOfJoiningListenerTest {
   private static final String TIMEZONE = "Europe/London";
 
   private static final String PERSON_ID = "40";
+  private static final String USER_ID = UUID.randomUUID().toString();
   private static final String MANAGING_DEANERY = "deanery1";
   private static final Instant SYNCED_AT = Instant.now();
 
   private ConditionsOfJoiningListener listener;
+  private UserAccountService userAccountService;
   private EmailService emailService;
 
   @BeforeEach
   void setUp() {
+    userAccountService = mock(UserAccountService.class);
+    when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(Set.of(USER_ID));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(new UserAccountDetails("", ""));
+
     emailService = mock(EmailService.class);
-    listener = new ConditionsOfJoiningListener(emailService, APP_DOMAIN, TIMEZONE);
+    listener = new ConditionsOfJoiningListener(userAccountService, emailService, APP_DOMAIN,
+        TIMEZONE);
   }
 
   @Test
-  void shouldThrowExceptionWhenCojReceivedWithoutTraineeId() {
+  void shouldThrowExceptionWhenCojReceivedWithoutPersonId() {
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(null, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
@@ -71,8 +85,55 @@ class ConditionsOfJoiningListenerTest {
   }
 
   @Test
+  void shouldThrowExceptionWhenCojReceivedAndPersonIdNotFound() {
+    when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(Set.of());
+
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> listener.handleConditionsOfJoiningReceived(event));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCojReceivedAndMultiplePersonIdResults() {
+    when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(
+        Set.of(USER_ID, UUID.randomUUID().toString()));
+
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(null, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> listener.handleConditionsOfJoiningReceived(event));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCojReceivedAndUserDetailsNotFound() {
+    when(userAccountService.getUserDetails(USER_ID)).thenThrow(UserNotFoundException.class);
+
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    assertThrows(UserNotFoundException.class,
+        () -> listener.handleConditionsOfJoiningReceived(event));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCojReceivedAndSendingFails() throws MessagingException {
+    doThrow(MessagingException.class).when(emailService).sendMessage(any(), any(), any(), any());
+
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    assertThrows(MessagingException.class, () -> listener.handleConditionsOfJoiningReceived(event));
+  }
+
+
+  @Test
   void shouldSetDestinationWhenCojReceived() throws MessagingException {
-    // TODO: rewrite for Cognito lookup.
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails("anthony.gilliam@tis.nhs.uk", ""));
+
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
@@ -170,8 +231,10 @@ class ConditionsOfJoiningListenerTest {
   }
 
   @Test
-  void shouldIncludeNameWhenCojReceived() throws MessagingException {
-    // TODO: rewrite for Cognito lookup.
+  void shouldIncludeNameWhenCojReceivedAndNameAvailable() throws MessagingException {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails("", "Gilliam"));
+
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
@@ -182,5 +245,19 @@ class ConditionsOfJoiningListenerTest {
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected name.", templateVariables.get("name"), is("Dr Gilliam"));
+  }
+
+  @Test
+  void shouldAddressDoctorWhenCojReceivedAndNameNotAvailable() throws MessagingException {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+
+    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
+    assertThat("Unexpected name.", templateVariables.get("name"), is("Doctor"));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
+import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
+
+@SpringBootTest(properties = "embedded.containers.enabled=true")
+@ActiveProfiles({"redis", "test"})
+@Testcontainers(disabledWithoutDocker = true)
+@ExtendWith(MockitoExtension.class)
+class UserAccountServiceIntegrationTest {
+
+  private static final String PERSON_ID = "40";
+  private static final String USER_ID = UUID.randomUUID().toString();
+
+  private static final String ATTRIBUTE_PERSON_ID = "custom:tisId";
+  private static final String ATTRIBUTE_USER_ID = "sub";
+
+  @MockBean
+  private CognitoIdentityProviderClient cognitoClient;
+
+  @Mock
+  private ListUsersIterable responses;
+  @Mock
+  private SdkIterable<UserType> users;
+
+  @Autowired
+  UserAccountService service;
+
+  @Autowired
+  CacheManager cacheManager;
+
+  private Cache userIdCache;
+
+  @BeforeEach
+  void setUp() {
+    userIdCache = cacheManager.getCache("UserId");
+    assert userIdCache != null;
+    userIdCache.clear();
+  }
+
+  @Test
+  void shouldBuildUserAccountIdCacheWhenPersonIdNotFound() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
+    when(responses.users()).thenReturn(users);
+
+    UserType user = UserType.builder().attributes(
+        AttributeType.builder().name(ATTRIBUTE_PERSON_ID).value(PERSON_ID).build(),
+        AttributeType.builder().name(ATTRIBUTE_USER_ID).value(USER_ID.toString()).build()
+    ).build();
+    when(users.stream()).thenReturn(Stream.of(user));
+
+    Set<String> returnedUserIds = service.getUserAccountIds(PERSON_ID);
+
+    assertThat("Unexpected user IDs count.", returnedUserIds.size(), is(1));
+    assertThat("Unexpected user IDs.", returnedUserIds, hasItem(USER_ID));
+
+    Set<String> cachedUserIds = userIdCache.get(PERSON_ID, Set.class);
+    assertThat("Unexpected user IDs.", cachedUserIds, notNullValue());
+    assertThat("Unexpected user IDs count.", cachedUserIds.size(), is(1));
+    assertThat("Unexpected user IDs.", cachedUserIds, hasItem(USER_ID));
+  }
+
+  @Test
+  void shouldReturnCachedUserAccountIdWhenPersonIdFound() {
+    userIdCache.put(PERSON_ID, Set.of(USER_ID));
+
+    Set<String> returnedUserIds = service.getUserAccountIds(PERSON_ID);
+
+    assertThat("Unexpected user IDs count.", returnedUserIds.size(), is(1));
+    assertThat("Unexpected user IDs.", returnedUserIds, hasItem(USER_ID));
+
+    verifyNoInteractions(cognitoClient);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
@@ -1,0 +1,203 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminGetUserRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminGetUserResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
+import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+
+class UserAccountServiceTest {
+
+  private static final String USER_POOL_ID = "userPool123";
+
+  private static final String USER_ID_1 = UUID.randomUUID().toString();
+  private static final String PERSON_ID_1 = "1";
+
+  private static final String USER_ID_2 = UUID.randomUUID().toString();
+  private static final String PERSON_ID_2 = "2";
+  private static final String EMAIL = "anthony.gilliam@tis.nhs.uk";
+  private static final String FAMILY_NAME = "Gilliam";
+
+  private static final String ATTRIBUTE_PERSON_ID = "custom:tisId";
+  private static final String ATTRIBUTE_USER_ID = "sub";
+
+  private UserAccountService service;
+  private CognitoIdentityProviderClient cognitoClient;
+  private Cache cache;
+
+  @BeforeEach
+  void setUp() {
+    cognitoClient = mock(CognitoIdentityProviderClient.class);
+    cache = mock(Cache.class);
+
+    CacheManager cacheManager = mock(CacheManager.class);
+    when(cacheManager.getCache("UserId")).thenReturn(cache);
+
+    service = new UserAccountService(cognitoClient, USER_POOL_ID, cacheManager);
+  }
+
+  @Test
+  void shouldRequestUserAccountIdsFromGivenUserPoolWhenGettingUserAccountIds() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    ListUsersIterable responses = mock(ListUsersIterable.class);
+
+    ArgumentCaptor<ListUsersRequest> requestCaptor = ArgumentCaptor.forClass(
+        ListUsersRequest.class);
+    when(cognitoClient.listUsersPaginator(requestCaptor.capture())).thenReturn(responses);
+
+    SdkIterable<UserType> users = mock(SdkIterable.class);
+    when(responses.users()).thenReturn(users);
+    when(users.stream()).thenReturn(Stream.of());
+
+    service.getUserAccountIds(PERSON_ID_1);
+
+    ListUsersRequest request = requestCaptor.getValue();
+    assertThat("Unexpected request user pool.", request.userPoolId(), is(USER_POOL_ID));
+  }
+
+  @Test
+  void shouldCacheAllUserAccountIdsWhenGettingUserAccountIds() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    ListUsersIterable responses = mock(ListUsersIterable.class);
+    when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
+
+    SdkIterable<UserType> users = mock(SdkIterable.class);
+    when(responses.users()).thenReturn(users);
+
+    UserType user1 = UserType.builder().attributes(
+        AttributeType.builder().name(ATTRIBUTE_PERSON_ID).value(PERSON_ID_1).build(),
+        AttributeType.builder().name(ATTRIBUTE_USER_ID).value(USER_ID_1.toString()).build()
+    ).build();
+    UserType user2 = UserType.builder().attributes(
+        AttributeType.builder().name(ATTRIBUTE_PERSON_ID).value(PERSON_ID_2).build(),
+        AttributeType.builder().name(ATTRIBUTE_USER_ID).value(USER_ID_2.toString()).build()
+    ).build();
+    when(users.stream()).thenReturn(Stream.of(user1, user2));
+
+    when(cache.get(any())).thenReturn(null);
+
+    service.getUserAccountIds(PERSON_ID_1);
+
+    verify(cache).put(PERSON_ID_1, Set.of(USER_ID_1));
+    verify(cache).put(PERSON_ID_2, Set.of(USER_ID_2));
+  }
+
+  @Test
+  void shouldCacheDuplicateUserAccountIdsWhenGettingUserAccountIds() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    ListUsersIterable responses = mock(ListUsersIterable.class);
+    when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
+
+    SdkIterable<UserType> users = mock(SdkIterable.class);
+    when(responses.users()).thenReturn(users);
+
+    UserType user2 = UserType.builder().attributes(
+        AttributeType.builder().name(ATTRIBUTE_PERSON_ID).value(PERSON_ID_1).build(),
+        AttributeType.builder().name(ATTRIBUTE_USER_ID).value(USER_ID_2.toString()).build()
+    ).build();
+    when(users.stream()).thenReturn(Stream.of(user2));
+
+    when(cache.get(PERSON_ID_1, Set.class)).thenReturn(new HashSet<>(Set.of(USER_ID_1)));
+
+    service.getUserAccountIds(PERSON_ID_1);
+
+    verify(cache).put(PERSON_ID_1, Set.of(USER_ID_1, USER_ID_2));
+  }
+
+  @Test
+  void shouldGetUserAccountIdsFromCache() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    ListUsersIterable responses = mock(ListUsersIterable.class);
+    when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
+
+    SdkIterable<UserType> users = mock(SdkIterable.class);
+    when(responses.users()).thenReturn(users);
+
+    when(cache.get(PERSON_ID_1, Set.class)).thenReturn(Set.of(USER_ID_1, USER_ID_2));
+
+    Set<String> userAccountIds = service.getUserAccountIds(PERSON_ID_1);
+
+    assertThat("Unexpected user IDs count.", userAccountIds.size(), is(2));
+    assertThat("Unexpected user IDs.", userAccountIds, hasItems(USER_ID_1, USER_ID_2));
+  }
+
+  @Test
+  void shouldGetUserDetailsWhenUserFound() {
+    AdminGetUserResponse response = AdminGetUserResponse.builder()
+        .userAttributes(
+            AttributeType.builder().name("email").value(EMAIL).build(),
+            AttributeType.builder().name("family_name").value(FAMILY_NAME).build()
+        ).build();
+
+    when(cognitoClient.adminGetUser(any(AdminGetUserRequest.class))).thenReturn(response);
+
+    UserAccountDetails userDetails = service.getUserDetails(USER_ID_1);
+
+    assertThat("Unexpected email.", userDetails.email(), is(EMAIL));
+    assertThat("Unexpected family name.", userDetails.familyName(), is(FAMILY_NAME));
+  }
+
+  @Test
+  void shouldGetEmptyUserDetailsWhenUserFoundWithMissingAttributes() {
+    AdminGetUserResponse response = AdminGetUserResponse.builder().build();
+    when(cognitoClient.adminGetUser(any(AdminGetUserRequest.class))).thenReturn(response);
+
+    UserAccountDetails userDetails = service.getUserDetails(USER_ID_1);
+
+    assertThat("Unexpected email.", userDetails.email(), nullValue());
+    assertThat("Unexpected family name.", userDetails.familyName(), nullValue());
+  }
+
+  @Test
+  void shouldThrowExceptionGettingUserDetailsWhenUserNotFound() {
+    when(cognitoClient.adminGetUser(any(AdminGetUserRequest.class))).thenThrow(
+        UserNotFoundException.class);
+
+    assertThrows(UserNotFoundException.class, () -> service.getUserDetails(USER_ID_1));
+  }
+}

--- a/src/test/resources/application-redis.yml
+++ b/src/test/resources/application-redis.yml
@@ -1,0 +1,7 @@
+spring:
+  data:
+    redis:
+      host: ${embedded.redis.host}
+      port: ${embedded.redis.port}
+      user: ${embedded.redis.user}
+      password: ${embedded.redis.password}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,7 +10,7 @@ spring:
   cloud:
     aws:
       region:
-        static: eu-west-2
+        static: aws-global
       sqs:
         enabled: false
     compatibility-verifier:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,6 @@
 application:
+  cognito:
+    user-pool-id: dummy-value
   email:
     sender: dummy-value
   queues:
@@ -11,3 +13,5 @@ spring:
         static: eu-west-2
       sqs:
         enabled: false
+    compatibility-verifier:
+      enabled: false # TODO: For unknown reasons there is currently a flagged incompatibility between Spring Cloud 2022.0.4 and Spring Boot 3.1.x.

--- a/src/test/resources/bootstrap.properties
+++ b/src/test/resources/bootstrap.properties
@@ -1,0 +1,1 @@
+embedded.containers.enabled=false


### PR DESCRIPTION
Create a UserAccountService which will provide methods for retrieving the user account ID and details for a given TIS person/trainee ID. As the person ID is stored in a custom attribute, the results will be cached for 24 hours due to the inability to filter by custom attributes when querying Cognito.

Update the COJ event handling to retrive the trainee's email and name to use for the email messaging.

TIS21-5058
TIS21-5055