### PR TITLE
fix: COJ confirmation's link to TSS not working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.2.0"
+version = "0.2.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -29,7 +29,6 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/resources/templates/email/coj-confirmation.html
+++ b/src/main/resources/templates/email/coj-confirmation.html
@@ -13,7 +13,7 @@
     </p>
     <p>
       You can access a PDF of your signed Conditions of Joining by visiting
-      <a th:href="${not #strings.isEmpty(host)}? @{{host}/programmes(host=${host})} : _">TIS Self-Service</a>.
+      <a th:href="${not #strings.isEmpty(domain)}? @{{domain}/programmes(domain=${domain})} : _">TIS Self-Service</a>.
     </p>
   </body>
 </html>


### PR DESCRIPTION
The `host` property was renamed to `domain` but the email template was not updated.

Update `coj-confirmation.html` to use `domain` instead of `host`, this will allow emails to include a link to TSS again.

TIS21-5058
TIS21-5055