### PR TITLE
fix: COJ notification formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.2.1"
+version = "0.2.2"
 
 configurations {
   compileOnly {
@@ -61,6 +61,8 @@ dependencies {
   testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
   testImplementation "com.playtika.testcontainers:embedded-redis:3.0.1"
   testImplementation "org.testcontainers:junit-jupiter:1.19.1"
+
+  testImplementation "org.jsoup:jsoup:1.16.1"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
@@ -56,9 +55,10 @@ public class ConditionsOfJoiningListener {
   /**
    * Construct a listener for conditions of joining events.
    *
-   * @param emailService The service to use for sending emails.
-   * @param appDomain    The application domain to link to.
-   * @param timezone     The timezone to base event times on.
+   * @param userAccountService The service for getting user account details.
+   * @param emailService       The service to use for sending emails.
+   * @param appDomain          The application domain to link to.
+   * @param timezone           The timezone to base event times on.
    */
   public ConditionsOfJoiningListener(UserAccountService userAccountService,
       EmailService emailService,
@@ -102,9 +102,7 @@ public class ConditionsOfJoiningListener {
         case 1 -> {
           UserAccountDetails userDetails = userAccountService.getUserDetails(
               userAccountIds.iterator().next());
-          String familyName = userDetails.familyName();
-          String name = Strings.isBlank(familyName) ? "Doctor" : "Dr " + familyName;
-          templateVariables.put("name", name);
+          templateVariables.put("name", userDetails.familyName());
           destination = userDetails.email();
         }
         default ->

--- a/src/main/resources/templates/email/coj-confirmation.html
+++ b/src/main/resources/templates/email/coj-confirmation.html
@@ -4,16 +4,28 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   </head>
   <body>
-    <p>Dear <span data-th-text="${name} ?: _">Doctor</span>,</p>
+    <p>
+      Dear
+      <span th:text="${not #strings.isEmpty(name)} ? |Dr ${name}| : _"
+        >Doctor</span
+      >,
+    </p>
     <p>
       We want to inform you that your local deanery office
-      <span th:text="${managingDeanery}? | (${managingDeanery}) | : _"></span>
-      has received your signed Conditions of Joining
-      <span th:text="${syncedAt}? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"></span>.
+      <span
+        th:text="${not #strings.isEmpty(managingDeanery)} ? | (${managingDeanery}) | : _"
+      ></span
+      >has received your signed Conditions of Joining<span
+        th:text="${syncedAt} ? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"
+      ></span
+      >.
     </p>
     <p>
       You can access a PDF of your signed Conditions of Joining by visiting
-      <a th:href="${not #strings.isEmpty(domain)}? @{{domain}/programmes(domain=${domain})} : _">TIS Self-Service</a>.
+      <a
+        th:href="${not #strings.isEmpty(domain)} ? @{{domain}/programmes(domain=${domain})} : _"
+        >TIS Self-Service</a
+      >.
     </p>
   </body>
 </html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -1,0 +1,323 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.ActiveProfiles;
+import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
+import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+import uk.nhs.tis.trainee.notifications.service.EmailService;
+import uk.nhs.tis.trainee.notifications.service.UserAccountService;
+
+@SpringBootTest(classes = {ConditionsOfJoiningListener.class, EmailService.class})
+@ActiveProfiles("test")
+@ImportAutoConfiguration(ThymeleafAutoConfiguration.class)
+class ConditionsOfJoiningListenerIntegrationTest {
+
+  private static final String PERSON_ID = "40";
+  private static final String USER_ID = UUID.randomUUID().toString();
+  private static final String EMAIL = "anthony.gilliam@tis.nhs.uk";
+  private static final String FAMILY_NAME = "Gilliam";
+  private static final String MANAGING_DEANERY = "Mars LO";
+  private static final Instant SYNCED_AT = Instant.parse("2023-08-01T00:00:00Z");
+  private static final String NEXT_STEPS_LINK = "https://local.notifications.com/programmes";
+
+  private static final String DEFAULT_GREETING = "Dear Doctor,";
+  private static final String DEFAULT_DETAIL = "We want to inform you that your local deanery"
+      + " office has received your signed Conditions of Joining.";
+  private static final String DEFAULT_NEXT_STEPS = "You can access a PDF of your signed Conditions"
+      + " of Joining by visiting TIS Self-Service.";
+
+  @MockBean
+  private JavaMailSender mailSender;
+
+  @MockBean
+  private UserAccountService userAccountService;
+
+  @Autowired
+  private EmailService emailService;
+
+  @Autowired
+  private ConditionsOfJoiningListener listener;
+
+  @BeforeEach
+  void setUp() {
+    when(mailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
+    when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(Set.of(USER_ID));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldSendDefaultCojConfirmationWhenTemplateVariablesNotAvailable(String missingValue)
+      throws Exception {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, missingValue,
+        new ConditionsOfJoining(null));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(EMAIL, missingValue));
+
+    // Create a new instance of the listener to allow overriding the domain.
+    URI missingDomain = missingValue == null ? null : URI.create(missingValue);
+    ConditionsOfJoiningListener listener = new ConditionsOfJoiningListener(userAccountService,
+        emailService, missingDomain, "Europe/London");
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+
+    Elements bodyChildren = content.body().children();
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+
+    Element greeting = bodyChildren.get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is(DEFAULT_GREETING));
+
+    Element eventDetail = bodyChildren.get(1);
+    assertThat("Unexpected element tag.", eventDetail.tagName(), is("p"));
+    assertThat("Unexpected event detail.", eventDetail.text(), is(DEFAULT_DETAIL));
+
+    Element nextSteps = bodyChildren.get(2);
+    assertThat("Unexpected element tag.", nextSteps.tagName(), is("p"));
+    assertThat("Unexpected next steps.", nextSteps.text(), is(DEFAULT_NEXT_STEPS));
+
+    Elements nextStepsLinks = nextSteps.getElementsByTag("a");
+    assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
+    Element tssLink = nextStepsLinks.get(0);
+    assertThat("Unexpected next steps link.", tssLink.attr("href"), is(""));
+  }
+
+  @Test
+  void shouldSendFullyTailoredCojConfirmationWhenAllTemplateVariablesAvailable() throws Exception {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(SYNCED_AT));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(EMAIL, FAMILY_NAME));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+
+    Elements bodyChildren = content.body().children();
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+
+    Element greeting = bodyChildren.get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is("Dear Dr Gilliam,"));
+
+    Element eventDetail = bodyChildren.get(1);
+    assertThat("Unexpected element tag.", eventDetail.tagName(), is("p"));
+    assertThat("Unexpected event detail.", eventDetail.text(),
+        is("We want to inform you that your local deanery office (Mars LO) has received your signed"
+            + " Conditions of Joining on 01 August 2023."));
+
+    Element nextSteps = bodyChildren.get(2);
+    assertThat("Unexpected element tag.", nextSteps.tagName(), is("p"));
+    assertThat("Unexpected next steps.", nextSteps.text(),
+        is("You can access a PDF of your signed Conditions of Joining by visiting TIS"
+            + " Self-Service."));
+
+    Elements nextStepsLinks = nextSteps.getElementsByTag("a");
+    assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
+    Element tssLink = nextStepsLinks.get(0);
+    assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+  }
+
+  @Test
+  void shouldSendCojConfirmationWithTailoredNameWhenAvailable() throws Exception {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, null,
+        new ConditionsOfJoining(null));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(EMAIL, FAMILY_NAME));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+
+    Elements bodyChildren = content.body().children();
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+
+    Element greeting = bodyChildren.get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is("Dear Dr Gilliam,"));
+
+    Element eventDetail = bodyChildren.get(1);
+    assertThat("Unexpected element tag.", eventDetail.tagName(), is("p"));
+    assertThat("Unexpected event detail.", eventDetail.text(), is(DEFAULT_DETAIL));
+
+    Element nextSteps = bodyChildren.get(2);
+    assertThat("Unexpected element tag.", nextSteps.tagName(), is("p"));
+    assertThat("Unexpected next steps.", nextSteps.text(), is(DEFAULT_NEXT_STEPS));
+
+    Elements nextStepsLinks = nextSteps.getElementsByTag("a");
+    assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
+    Element tssLink = nextStepsLinks.get(0);
+    assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+  }
+
+  @Test
+  void shouldSendCojConfirmationWithTailoredLocalOfficeWhenAvailable() throws Exception {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
+        new ConditionsOfJoining(null));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(EMAIL, null));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+
+    Elements bodyChildren = content.body().children();
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+
+    Element greeting = bodyChildren.get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is(DEFAULT_GREETING));
+
+    Element eventDetail = bodyChildren.get(1);
+    assertThat("Unexpected element tag.", eventDetail.tagName(), is("p"));
+    assertThat("Unexpected event detail.", eventDetail.text(),
+        is("We want to inform you that your local deanery office (Mars LO) has received your signed"
+            + " Conditions of Joining."));
+
+    Element nextSteps = bodyChildren.get(2);
+    assertThat("Unexpected element tag.", nextSteps.tagName(), is("p"));
+    assertThat("Unexpected next steps.", nextSteps.text(), is(DEFAULT_NEXT_STEPS));
+
+    Elements nextStepsLinks = nextSteps.getElementsByTag("a");
+    assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
+    Element tssLink = nextStepsLinks.get(0);
+    assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+  }
+
+  @Test
+  void shouldSendCojConfirmationWithTailoredSyncedAtWhenAvailable() throws Exception {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, null,
+        new ConditionsOfJoining(SYNCED_AT));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(EMAIL, null));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+
+    Elements bodyChildren = content.body().children();
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+
+    Element greeting = bodyChildren.get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is(DEFAULT_GREETING));
+
+    Element eventDetail = bodyChildren.get(1);
+    assertThat("Unexpected element tag.", eventDetail.tagName(), is("p"));
+    assertThat("Unexpected event detail.", eventDetail.text(),
+        is("We want to inform you that your local deanery office has received your signed"
+            + " Conditions of Joining on 01 August 2023."));
+
+    Element nextSteps = bodyChildren.get(2);
+    assertThat("Unexpected element tag.", nextSteps.tagName(), is("p"));
+    assertThat("Unexpected next steps.", nextSteps.text(), is(DEFAULT_NEXT_STEPS));
+
+    Elements nextStepsLinks = nextSteps.getElementsByTag("a");
+    assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
+    Element tssLink = nextStepsLinks.get(0);
+    assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+  }
+
+  @Test
+  void shouldSendCojConfirmationWithTailoredDomainWhenAvailable() throws Exception {
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, null,
+        new ConditionsOfJoining(null));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(EMAIL, null));
+
+    listener.handleConditionsOfJoiningReceived(event);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+
+    Elements bodyChildren = content.body().children();
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+
+    Element greeting = bodyChildren.get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is(DEFAULT_GREETING));
+
+    Element eventDetail = bodyChildren.get(1);
+    assertThat("Unexpected element tag.", eventDetail.tagName(), is("p"));
+    assertThat("Unexpected event detail.", eventDetail.text(), is(DEFAULT_DETAIL));
+
+    Element nextSteps = bodyChildren.get(2);
+    assertThat("Unexpected element tag.", nextSteps.tagName(), is("p"));
+    assertThat("Unexpected next steps.", nextSteps.text(), is(DEFAULT_NEXT_STEPS));
+
+    Elements nextStepsLinks = nextSteps.getElementsByTag("a");
+    assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
+    Element tssLink = nextStepsLinks.get(0);
+    assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -69,7 +69,7 @@ class ConditionsOfJoiningListenerTest {
   void setUp() {
     userAccountService = mock(UserAccountService.class);
     when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(Set.of(USER_ID));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(new UserAccountDetails("", ""));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(new UserAccountDetails("", null));
 
     emailService = mock(EmailService.class);
     listener = new ConditionsOfJoiningListener(userAccountService, emailService, APP_DOMAIN,
@@ -275,11 +275,11 @@ class ConditionsOfJoiningListenerTest {
     verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    assertThat("Unexpected name.", templateVariables.get("name"), is("Dr Gilliam"));
+    assertThat("Unexpected name.", templateVariables.get("name"), is("Gilliam"));
   }
 
   @Test
-  void shouldAddressDoctorWhenCojReceivedAndNameNotAvailable() throws MessagingException {
+  void shouldNotIncludeNameWhenCojReceivedAndNameNotAvailable() throws MessagingException {
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
@@ -289,6 +289,6 @@ class ConditionsOfJoiningListenerTest {
     verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    assertThat("Unexpected name.", templateVariables.get("name"), is("Doctor"));
+    assertThat("Unexpected name.", templateVariables.get("name"), nullValue());
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.util.ResourceUtils.CLASSPATH_URL_PREFIX;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.util.ResourceUtils;
+
+@SpringBootTest(classes = EmailService.class)
+@ImportAutoConfiguration(ThymeleafAutoConfiguration.class)
+class EmailServiceIntegrationTest {
+
+  private static final String RECIPIENT = "test@tis.nhs.uk";
+  private static final String SUBJECT = "Test Email";
+
+  @MockBean
+  private JavaMailSender mailSender;
+
+  @Autowired
+  private EmailService service;
+
+  @BeforeEach
+  void setUp() {
+    when(mailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
+  }
+
+  private static Stream<String> getEmailTemplates() throws FileNotFoundException {
+    File emailTemplateFolder = ResourceUtils.getFile(CLASSPATH_URL_PREFIX + "templates/email/");
+    return Arrays.stream(Objects.requireNonNull(emailTemplateFolder.listFiles()))
+        .map(file -> "email/" + file.getName().replace(".html", ""));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getEmailTemplates")
+  void shouldGreetDoctorsConsistentlyWhenNameNotAvailable(String template) throws Exception {
+    service.sendMessage(RECIPIENT, SUBJECT, template, Map.of());
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    Element greeting = body.children().get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is("Dear Doctor,"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getEmailTemplates")
+  void shouldGreetDoctorsConsistentlyWhenNameAvailable(String template) throws Exception {
+    service.sendMessage(RECIPIENT, SUBJECT, template, Map.of("name", "Gilliam"));
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    Element greeting = body.children().get(0);
+    assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
+    assertThat("Unexpected greeting.", greeting.text(), is("Dear Dr Gilliam,"));
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,7 @@
 application:
   cognito:
     user-pool-id: dummy-value
+  domain: https://local.notifications.com
   email:
     sender: dummy-value
   queues:


### PR DESCRIPTION
The Conditions of Joining notification is not correctly formatted in all cases. If the `syncedAt` timestamp is not available there is an additional space before the period of the event detail.

> We want to inform you that your local deanery office has received you
> signed conditions of joining .

Another issue was the managing deanery and name appearing incorrectly when empty strings rather than `null` values.

e.g.

> Dear Dr ,

> We want to inform you that your local deanery office () has received
your signed Conditions of Joining.

Update the COJ notification template to ensure that whitespace is used correct and more variables handle empty inputs as well as null.

Refactor ConditionsOfJoiningListener to just provide the family name to the template instead of pre-transforming it.

Write integration tests to verify the behaviour of the template. ConditionsOfJoiningListenerIntegrationTest should verify each combination of available template variables specific to Conditions of Joining notifications.
EmailServiceIntegrationTest should test that all email templates use a consistent style e.g. greeting.

TIS21-5115
TIS21-5134