### PR TITLE
refactor: move common functionality from listener to service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.2.2"
+version = "0.2.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -60,11 +60,6 @@ public class ConditionsOfJoiningListener {
   public void handleConditionsOfJoiningReceived(ProgrammeMembershipEvent event)
       throws MessagingException {
     log.info("Handling COJ received event {}.", event);
-    String traineeId = event.personId();
-
-    if (traineeId == null) {
-      throw new IllegalArgumentException("Unable to send notification as no trainee ID available");
-    }
 
     Map<String, Object> templateVariables = new HashMap<>();
     templateVariables.put("managingDeanery", event.managingDeanery());
@@ -73,6 +68,7 @@ public class ConditionsOfJoiningListener {
       templateVariables.put("syncedAt", event.conditionsOfJoining().syncedAt());
     }
 
+    String traineeId = event.personId();
     emailService.sendMessageToExistingUser(traineeId, CONFIRMATION_TEMPLATE, templateVariables);
     log.info("COJ received notification sent for trainee {}.", traineeId);
   }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -23,15 +23,24 @@ package uk.nhs.tis.trainee.notifications.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 
 /**
  * A service for sending emails.
@@ -40,41 +49,112 @@ import org.thymeleaf.context.Context;
 @Service
 public class EmailService {
 
+  private final UserAccountService userAccountService;
   private final JavaMailSender mailSender;
   private final TemplateEngine templateEngine;
   private final String sender;
+  private final URI appDomain;
+  private final String timezone;
 
-  EmailService(JavaMailSender mailSender, TemplateEngine templateEngine,
-      @Value("${application.email.sender}") String sender) {
+  EmailService(UserAccountService userAccountService, JavaMailSender mailSender,
+      TemplateEngine templateEngine, @Value("${application.email.sender}") String sender,
+      @Value("${application.domain}") URI appDomain,
+      @Value("${application.timezone}") String timezone) {
+    this.userAccountService = userAccountService;
     this.mailSender = mailSender;
     this.templateEngine = templateEngine;
     this.sender = sender;
+    this.appDomain = appDomain;
+    this.timezone = timezone;
   }
 
   /**
-   * Send an email message using a given template.
+   * Email a user with an existing account, the name and domain variables will be set if not
+   * provided.
    *
-   * @param recipient         Where the email should be sent.
-   * @param subject           The email subject line.
+   * @param traineeId         The trainee ID of the user.
    * @param templateName      The email template to use.
    * @param templateVariables The variables to pass to the template.
    * @throws MessagingException When the message could not be sent.
    */
-  public void sendMessage(String recipient, String subject, String templateName,
+  public void sendMessageToExistingUser(String traineeId, String templateName,
+      Map<String, Object> templateVariables)
+      throws MessagingException {
+    UserAccountDetails userDetails = getRecipientAccount(traineeId);
+
+    if (Strings.isBlank(userDetails.email())) {
+      String message = "Could not find email address for user '%s'".formatted(traineeId);
+      throw new IllegalArgumentException(message);
+    }
+
+    templateVariables = new HashMap<>(templateVariables);
+    templateVariables.putIfAbsent("name", userDetails.familyName());
+    sendMessage(userDetails.email(), templateName, templateVariables);
+  }
+
+  /**
+   * Send an email message using a given template, the domain variable will be set if not provided.
+   *
+   * @param recipient         Where the email should be sent.
+   * @param templateName      The email template to use.
+   * @param templateVariables The variables to pass to the template.
+   * @throws MessagingException When the message could not be sent.
+   */
+  private void sendMessage(String recipient, String templateName,
       Map<String, Object> templateVariables) throws MessagingException {
     log.info("Sending template {} to {}.", templateName, recipient);
+
+    // Add the application domain for any templates with hyperlinks.
+    templateVariables.putIfAbsent("domain", appDomain);
+
+    // Convert UTC timestamps to the Local Office timezone.
+    localizeTimestamps(templateVariables);
     Context templateContext = new Context();
     templateContext.setVariables(templateVariables);
-    String text = templateEngine.process(templateName, templateContext);
+
+    String subject = templateEngine.process(templateName, Set.of("subject"), templateContext);
+    String content = templateEngine.process(templateName, Set.of("content"), templateContext);
 
     MimeMessage mimeMessage = mailSender.createMimeMessage();
     MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, StandardCharsets.UTF_8.name());
     helper.setTo(recipient);
     helper.setFrom(sender);
     helper.setSubject(subject);
-    helper.setText(text, true);
+    helper.setText(content, true);
 
     mailSender.send(helper.getMimeMessage());
     log.info("Sent template {} to {}.", templateName, recipient);
+  }
+
+  /**
+   * Localize any compatible data types.
+   *
+   * @param templateVariables The template variables to localize.
+   */
+  private void localizeTimestamps(Map<String, Object> templateVariables) {
+    for (Entry<String, Object> entry : templateVariables.entrySet()) {
+
+      if (entry.getValue() instanceof Instant timestamp) {
+        ZonedDateTime localised = ZonedDateTime.ofInstant(timestamp, ZoneId.of(timezone));
+        entry.setValue(localised);
+      }
+    }
+  }
+
+  /**
+   * Get the user account for the given trainee ID.
+   *
+   * @param traineeId The trainee ID to get the account for.
+   * @return The found account.
+   */
+  private UserAccountDetails getRecipientAccount(String traineeId) {
+    Set<String> userAccountIds = userAccountService.getUserAccountIds(traineeId);
+
+    return switch (userAccountIds.size()) {
+      case 0 -> throw new IllegalArgumentException("No user account found for the given ID.");
+      case 1 -> userAccountService.getUserDetails(userAccountIds.iterator().next());
+      default ->
+          throw new IllegalArgumentException("Multiple user accounts found for the given ID.");
+    };
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -78,8 +78,11 @@ public class EmailService {
    * @throws MessagingException When the message could not be sent.
    */
   public void sendMessageToExistingUser(String traineeId, String templateName,
-      Map<String, Object> templateVariables)
-      throws MessagingException {
+      Map<String, Object> templateVariables) throws MessagingException {
+    if (traineeId == null) {
+      throw new IllegalArgumentException("Unable to send notification as no trainee ID available");
+    }
+
     UserAccountDetails userDetails = getRecipientAccount(traineeId);
 
     if (Strings.isBlank(userDetails.email())) {

--- a/src/main/resources/templates/email/coj-confirmation.html
+++ b/src/main/resources/templates/email/coj-confirmation.html
@@ -4,28 +4,25 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   </head>
   <body>
-    <p>
-      Dear
-      <span th:text="${not #strings.isEmpty(name)} ? |Dr ${name}| : _"
-        >Doctor</span
-      >,
-    </p>
-    <p>
-      We want to inform you that your local deanery office
-      <span
-        th:text="${not #strings.isEmpty(managingDeanery)} ? | (${managingDeanery}) | : _"
-      ></span
-      >has received your signed Conditions of Joining<span
-        th:text="${syncedAt} ? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"
-      ></span
-      >.
-    </p>
-    <p>
-      You can access a PDF of your signed Conditions of Joining by visiting
-      <a
-        th:href="${not #strings.isEmpty(domain)} ? @{{domain}/programmes(domain=${domain})} : _"
-        >TIS Self-Service</a
-      >.
-    </p>
+    <th:block th:fragment="subject">We've received your Conditions of Joining</th:block>
+    <th:block th:fragment="content">
+      <div th:replace="fragments/greeting :: body"></div>
+      <p>
+        We want to inform you that your local deanery office<span
+          th:text="${not #strings.isEmpty(managingDeanery)} ? | (${managingDeanery}) | : _"
+        >
+        </span
+        >has received your signed Conditions of Joining<span
+          th:text="${syncedAt} ? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"
+        ></span
+        >.
+      </p>
+      <p>
+        You can access a PDF of your signed Conditions of Joining by visiting
+        <a th:href="${not #strings.isEmpty(domain)} ? @{{domain}/programmes(domain=${domain})} : _"
+          >TIS Self-Service</a
+        >.
+      </p>
+    </th:block>
   </body>
 </html>

--- a/src/main/resources/templates/fragments/greeting.html
+++ b/src/main/resources/templates/fragments/greeting.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body>
+    <p>Dear <span th:text="${not #strings.isEmpty(name)} ? |Dr ${name}| : _">Doctor</span>,</p>
+  </body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -57,15 +57,6 @@ class ConditionsOfJoiningListenerTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenCojReceivedWithoutPersonId() {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(null, MANAGING_DEANERY,
-        new ConditionsOfJoining(SYNCED_AT));
-
-    assertThrows(IllegalArgumentException.class,
-        () -> listener.handleConditionsOfJoiningReceived(event));
-  }
-
-  @Test
   void shouldThrowExceptionWhenCojReceivedAndSendingFails() throws MessagingException {
     doThrow(MessagingException.class).when(emailService)
         .sendMessageToExistingUser(any(), any(), any());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -30,50 +30,30 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import jakarta.mail.MessagingException;
-import java.net.URI;
 import java.time.Instant;
-import java.time.Month;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent.ConditionsOfJoining;
-import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 import uk.nhs.tis.trainee.notifications.service.EmailService;
-import uk.nhs.tis.trainee.notifications.service.UserAccountService;
 
 class ConditionsOfJoiningListenerTest {
 
-  private static final URI APP_DOMAIN = URI.create("https://local.notifications.com");
-  private static final String TIMEZONE = "Europe/London";
-
   private static final String PERSON_ID = "40";
-  private static final String USER_ID = UUID.randomUUID().toString();
   private static final String MANAGING_DEANERY = "deanery1";
   private static final Instant SYNCED_AT = Instant.now();
 
   private ConditionsOfJoiningListener listener;
-  private UserAccountService userAccountService;
   private EmailService emailService;
 
   @BeforeEach
   void setUp() {
-    userAccountService = mock(UserAccountService.class);
-    when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(Set.of(USER_ID));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(new UserAccountDetails("", null));
-
     emailService = mock(EmailService.class);
-    listener = new ConditionsOfJoiningListener(userAccountService, emailService, APP_DOMAIN,
-        TIMEZONE);
+    listener = new ConditionsOfJoiningListener(emailService);
   }
 
   @Test
@@ -86,42 +66,9 @@ class ConditionsOfJoiningListenerTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenCojReceivedAndPersonIdNotFound() {
-    when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(Set.of());
-
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(SYNCED_AT));
-
-    assertThrows(IllegalArgumentException.class,
-        () -> listener.handleConditionsOfJoiningReceived(event));
-  }
-
-  @Test
-  void shouldThrowExceptionWhenCojReceivedAndMultiplePersonIdResults() {
-    when(userAccountService.getUserAccountIds(PERSON_ID)).thenReturn(
-        Set.of(USER_ID, UUID.randomUUID().toString()));
-
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(SYNCED_AT));
-
-    assertThrows(IllegalArgumentException.class,
-        () -> listener.handleConditionsOfJoiningReceived(event));
-  }
-
-  @Test
-  void shouldThrowExceptionWhenCojReceivedAndUserDetailsNotFound() {
-    when(userAccountService.getUserDetails(USER_ID)).thenThrow(UserNotFoundException.class);
-
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(SYNCED_AT));
-
-    assertThrows(UserNotFoundException.class,
-        () -> listener.handleConditionsOfJoiningReceived(event));
-  }
-
-  @Test
   void shouldThrowExceptionWhenCojReceivedAndSendingFails() throws MessagingException {
-    doThrow(MessagingException.class).when(emailService).sendMessage(any(), any(), any(), any());
+    doThrow(MessagingException.class).when(emailService)
+        .sendMessageToExistingUser(any(), any(), any());
 
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
@@ -129,29 +76,14 @@ class ConditionsOfJoiningListenerTest {
     assertThrows(MessagingException.class, () -> listener.handleConditionsOfJoiningReceived(event));
   }
 
-
   @Test
-  void shouldSetDestinationWhenCojReceived() throws MessagingException {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails("anthony.gilliam@tis.nhs.uk", ""));
-
+  void shouldSetTraineeIdWhenCojReceived() throws MessagingException {
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    verify(emailService).sendMessage(eq("anthony.gilliam@tis.nhs.uk"), any(), any(), any());
-  }
-
-  @Test
-  void shouldSetSubjectWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(SYNCED_AT));
-
-    listener.handleConditionsOfJoiningReceived(event);
-
-    verify(emailService).sendMessage(any(), eq("We've received your Conditions of Joining"), any(),
-        any());
+    verify(emailService).sendMessageToExistingUser(eq(PERSON_ID), any(), any());
   }
 
   @Test
@@ -161,21 +93,7 @@ class ConditionsOfJoiningListenerTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    verify(emailService).sendMessage(any(), any(), eq("email/coj-confirmation"), any());
-  }
-
-  @Test
-  void shouldIncludeDomainWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(SYNCED_AT));
-
-    listener.handleConditionsOfJoiningReceived(event);
-
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
-
-    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    assertThat("Unexpected domain.", templateVariables.get("domain"), is(APP_DOMAIN));
+    verify(emailService).sendMessageToExistingUser(any(), eq("email/coj-confirmation"), any());
   }
 
   @Test
@@ -186,7 +104,7 @@ class ConditionsOfJoiningListenerTest {
     listener.handleConditionsOfJoiningReceived(event);
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+    verify(emailService).sendMessageToExistingUser(any(), any(), templateVarsCaptor.capture());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected managing deanery.", templateVariables.get("managingDeanery"),
@@ -201,11 +119,10 @@ class ConditionsOfJoiningListenerTest {
     listener.handleConditionsOfJoiningReceived(event);
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+    verify(emailService).sendMessageToExistingUser(any(), any(), templateVarsCaptor.capture());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    ZonedDateTime syncedAt = (ZonedDateTime) templateVariables.get("syncedAt");
-    assertThat("Unexpected synced at.", syncedAt, nullValue());
+    assertThat("Unexpected synced at.", templateVariables.get("syncedAt"), nullValue());
   }
 
   @Test
@@ -216,79 +133,23 @@ class ConditionsOfJoiningListenerTest {
     listener.handleConditionsOfJoiningReceived(event);
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+    verify(emailService).sendMessageToExistingUser(any(), any(), templateVarsCaptor.capture());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    ZonedDateTime syncedAt = (ZonedDateTime) templateVariables.get("syncedAt");
-    assertThat("Unexpected synced at.", syncedAt, nullValue());
+    assertThat("Unexpected synced at.", templateVariables.get("syncedAt"), nullValue());
   }
 
   @Test
-  void shouldIncludeGmtSyncedAtWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(Instant.parse("2021-02-03T04:05:06Z")));
-
-    listener.handleConditionsOfJoiningReceived(event);
-
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
-
-    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    ZonedDateTime syncedAt = (ZonedDateTime) templateVariables.get("syncedAt");
-
-    assertThat("Unexpected synced at day.", syncedAt.getDayOfMonth(), is(3));
-    assertThat("Unexpected synced at month.", syncedAt.getMonth(), is(Month.FEBRUARY));
-    assertThat("Unexpected synced at year.", syncedAt.getYear(), is(2021));
-    assertThat("Unexpected synced at zone.", syncedAt.getZone(), is(ZoneId.of(TIMEZONE)));
-  }
-
-  @Test
-  void shouldIncludeBstSyncedAtWhenCojReceived() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(Instant.parse("2021-08-03T23:05:06Z")));
-
-    listener.handleConditionsOfJoiningReceived(event);
-
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
-
-    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    ZonedDateTime syncedAt = (ZonedDateTime) templateVariables.get("syncedAt");
-
-    assertThat("Unexpected synced at day.", syncedAt.getDayOfMonth(), is(4));
-    assertThat("Unexpected synced at month.", syncedAt.getMonth(), is(Month.AUGUST));
-    assertThat("Unexpected synced at year.", syncedAt.getYear(), is(2021));
-    assertThat("Unexpected synced at zone.", syncedAt.getZone(), is(ZoneId.of(TIMEZONE)));
-  }
-
-  @Test
-  void shouldIncludeNameWhenCojReceivedAndNameAvailable() throws MessagingException {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails("", "Gilliam"));
-
+  void shouldIncludeSyncedAtWhenCojReceivedWithValidSyncedAt() throws MessagingException {
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
         new ConditionsOfJoining(SYNCED_AT));
 
     listener.handleConditionsOfJoiningReceived(event);
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
+    verify(emailService).sendMessageToExistingUser(any(), any(), templateVarsCaptor.capture());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    assertThat("Unexpected name.", templateVariables.get("name"), is("Gilliam"));
-  }
-
-  @Test
-  void shouldNotIncludeNameWhenCojReceivedAndNameNotAvailable() throws MessagingException {
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(PERSON_ID, MANAGING_DEANERY,
-        new ConditionsOfJoining(SYNCED_AT));
-
-    listener.handleConditionsOfJoiningReceived(event);
-
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(emailService).sendMessage(any(), any(), any(), templateVarsCaptor.capture());
-
-    Map<String, Object> templateVariables = templateVarsCaptor.getValue();
-    assertThat("Unexpected name.", templateVariables.get("name"), nullValue());
+    assertThat("Unexpected synced at.", templateVariables.get("syncedAt"), is(SYNCED_AT));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.activation.DataHandler;
@@ -92,7 +93,15 @@ class EmailServiceTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenSendingToExistingUserAndPersonIdNotFound() {
+  void shouldThrowExceptionWhenCojReceivedWithoutTraineeId() {
+    assertThrows(IllegalArgumentException.class,
+        () -> service.sendMessageToExistingUser(null, null, null));
+
+    verifyNoInteractions(userAccountService);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenSendingToExistingUserAndTraineeIdNotFound() {
     when(userAccountService.getUserAccountIds(TRAINEE_ID)).thenReturn(Set.of());
 
     assertThrows(IllegalArgumentException.class,
@@ -100,7 +109,7 @@ class EmailServiceTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenSendingToExistingUserAndAndMultiplePersonIdResults() {
+  void shouldThrowExceptionWhenSendingToExistingUserAndAndMultipleTraineeIdResults() {
     when(userAccountService.getUserAccountIds(TRAINEE_ID)).thenReturn(
         Set.of(USER_ID, UUID.randomUUID().toString()));
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -21,11 +21,15 @@
 
 package uk.nhs.tis.trainee.notifications.service;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,37 +40,188 @@ import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMessage.RecipientType;
 import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 
 class EmailServiceTest {
 
   private static final String RECIPIENT = "anthony.gilliam@tis.nhs.uk";
+  private static final String TRAINEE_ID = "40";
+  private static final String USER_ID = UUID.randomUUID().toString();
   private static final String SENDER = "sender@test.email";
+  private static final URI APP_DOMAIN = URI.create("local.notifications.com");
+  private static final String TIMEZONE = "Europe/London";
 
   private EmailService service;
+  private UserAccountService userAccountService;
   private JavaMailSender mailSender;
   private TemplateEngine templateEngine;
 
   @BeforeEach
   void setUp() {
+    userAccountService = mock(UserAccountService.class);
+    when(userAccountService.getUserAccountIds(TRAINEE_ID)).thenReturn(Set.of(USER_ID));
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(RECIPIENT, null));
+
     mailSender = mock(JavaMailSender.class);
     when(mailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
 
     templateEngine = mock(TemplateEngine.class);
-    when(templateEngine.process(any(String.class), any(Context.class))).thenReturn("");
+    when(templateEngine.process(any(), any(), any(Context.class))).thenReturn("");
 
-    service = new EmailService(mailSender, templateEngine, SENDER);
+    service = new EmailService(userAccountService, mailSender, templateEngine, SENDER, APP_DOMAIN,
+        TIMEZONE);
   }
 
   @Test
-  void shouldSendMessageToRecipient() throws MessagingException {
-    service.sendMessage(RECIPIENT, "", "", Map.of());
+  void shouldThrowExceptionWhenSendingToExistingUserAndPersonIdNotFound() {
+    when(userAccountService.getUserAccountIds(TRAINEE_ID)).thenReturn(Set.of());
+
+    assertThrows(IllegalArgumentException.class,
+        () -> service.sendMessageToExistingUser(TRAINEE_ID, null, null));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenSendingToExistingUserAndAndMultiplePersonIdResults() {
+    when(userAccountService.getUserAccountIds(TRAINEE_ID)).thenReturn(
+        Set.of(USER_ID, UUID.randomUUID().toString()));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> service.sendMessageToExistingUser(TRAINEE_ID, null, null));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenSendingToExistingUserAndUserDetailsNotFound() {
+    when(userAccountService.getUserDetails(USER_ID)).thenThrow(UserNotFoundException.class);
+
+    assertThrows(UserNotFoundException.class,
+        () -> service.sendMessageToExistingUser(TRAINEE_ID, null, null));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldThrowExceptionWhenSendingToExistingUserAndEmailNotFound(String email) {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(email, "Gilliam"));
+
+    assertThrows(IllegalArgumentException.class,
+        () -> service.sendMessageToExistingUser(TRAINEE_ID, null, null));
+  }
+
+  @Test
+  void shouldGetNameFromUserAccountWhenNoNameProvided() throws MessagingException {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(RECIPIENT, "Gilliam"));
+
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of());
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine, atLeastOnce()).process(any(), any(), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+    assertThat("Unexpected name variable.", context.getVariable("name"), is("Gilliam"));
+  }
+
+  @Test
+  void shouldUseProvidedNameWhenNameProvided() throws MessagingException {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails(RECIPIENT, "Gilliam"));
+
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of("name", "Maillig"));
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine, atLeastOnce()).process(any(), any(), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+    assertThat("Unexpected name variable.", context.getVariable("name"), is("Maillig"));
+  }
+
+  @Test
+  void shouldGetDomainFromPropertiesWhenNoDomainProvided() throws MessagingException {
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of());
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine, atLeastOnce()).process(any(), any(), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+    assertThat("Unexpected domain variable.", context.getVariable("domain"), is(APP_DOMAIN));
+  }
+
+  @Test
+  void shouldUseProvidedDomainWhenDomainProvided() throws MessagingException {
+    URI domain = URI.create("local.override.com");
+
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of("domain", domain));
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine, atLeastOnce()).process(any(), any(), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+    assertThat("Unexpected domain variable.", context.getVariable("domain"), is(domain));
+  }
+
+  @Test
+  void shouldLocalizeTimestampWhenTimezoneGmt() throws MessagingException {
+    Instant instant = Instant.parse("2021-02-03T04:05:06Z");
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of("timestamp", instant));
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine, atLeastOnce()).process(any(), any(), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+    Object timestamp = context.getVariable("timestamp");
+    assertThat("Unexpected timestamp type.", timestamp, instanceOf(ZonedDateTime.class));
+
+    ZonedDateTime zonedDateTime = (ZonedDateTime) timestamp;
+    assertThat("Unexpected synced at day.", zonedDateTime.getDayOfMonth(), is(3));
+    assertThat("Unexpected synced at month.", zonedDateTime.getMonth(), is(Month.FEBRUARY));
+    assertThat("Unexpected synced at year.", zonedDateTime.getYear(), is(2021));
+    assertThat("Unexpected synced at zone.", zonedDateTime.getZone(), is(ZoneId.of(TIMEZONE)));
+  }
+
+  @Test
+  void shouldLocalizeTimestampWhenTimezoneBst() throws MessagingException {
+    Instant instant = Instant.parse("2021-08-03T23:05:06Z");
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of("timestamp", instant));
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine, atLeastOnce()).process(any(), any(), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+    Object timestamp = context.getVariable("timestamp");
+    assertThat("Unexpected timestamp type.", timestamp, instanceOf(ZonedDateTime.class));
+
+    ZonedDateTime zonedDateTime = (ZonedDateTime) timestamp;
+    assertThat("Unexpected synced at day.", zonedDateTime.getDayOfMonth(), is(4));
+    assertThat("Unexpected synced at month.", zonedDateTime.getMonth(), is(Month.AUGUST));
+    assertThat("Unexpected synced at year.", zonedDateTime.getYear(), is(2021));
+    assertThat("Unexpected synced at zone.", zonedDateTime.getZone(), is(ZoneId.of(TIMEZONE)));
+  }
+
+  @Test
+  void shouldSendMessageToUserAccountEmail() throws MessagingException {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserAccountDetails("anthony.gilliam@tis.nhs.uk", ""));
+
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of());
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
@@ -82,7 +237,7 @@ class EmailServiceTest {
 
   @Test
   void shouldSendMessageFromSender() throws MessagingException {
-    service.sendMessage(RECIPIENT, "", "", Map.of());
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of());
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
@@ -95,39 +250,30 @@ class EmailServiceTest {
 
   @Test
   void shouldSendMessageWithSubject() throws MessagingException {
-    String subject = "Test Notification";
+    String template = "Test subject";
+    when(templateEngine.process(any(), eq(Set.of("subject")), any())).thenReturn(template);
 
-    service.sendMessage(RECIPIENT, subject, "", Map.of());
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of());
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
-    assertThat("Unexpected subject.", message.getSubject(), is(subject));
+    assertThat("Unexpected subject.", message.getSubject(), is(template));
   }
 
   @Test
-  void shouldSendMessageWithBody() throws MessagingException, IOException {
-    String body = """
-        <!DOCTYPE html>
-        <html>
-          <head>
-            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-          </head>
-          <body>
-            <div>Test message body</div>
-          </body>
-        </html>
-        """;
-    when(templateEngine.process(any(String.class), any())).thenReturn(body);
+  void shouldSendMessageWithContent() throws MessagingException, IOException {
+    String template = "<div>Test message body</div>";
+    when(templateEngine.process(any(), eq(Set.of("content")), any())).thenReturn(template);
 
-    service.sendMessage(RECIPIENT, "", "email/test.html", Map.of("key1", "value1"));
+    service.sendMessageToExistingUser(TRAINEE_ID, "", Map.of());
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
-    assertThat("Unexpected content.", message.getContent(), is(body));
+    assertThat("Unexpected content.", message.getContent(), is(template));
 
     DataHandler dataHandler = message.getDataHandler();
     assertThat("Unexpected content type.", dataHandler.getContentType(),
@@ -138,13 +284,22 @@ class EmailServiceTest {
   void shouldProcessTheTemplateWhenSendingMessage() throws MessagingException, IOException {
     String templateName = "email/test.html";
 
-    service.sendMessage(RECIPIENT, "", templateName, Map.of("key1", "value1"));
+    service.sendMessageToExistingUser(TRAINEE_ID, templateName, Map.of("key1", "value1"));
 
+    ArgumentCaptor<Set<String>> selectorCaptor = ArgumentCaptor.forClass(Set.class);
     ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
-    verify(templateEngine).process(eq(templateName), contextCaptor.capture());
+    verify(templateEngine, times(2)).process(eq(templateName), selectorCaptor.capture(),
+        contextCaptor.capture());
 
-    Context context = contextCaptor.getValue();
-    assertThat("Unexpected template variable count.", context.getVariableNames().size(), is(1));
+    List<Set<String>> selectors = selectorCaptor.getAllValues();
+    assertThat("Unexpected selector.", selectors.get(0), is(Set.of("subject")));
+    assertThat("Unexpected selector.", selectors.get(1), is(Set.of("content")));
+
+    List<Context> contexts = contextCaptor.getAllValues();
+    Context context = contexts.get(0);
+    assertThat("Unexpected template variable.", context.getVariable("key1"), is("value1"));
+
+    context = contexts.get(1);
     assertThat("Unexpected template variable.", context.getVariable("key1"), is("value1"));
   }
 }


### PR DESCRIPTION
The ConditionsOfJoiningListener performs user account lookup and localisation, which should be moved to the EmailService so the behaviour is shared by other sent emails.
Refactor the implementation and tests to move this behaviour.

Refactor the coj-confirmation.html to extract the greeting in to a new greeting.html fragment, which can be shared across templates.

TIS21-5115
TIS21-5134