### PR TITLE
fix: NPE when no account found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.4.0"
+version = "0.4.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
@@ -68,13 +68,15 @@ public class UserAccountService {
    * Get all user account IDs associated with the given person ID.
    *
    * @param personId The person ID to get the user IDs for.
-   * @return The found user IDs.
+   * @return The found user IDs, or empty if not found.
    */
   @Cacheable(USER_ID_CACHE)
   public Set<String> getUserAccountIds(String personId) {
     log.info("User account not found in the cache.");
     cacheAllUserAccountIds();
-    return cache.get(personId, Set.class);
+
+    Set<String> userAccountIds = cache.get(personId, Set.class);
+    return userAccountIds != null ? userAccountIds : Set.of();
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
@@ -87,14 +87,14 @@ class UserAccountServiceIntegrationTest {
   }
 
   @Test
-  void shouldBuildUserAccountIdCacheWhenPersonIdNotFound() {
+  void shouldBuildUserAccountIdCacheWhenPersonNotInCache() {
     // The response is mocked instead of constructed due to embedded pagination handling.
     when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
     when(responses.users()).thenReturn(users);
 
     UserType user = UserType.builder().attributes(
         AttributeType.builder().name(ATTRIBUTE_PERSON_ID).value(PERSON_ID).build(),
-        AttributeType.builder().name(ATTRIBUTE_USER_ID).value(USER_ID.toString()).build()
+        AttributeType.builder().name(ATTRIBUTE_USER_ID).value(USER_ID).build()
     ).build();
     when(users.stream()).thenReturn(Stream.of(user));
 
@@ -110,7 +110,24 @@ class UserAccountServiceIntegrationTest {
   }
 
   @Test
-  void shouldReturnCachedUserAccountIdWhenPersonIdFound() {
+  void shouldReturnEmptyWhenPersonNotFoundAfterBuildingCache() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
+    when(responses.users()).thenReturn(users);
+
+    UserType user = UserType.builder().attributes(
+        AttributeType.builder().name(ATTRIBUTE_PERSON_ID).value(PERSON_ID).build(),
+        AttributeType.builder().name(ATTRIBUTE_USER_ID).value(USER_ID).build()
+    ).build();
+    when(users.stream()).thenReturn(Stream.of(user));
+
+    Set<String> returnedUserIds = service.getUserAccountIds("notFound");
+
+    assertThat("Unexpected user IDs count.", returnedUserIds.size(), is(0));
+  }
+
+  @Test
+  void shouldReturnCachedUserAccountIdWhenPersonInCache() {
     userIdCache.put(PERSON_ID, Set.of(USER_ID));
 
     Set<String> returnedUserIds = service.getUserAccountIds(PERSON_ID);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
@@ -167,6 +167,22 @@ class UserAccountServiceTest {
   }
 
   @Test
+  void shouldGetEmptyUserAccountIdsWhenAccountNotFoundAfterBuildingCache() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    ListUsersIterable responses = mock(ListUsersIterable.class);
+    when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
+
+    SdkIterable<UserType> users = mock(SdkIterable.class);
+    when(responses.users()).thenReturn(users);
+
+    when(cache.get(PERSON_ID_1, Set.class)).thenReturn(null);
+
+    Set<String> userAccountIds = service.getUserAccountIds(PERSON_ID_1);
+
+    assertThat("Unexpected user IDs count.", userAccountIds.size(), is(0));
+  }
+
+  @Test
   void shouldGetUserDetailsWhenUserFound() {
     AdminGetUserResponse response = AdminGetUserResponse.builder()
         .userAttributes(


### PR DESCRIPTION
When no account is found for a given trainee ID `null` is being passed back, causing downstream NullPointerExceptions. The UserAccountService should instead return an empty set.

TIS21-5115