### PR TITLE
feat: survey links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.4.1"
+version = "0.4.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/templates/email/coj-confirmation.html
+++ b/src/main/resources/templates/email/coj-confirmation.html
@@ -23,6 +23,11 @@
           >TIS Self-Service</a
         >.
       </p>
+      <hr>
+      <p id="SURVEY_LINK">
+        Was this email useful? Let us know what you think in a <a
+        href="https://forms.gle/P2cdQUgTDWqjUodJA">two-question survey</a>.
+      </p>
     </th:block>
   </body>
 </html>

--- a/src/main/resources/templates/email/form-updated.html
+++ b/src/main/resources/templates/email/form-updated.html
@@ -47,6 +47,12 @@
     </p>
   </span>
 </span>
+  <hr>
+  <p id="SURVEY_LINK">
+    Was this email useful? Let us know what you think in a <a
+    href="https://forms.gle/KJgQzMop2TbLTaZo7">two-question survey</a>.
+  </p>
+
 </th:block>
 </body>
 </html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -70,6 +70,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
   private static final String MANAGING_DEANERY = "Mars LO";
   private static final Instant SYNCED_AT = Instant.parse("2023-08-01T00:00:00Z");
   private static final String NEXT_STEPS_LINK = "https://local.notifications.com/programmes";
+  private static final String SURVEY_LINK = "https://forms.gle/P2cdQUgTDWqjUodJA";
 
   private static final String DEFAULT_GREETING = "Dear Doctor,";
   private static final String DEFAULT_DETAIL = "We want to inform you that your local deanery"
@@ -122,7 +123,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(5));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -140,6 +141,13 @@ class ConditionsOfJoiningListenerIntegrationTest {
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"), is(""));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -158,7 +166,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(5));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -180,6 +188,13 @@ class ConditionsOfJoiningListenerIntegrationTest {
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -198,7 +213,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(5));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -216,6 +231,13 @@ class ConditionsOfJoiningListenerIntegrationTest {
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -234,7 +256,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(5));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -254,6 +276,13 @@ class ConditionsOfJoiningListenerIntegrationTest {
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -272,7 +301,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(5));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -292,6 +321,13 @@ class ConditionsOfJoiningListenerIntegrationTest {
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -310,7 +346,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(3));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(5));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -328,5 +364,12 @@ class ConditionsOfJoiningListenerIntegrationTest {
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(1));
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"), is(NEXT_STEPS_LINK));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
@@ -71,6 +71,7 @@ class FormListenerIntegrationTest {
 
   private static final Instant FORM_UPDATED_AT = Instant.parse("2023-08-01T00:00:00Z");
   private static final String NEXT_STEPS_LINK = "https://local.notifications.com/form-type";
+  private static final String SURVEY_LINK = "https://forms.gle/KJgQzMop2TbLTaZo7";
 
   private static final String FORM_NAME = "123.json";
   private static final String FORM_SUBMITTED = "SUBMITTED";
@@ -130,7 +131,7 @@ class FormListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(2));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(4));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -149,6 +150,13 @@ class FormListenerIntegrationTest {
 
     Elements nextStepsLinks = nextSteps.getElementsByTag("a");
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(0));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -168,7 +176,7 @@ class FormListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(2));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(4));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -193,6 +201,13 @@ class FormListenerIntegrationTest {
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"),
         is(NEXT_STEPS_LINK));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -212,7 +227,7 @@ class FormListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(2));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(4));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -237,6 +252,13 @@ class FormListenerIntegrationTest {
     Element tssLink = nextStepsLinks.get(0);
     assertThat("Unexpected next steps link.", tssLink.attr("href"),
         is(NEXT_STEPS_LINK));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 
   @Test
@@ -256,7 +278,7 @@ class FormListenerIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
 
     Elements bodyChildren = content.body().children();
-    assertThat("Unexpected body children count.", bodyChildren.size(), is(2));
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(4));
 
     Element greeting = bodyChildren.get(0);
     assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
@@ -279,5 +301,12 @@ class FormListenerIntegrationTest {
 
     Elements nextStepsLinks = nextSteps.getElementsByTag("a");
     assertThat("Unexpected next steps link count.", nextStepsLinks.size(), is(0));
+
+    Element surveyPara = content.getElementById("SURVEY_LINK");
+    Elements surveyLinks = surveyPara.getElementsByTag("a");
+    assertThat("Unexpected survey link count.", surveyLinks.size(), is(1));
+    Element surveyLink = surveyLinks.get(0);
+    assertThat("Unexpected survey link.", surveyLink.attr("href"),
+        is(SURVEY_LINK));
   }
 }


### PR DESCRIPTION
This is a pretty dumb PR, but without knowing how often the survey URL might be updated/changed, it seemed a waste to engineer it any more abstractly.

Note: as per ticket, no credentials survey at this point. I'm guessing we'll iterate on this before the credentials work goes live anyhow.

TIS21-5184
TIS21-5185