### PR TITLE
feat: trainee history endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.0.0"
+version = "1.1.0"
 
 configurations {
   compileOnly {
@@ -60,7 +60,9 @@ dependencies {
   implementation "io.sentry:sentry-logback:$sentryVersion"
 
   testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
-  testImplementation "com.playtika.testcontainers:embedded-redis:3.0.5"
+  ext.playtikaTestcontainersVersion = "3.0.5"
+  testImplementation "com.playtika.testcontainers:embedded-redis:$playtikaTestcontainersVersion"
+  testImplementation "com.playtika.testcontainers:embedded-mongodb:$playtikaTestcontainersVersion"
   testImplementation "org.testcontainers:junit-jupiter:1.19.1"
 
   testImplementation "org.jsoup:jsoup:1.16.2"

--- a/src/main/java/uk/nhs/tis/trainee/notifications/api/HistoryResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/api/HistoryResource.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.api;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+
+/**
+ * A controller providing API access to notification history.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/history")
+public class HistoryResource {
+
+  private final HistoryService service;
+
+  /**
+   * Create an instance of the history controller.
+   *
+   * @param service The service used to access notification history.
+   */
+  public HistoryResource(HistoryService service) {
+    this.service = service;
+  }
+
+  /**
+   * Get the notification history for a given trainee.
+   *
+   * @param traineeId The ID of the trainee to get the history for.
+   * @return The found history, may be empty.
+   */
+  @GetMapping("/{traineeId}")
+  ResponseEntity<List<HistoryDto>> getTraineeHistory(@PathVariable String traineeId) {
+    log.info("Retrieving notification history for trainee {}.", traineeId);
+    List<HistoryDto> history = service.findAllForTrainee(traineeId);
+    log.info("Found {} notifications for trainee {}.", history.size(), traineeId);
+    return ResponseEntity.ok(history);
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/HistoryDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/HistoryDto.java
@@ -19,26 +19,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.repository;
+package uk.nhs.tis.trainee.notifications.dto;
 
-import java.util.List;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
-import uk.nhs.tis.trainee.notifications.model.History;
+import java.time.Instant;
+import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
 
 /**
- * A repository of historical notifications.
+ * A DTO for historical notification data.
+ *
+ * @param id      The ID of the notification.
+ * @param type    The type of notification e.g. EMAIL
+ * @param subject The subject of the notification e.g. COJ_CONFIRMATION
+ * @param contact The contact details used to send the notifiation.
+ * @param sentAt  The timestamp the notification was sent at.
  */
-@Repository
-public interface HistoryRepository extends
-    MongoRepository<History, ObjectId> {
+public record HistoryDto(String id, MessageType type, NotificationType subject, String contact,
+                         Instant sentAt) {
 
-  /**
-   * Find all history for the given recipient ID.
-   *
-   * @param recipientId The ID of the recipient to get the history for.
-   * @return The found history, empty if none found.
-   */
-  List<History> findAllByRecipient_IdOrderBySentAtDesc(String recipientId);
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
@@ -19,26 +19,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.repository;
+package uk.nhs.tis.trainee.notifications.mapper;
 
 import java.util.List;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants.ComponentModel;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.model.History;
 
 /**
- * A repository of historical notifications.
+ * A mapper to convert between notification history data types.
  */
-@Repository
-public interface HistoryRepository extends
-    MongoRepository<History, ObjectId> {
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface HistoryMapper {
 
   /**
-   * Find all history for the given recipient ID.
+   * Convert history entities to history DTOs.
    *
-   * @param recipientId The ID of the recipient to get the history for.
-   * @return The found history, empty if none found.
+   * @param entities The history entities to convert.
+   * @return The converted history DTOs.
    */
-  List<History> findAllByRecipient_IdOrderBySentAtDesc(String recipientId);
+  List<HistoryDto> toDtos(List<History> entities);
+
+  /**
+   * Convert a history entity to a history DTO.
+   *
+   * @param entity The history entity to convert.
+   * @return The converted history DTOs.
+   */
+  @Mapping(target = "id", expression = "java(entity.id().toString())")
+  @Mapping(target = "type", source = "recipient.type")
+  @Mapping(target = "subject", source = "type")
+  @Mapping(target = "contact", source = "recipient.contact")
+  @Mapping(target = "sentAt")
+  HistoryDto toDto(History entity);
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -21,7 +21,10 @@
 
 package uk.nhs.tis.trainee.notifications.service;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.mapper.HistoryMapper;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.repository.HistoryRepository;
 
@@ -32,12 +35,31 @@ import uk.nhs.tis.trainee.notifications.repository.HistoryRepository;
 public class HistoryService {
 
   private final HistoryRepository repository;
+  private final HistoryMapper mapper;
 
-  public HistoryService(HistoryRepository repository) {
+  public HistoryService(HistoryRepository repository, HistoryMapper mapper) {
     this.repository = repository;
+    this.mapper = mapper;
   }
 
+  /**
+   * Save a notification history.
+   *
+   * @param history The notification to save in history.
+   * @return The saved notification history.
+   */
   public History save(History history) {
     return repository.save(history);
+  }
+
+  /**
+   * Find all historic notifications for the given Trainee.
+   *
+   * @param traineeId The ID of the trainee to get notifications for.
+   * @return The found notifications, empty if none found.
+   */
+  public List<HistoryDto> findAllForTrainee(String traineeId) {
+    List<History> history = repository.findAllByRecipient_IdOrderBySentAtDesc(traineeId);
+    return mapper.toDtos(history);
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.api;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.CREDENTIAL_REVOKED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+
+@WebMvcTest(controllers = HistoryResource.class)
+@AutoConfigureMockMvc
+class HistoryResourceTest {
+
+  private static final String TRAINEE_ID = "40";
+  private static final String TRAINEE_CONTACT_1 = "test1@tis.nhs.uk";
+  private static final String TRAINEE_CONTACT_2 = "test2@tis.nhs.uk";
+  private static final String TRAINEE_CONTACT_3 = "test3@tis.nhs.uk";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private HistoryService service;
+
+
+  @Test
+  void shouldReturnEmptyArrayWhenNoHistoryFound() throws Exception {
+    when(service.findAllForTrainee(TRAINEE_ID)).thenReturn(List.of());
+
+    mockMvc.perform(get("/api/history/{traineeId}", TRAINEE_ID)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldReturnHistoryArrayWhenHistoryFound() throws Exception {
+    HistoryDto history1 = new HistoryDto("1", EMAIL, COJ_CONFIRMATION, TRAINEE_CONTACT_1,
+        Instant.MIN);
+    HistoryDto history2 = new HistoryDto("2", EMAIL, CREDENTIAL_REVOKED, TRAINEE_CONTACT_2,
+        Instant.EPOCH);
+    HistoryDto history3 = new HistoryDto("3", EMAIL, FORM_UPDATED, TRAINEE_CONTACT_3, Instant.MAX);
+
+    when(service.findAllForTrainee(TRAINEE_ID)).thenReturn(List.of(history1, history2, history3));
+
+    mockMvc.perform(get("/api/history/{traineeId}", TRAINEE_ID)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(3)))
+        .andExpect(jsonPath("$[0].id").value("1"))
+        .andExpect(jsonPath("$[0].type").value(EMAIL.toString()))
+        .andExpect(jsonPath("$[0].subject").value(COJ_CONFIRMATION.toString()))
+        .andExpect(jsonPath("$[0].contact").value(TRAINEE_CONTACT_1))
+        .andExpect(jsonPath("$[0].sentAt").value(Instant.MIN.toString()))
+        .andExpect(jsonPath("$[1].id").value("2"))
+        .andExpect(jsonPath("$[1].type").value(EMAIL.toString()))
+        .andExpect(jsonPath("$[1].subject").value(CREDENTIAL_REVOKED.toString()))
+        .andExpect(jsonPath("$[1].contact").value(TRAINEE_CONTACT_2))
+        .andExpect(jsonPath("$[1].sentAt").value(Instant.EPOCH.toString()))
+        .andExpect(jsonPath("$[2].id").value("3"))
+        .andExpect(jsonPath("$[2].type").value(EMAIL.toString()))
+        .andExpect(jsonPath("$[2].subject").value(FORM_UPDATED.toString()))
+        .andExpect(jsonPath("$[2].contact").value(TRAINEE_CONTACT_3))
+        .andExpect(jsonPath("$[2].sentAt").value(Instant.MAX.toString()));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+
+@SpringBootTest(
+    properties = {"embedded.containers.enabled=true", "embedded.containers.mongodb.enabled=true"})
+@ActiveProfiles({"mongodb", "test"})
+@Testcontainers(disabledWithoutDocker = true)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+class HistoryServiceIntegrationTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_CONTACT = "test@tis.nhs.uk";
+
+  private static final String TEMPLATE_NAME = "email/test-template";
+  private static final String TEMPLATE_VERSION = "v1.2.3";
+  private static final Map<String, Object> TEMPLATE_VARIABLES = Map.of(
+      "key1", "value1",
+      "key2", "value2");
+
+  private static final Instant SENT_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+  @Autowired
+  private HistoryService service;
+
+  @Test
+  void shouldSaveHistory() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+
+    History history = new History(null, FORM_UPDATED, recipientInfo, templateInfo, SENT_AT);
+    History savedHistory = service.save(history);
+
+    assertThat("Unexpected ID.", savedHistory.id(), instanceOf(ObjectId.class));
+    assertThat("Unexpected type.", savedHistory.type(), is(FORM_UPDATED));
+    assertThat("Unexpected sent at.", savedHistory.sentAt(), is(SENT_AT));
+
+    RecipientInfo savedRecipientInfo = savedHistory.recipient();
+    assertThat("Unexpected recipient id.", savedRecipientInfo.id(), is(TRAINEE_ID));
+    assertThat("Unexpected recipient type.", savedRecipientInfo.type(), is(EMAIL));
+    assertThat("Unexpected recipient contact.", savedRecipientInfo.contact(), is(TRAINEE_CONTACT));
+
+    TemplateInfo savedTemplateInfo = savedHistory.template();
+    assertThat("Unexpected template name.", savedTemplateInfo.name(), is(TEMPLATE_NAME));
+    assertThat("Unexpected template version.", savedTemplateInfo.version(), is(TEMPLATE_VERSION));
+    assertThat("Unexpected template variables.", savedTemplateInfo.variables(),
+        is(TEMPLATE_VARIABLES));
+  }
+
+  @Test
+  void shouldNotFindNotificationsWhenTraineeIdNotMatches() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+
+    History history = new History(null, FORM_UPDATED, recipientInfo, templateInfo, SENT_AT);
+    service.save(history);
+
+    List<HistoryDto> foundHistory = service.findAllForTrainee("notFound");
+
+    assertThat("Unexpected history count.", foundHistory.size(), is(0));
+  }
+
+  @Test
+  void shouldFindNotificationsWhenTraineeIdMatches() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+
+    History history = new History(null, FORM_UPDATED, recipientInfo, templateInfo, SENT_AT);
+    History savedHistory = service.save(history);
+
+    List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", foundHistory.size(), is(1));
+
+    HistoryDto historyDto = foundHistory.get(0);
+    assertThat("Unexpected history id.", historyDto.id(), is(savedHistory.id().toString()));
+    assertThat("Unexpected history type.", historyDto.type(), is(EMAIL));
+    assertThat("Unexpected history subject.", historyDto.subject(), is(FORM_UPDATED));
+    assertThat("Unexpected history contact.", historyDto.contact(), is(TRAINEE_CONTACT));
+    assertThat("Unexpected history sent at.", historyDto.sentAt(), is(SENT_AT));
+  }
+
+  @Test
+  void shouldSortFoundNotificationsBySentAtWhenMultipleFound() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+
+    Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    service.save(new History(null, FORM_UPDATED, recipientInfo, templateInfo, now));
+
+    Instant before = SENT_AT.minus(Duration.ofDays(1));
+    service.save(new History(null, FORM_UPDATED, recipientInfo, templateInfo, before));
+
+    Instant after = SENT_AT.plus(Duration.ofDays(1));
+    service.save(new History(null, FORM_UPDATED, recipientInfo, templateInfo, after));
+
+    List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", foundHistory.size(), is(3));
+
+    HistoryDto history1 = foundHistory.get(0);
+    assertThat("Unexpected history sent at.", history1.sentAt(), is(after));
+
+    HistoryDto history2 = foundHistory.get(1);
+    assertThat("Unexpected history sent at.", history2.sentAt(), is(now));
+
+    HistoryDto history3 = foundHistory.get(2);
+    assertThat("Unexpected history sent at.", history3.sentAt(), is(before));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -27,13 +27,17 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.mapper.HistoryMapperImpl;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
@@ -42,13 +46,16 @@ import uk.nhs.tis.trainee.notifications.repository.HistoryRepository;
 
 class HistoryServiceTest {
 
+  private static final String TRAINEE_ID = "40";
+  private static final String TRAINEE_CONTACT = "test@tis.nhs.uk";
+
   private HistoryService service;
   private HistoryRepository repository;
 
   @BeforeEach
   void setUp() {
     repository = mock(HistoryRepository.class);
-    service = new HistoryService(repository);
+    service = new HistoryService(repository, new HistoryMapperImpl());
   }
 
   @ParameterizedTest
@@ -75,5 +82,49 @@ class HistoryServiceTest {
     assertThat("Unexpected recipient.", savedHistory.recipient(), sameInstance(recipientInfo));
     assertThat("Unexpected template.", savedHistory.template(), sameInstance(templateInfo));
     assertThat("Unexpected sent at.", savedHistory.sentAt(), is(now));
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldFindNoneForTraineeWhenNotificationsNotExist(NotificationType notificationType) {
+    when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(List.of());
+
+    List<HistoryDto> historyDtos = service.findAllForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", historyDtos.size(), is(0));
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldFindAllForTraineeWhenNotificationsExist(NotificationType notificationType) {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo("test/template/", "v1.2.3", Map.of());
+
+    ObjectId id1 = ObjectId.get();
+    History history1 = new History(id1, notificationType, recipientInfo, templateInfo, Instant.MIN);
+
+    ObjectId id2 = ObjectId.get();
+    History history2 = new History(id2, notificationType, recipientInfo, templateInfo, Instant.MAX);
+
+    when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
+        List.of(history1, history2));
+
+    List<HistoryDto> historyDtos = service.findAllForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", historyDtos.size(), is(2));
+
+    HistoryDto historyDto1 = historyDtos.get(0);
+    assertThat("Unexpected history id.", historyDto1.id(), is(id1.toString()));
+    assertThat("Unexpected history type.", historyDto1.type(), is(EMAIL));
+    assertThat("Unexpected history subject.", historyDto1.subject(), is(notificationType));
+    assertThat("Unexpected history contact.", historyDto1.contact(), is(TRAINEE_CONTACT));
+    assertThat("Unexpected history sent at.", historyDto1.sentAt(), is(Instant.MIN));
+
+    HistoryDto historyDto2 = historyDtos.get(1);
+    assertThat("Unexpected history id.", historyDto2.id(), is(id2.toString()));
+    assertThat("Unexpected history type.", historyDto2.type(), is(EMAIL));
+    assertThat("Unexpected history subject.", historyDto2.subject(), is(notificationType));
+    assertThat("Unexpected history contact.", historyDto2.contact(), is(TRAINEE_CONTACT));
+    assertThat("Unexpected history sent at.", historyDto2.sentAt(), is(Instant.MAX));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
@@ -42,6 +42,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
@@ -52,7 +54,8 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
 import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
 import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
 
-@SpringBootTest(properties = "embedded.containers.enabled=true")
+@SpringBootTest(
+    properties = {"embedded.containers.enabled=true", "embedded.containers.redis.enabled=true"})
 @ActiveProfiles({"redis", "test"})
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(MockitoExtension.class)

--- a/src/test/resources/application-mongodb.yml
+++ b/src/test/resources/application-mongodb.yml
@@ -1,0 +1,4 @@
+spring:
+  data:
+    mongodb:
+      uri: mongodb://${embedded.mongodb.host}:${embedded.mongodb.port}/${embedded.mongodb.database}?retryWrites=false

--- a/src/test/resources/bootstrap.properties
+++ b/src/test/resources/bootstrap.properties
@@ -1,1 +1,3 @@
 embedded.containers.enabled=false
+embedded.containers.mongodb.enabled=false
+embedded.containers.redis.enabled=false


### PR DESCRIPTION
Create an endpoint at `/api/history/{id}` to allow the notification history to be requested for a given trainee ID.
The resulting array will be ordered by descending `sentAt` timestamp (most recent appearing first).

TIS21-5124
TIS21-5125