### PR TITLE
Fix/username parameter

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -82,7 +82,7 @@
         },
         {
           "name": "MYSQL_USER",
-          "valueFrom": "/tis/trainee/${environment}/mysql/user"
+          "valueFrom": "/tis/trainee/${environment}/mysql/username"
         },
         {
           "name": "MYSQL_PASSWORD",

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.2.0"
+version = "1.2.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
ECS deployment failing with
```
 invalid ssm parameters:
/tis/trainee/preprod/mysql/user
```

NO-TICKET