### PR TITLE
build: set workflow Java versions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,9 @@ jobs:
     uses: health-education-england/.github/.github/workflows/ci-cd-gradle.yml@main
     with:
       cluster-prefix: trainee
+      java-version: |
+        21
+        17
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
       reject-pat: ${{ secrets.PAT_REJECT_APPROVALS }}

--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -9,5 +9,9 @@ jobs:
   analysis:
     name: Analyse PR
     uses: health-education-england/.github/.github/workflows/pr-analysis-gradle.yml@main
+    with:
+      java-version: |
+        21
+        17
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Java 21 is not available during the workflow as the default is 17, Java 21 needs to be passed to the workflow to allow the build to complete.

Gradle 8.4 supports building FOR Java 21, but not running WITH Java 21. So we must also make Java 17 available in the workflow.

The last provided version will be used by default, so `21, 17` is the preferred order to ensure that Gradle gets a compatible version to build with.

TIS21-5124