### PR TITLE
fix: handle correct PM event data

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -133,6 +133,6 @@
   "executionRoleArn": "ecsTaskExecutionRole",
   "taskRoleArn": "tis-trainee-notifications_task-role_${environment}",
   "networkMode": "awsvpc",
-  "cpu": "256",
-  "memory": "1024"
+  "cpu": "512",
+  "memory": "2048"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.3.2"
+version = "1.3.3"
 
 configurations {
   checkstyleConfig
@@ -77,7 +77,7 @@ dependencies {
 
   testImplementation "org.jsoup:jsoup:1.16.2"
 
-  checkstyleConfig ("com.puppycrawl.tools:checkstyle:${checkstyle.toolVersion}") {
+  checkstyleConfig("com.puppycrawl.tools:checkstyle:${checkstyle.toolVersion}") {
     transitive = false
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/RecordDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/RecordDto.java
@@ -21,17 +21,16 @@
 
 package uk.nhs.tis.trainee.notifications.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.io.Serializable;
+import java.util.Map;
+import lombok.Data;
 
 /**
- * A Programme Membership event.
- *
- * @param tisId The TIS ID of the Programme membership.
- * @param recrd The record DTO map.
+ * A DTO representing data records, as they are received and passed-on by tis-trainee-sync.
  */
-public record ProgrammeMembershipEvent(
-    String tisId,
-    @JsonProperty("record") RecordDto recrd) implements Serializable {
+@Data
+public class RecordDto {
 
+  private Map<String, String> data;
+
+  private Map<String, String> metadata;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.tis.trainee.notifications.event;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -60,13 +59,9 @@ public class ProgrammeMembershipListener {
   public void handleProgrammeMembershipUpdate(ProgrammeMembershipEvent event) {
     log.info("Handling programme membership update event {}.", event);
     if (event.recrd() != null && event.recrd().getData() != null) {
-      try {
-        ProgrammeMembership programmeMembership = mapper.toEntity(event.recrd().getData());
-        boolean isExcluded = programmeMembershipService.isExcluded(programmeMembership);
-        log.info("Programme membership {}: excluded {}.", event.tisId(), isExcluded);
-      } catch (JsonProcessingException e) {
-        log.error("Invalid programme membership event: {}", event);
-      }
+      ProgrammeMembership programmeMembership = mapper.toEntity(event.recrd().getData());
+      boolean isExcluded = programmeMembershipService.isExcluded(programmeMembership);
+      log.info("Programme membership {}: excluded {}.", event.tisId(), isExcluded);
     } else {
       log.info("Ignoring non programme membership update event: {}", event);
     }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.mapper.ProgrammeMembershipMapper;
-import uk.nhs.tis.trainee.notifications.mapper.ProgrammeMembershipMapperImpl;
 import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
 import uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService;
 
@@ -39,14 +38,17 @@ import uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService;
 public class ProgrammeMembershipListener {
 
   private final ProgrammeMembershipService programmeMembershipService;
+  private final ProgrammeMembershipMapper mapper;
 
   /**
    * Construct a listener for programme membership events.
    *
    * @param programmeMembershipService The programme membership service.
    */
-  public ProgrammeMembershipListener(ProgrammeMembershipService programmeMembershipService) {
+  public ProgrammeMembershipListener(ProgrammeMembershipService programmeMembershipService,
+      ProgrammeMembershipMapper mapper) {
     this.programmeMembershipService = programmeMembershipService;
+    this.mapper = mapper;
   }
 
   /**
@@ -57,7 +59,6 @@ public class ProgrammeMembershipListener {
   @SqsListener("${application.queues.programme-membership}")
   public void handleProgrammeMembershipUpdate(ProgrammeMembershipEvent event) {
     log.info("Handling programme membership update event {}.", event);
-    ProgrammeMembershipMapper mapper = new ProgrammeMembershipMapperImpl();
     if (event.recrd() != null && event.recrd().getData() != null) {
       try {
         ProgrammeMembership programmeMembership = mapper.toEntity(event.recrd().getData());

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants.ComponentModel;
+import org.mapstruct.ReportingPolicy;
+import uk.nhs.tis.trainee.notifications.model.Curriculum;
+import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
+
+/**
+ * A mapper to map between TIS Data and Programme Membership Data.
+ */
+@Mapper(componentModel = ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ProgrammeMembershipMapper {
+
+  /**
+   * Map a record data map to a ProgrammeMembership.
+   *
+   * @param recordData The map to convert.
+   * @return The mapped ProgrammeMembership.
+   */
+  default ProgrammeMembership toEntity(Map<String, String> recordData)
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(recordData.get("tisId"));
+    programmeMembership.setStartDate(LocalDate.parse(recordData.get("startDate")));
+
+    List<Curriculum> curricula = objectMapper.readValue(recordData.get("curricula"),
+        new TypeReference<>() {
+        });
+    programmeMembership.setCurricula(curricula);
+
+    return programmeMembership;
+  }
+}
+
+

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
@@ -26,10 +26,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
 import org.mapstruct.ReportingPolicy;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
@@ -47,22 +47,25 @@ public interface ProgrammeMembershipMapper {
    * @param recordData The map to convert.
    * @return The mapped ProgrammeMembership.
    */
-  default ProgrammeMembership toEntity(Map<String, String> recordData)
-      throws JsonProcessingException {
+  @Mapping(target = "curricula", source = "recordData.curricula")
+  @Mapping(target = "tisId", source = "recordData.tisId")
+  @Mapping(target = "startDate", source = "recordData.startDate")
+  ProgrammeMembership toEntity(Map<String, String> recordData);
+
+  /**
+   * Map a serialized list of curricula.
+   *
+   * @param curriculumString The serialized curricula.
+   * @return The list of Curriculum records.
+   * @throws JsonProcessingException if curricula are malformed.
+   */
+  default List<Curriculum> toCurricula(String curriculumString) throws JsonProcessingException {
     ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-    ProgrammeMembership programmeMembership = new ProgrammeMembership();
-    programmeMembership.setTisId(recordData.get("tisId"));
-    programmeMembership.setStartDate(LocalDate.parse(recordData.get("startDate")));
-
-    List<Curriculum> curricula = objectMapper.readValue(recordData.get("curricula"),
+    return objectMapper.readValue(curriculumString,
         new TypeReference<>() {
         });
-    programmeMembership.setCurricula(curricula);
-
-    return programmeMembership;
   }
 }
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/Curriculum.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/Curriculum.java
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.dto;
+package uk.nhs.tis.trainee.notifications.model;
 
 /**
  * A Programme membership's Curriculum.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
@@ -11,9 +11,7 @@ import lombok.Data;
 @Data
 public class ProgrammeMembership {
 
-  //String personId,
   private String tisId;
-  //String programmeName,
   private LocalDate startDate;
   private List<Curriculum> curricula = new ArrayList<>();
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
@@ -1,0 +1,19 @@
+package uk.nhs.tis.trainee.notifications.model;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * A programme membership.
+ */
+@Data
+public class ProgrammeMembership {
+
+  //String personId,
+  private String tisId;
+  //String programmeName,
+  private LocalDate startDate;
+  private List<Curriculum> curricula = new ArrayList<>();
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -24,8 +24,8 @@ package uk.nhs.tis.trainee.notifications.service;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import uk.nhs.tis.trainee.notifications.dto.Curriculum;
-import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
+import uk.nhs.tis.trainee.notifications.model.Curriculum;
+import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
 
 /**
  * A service for Programme memberships.
@@ -47,15 +47,14 @@ public class ProgrammeMembershipService {
    * programme membership.
    *
    * <p>This will be TRUE if any of the following are true in relation to the curricula:
-   * 1. None have curriculumSubType = MEDICAL_CURRICULUM or MEDICAL_SPR
-   * 2. Any have specialtyName = 'Public health medicine'
-   * 3. Any have specialtyName = 'Foundation'.
+   * 1. None have curriculumSubType = MEDICAL_CURRICULUM or MEDICAL_SPR 2. Any have specialtyName =
+   * 'Public health medicine' or 'Foundation'.
    *
    * @param programmeMembership the Programme membership.
    * @return true if the programme membership is excluded.
    */
-  public boolean isExcluded(ProgrammeMembershipEvent programmeMembership) {
-    List<Curriculum> curricula = programmeMembership.curricula();
+  public boolean isExcluded(ProgrammeMembership programmeMembership) {
+    List<Curriculum> curricula = programmeMembership.getCurricula();
     if (curricula == null) {
       return true;
     }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -47,7 +47,7 @@ public class ProgrammeMembershipService {
    * programme membership.
    *
    * <p>This will be TRUE if any of the following are true in relation to the curricula:
-   * 1. None have curriculumSubType = MEDICAL_CURRICULUM or MEDICAL_SPR 2. Any have specialtyName =
+   * 1. None have curriculumSubType = MEDICAL_CURRICULUM or MEDICAL_SPR. 2. Any have specialtyName =
    * 'Public health medicine' or 'Foundation'.
    *
    * @param programmeMembership the Programme membership.

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
@@ -41,7 +41,6 @@ import uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService;
 class ProgrammeMembershipListenerTest {
 
   private static final String TIS_ID = "123";
-  private static final String PERSON_ID = "abc";
   private static final LocalDate START_DATE = LocalDate.now();
 
   private ProgrammeMembershipListener listener;
@@ -101,7 +100,6 @@ class ProgrammeMembershipListenerTest {
   ProgrammeMembershipEvent buildPmEvent() {
     Map<String, String> dataMap = new HashMap<>();
     dataMap.put("tisId", TIS_ID);
-    dataMap.put("personId", PERSON_ID);
     dataMap.put("startDate", START_DATE.toString());
     dataMap.put("curricula",
         "[{\"curriculumSubType\": \"some type\", \"curriculumSpecialty\": \"some specialty\"}]");

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
@@ -23,11 +23,9 @@ package uk.nhs.tis.trainee.notifications.event;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,18 +65,6 @@ class ProgrammeMembershipListenerTest {
     //ensure events without record data are ignored, and not requeued
     RecordDto recordDto = new RecordDto();
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, recordDto);
-
-    assertDoesNotThrow(() -> listener.handleProgrammeMembershipUpdate(event));
-  }
-
-  @Test
-  void shouldNotThrowAnExceptionOnEventProcessingException() throws JsonProcessingException {
-    //ensure otherwise mangled events are not requeued
-    RecordDto recordDto = new RecordDto();
-    recordDto.setData(new HashMap<>());
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, recordDto);
-
-    doThrow(JsonProcessingException.class).when(mapper).toEntity(any());
 
     assertDoesNotThrow(() -> listener.handleProgrammeMembershipUpdate(event));
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
@@ -23,9 +23,11 @@ package uk.nhs.tis.trainee.notifications.event;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.dto.RecordDto;
+import uk.nhs.tis.trainee.notifications.mapper.ProgrammeMembershipMapper;
 import uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService;
 
 class ProgrammeMembershipListenerTest {
@@ -43,11 +46,13 @@ class ProgrammeMembershipListenerTest {
 
   private ProgrammeMembershipListener listener;
   private ProgrammeMembershipService programmeMembershipService;
+  private ProgrammeMembershipMapper mapper;
 
   @BeforeEach
   void setUp() {
     programmeMembershipService = mock(ProgrammeMembershipService.class);
-    listener = new ProgrammeMembershipListener(programmeMembershipService);
+    mapper = mock(ProgrammeMembershipMapper.class);
+    listener = new ProgrammeMembershipListener(programmeMembershipService, mapper);
   }
 
   @Test
@@ -63,6 +68,18 @@ class ProgrammeMembershipListenerTest {
     //ensure events without record data are ignored, and not requeued
     RecordDto recordDto = new RecordDto();
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, recordDto);
+
+    assertDoesNotThrow(() -> listener.handleProgrammeMembershipUpdate(event));
+  }
+
+  @Test
+  void shouldNotThrowAnExceptionOnEventProcessingException() throws JsonProcessingException {
+    //ensure otherwise mangled events are not requeued
+    RecordDto recordDto = new RecordDto();
+    recordDto.setData(new HashMap<>());
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, recordDto);
+
+    doThrow(JsonProcessingException.class).when(mapper).toEntity(any());
 
     assertDoesNotThrow(() -> listener.handleProgrammeMembershipUpdate(event));
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
+import uk.nhs.tis.trainee.notifications.dto.RecordDto;
+import uk.nhs.tis.trainee.notifications.model.Curriculum;
+import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
+
+class ProgrammeMembershipMapperTest {
+
+  private static final String TIS_ID = "123";
+  private static final LocalDate START_DATE = LocalDate.now();
+  private static final String CURRICULUM_SUB_TYPE = "sub-type";
+  private static final String CURRICULUM_SPECIALTY = "specialty";
+
+  private ProgrammeMembershipMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ProgrammeMembershipMapperImpl();
+  }
+
+  @Test
+  void shouldMapProgrammeMembershipEventToProgrammeMembership() throws JsonProcessingException {
+    ProgrammeMembershipEvent event = buildPmEvent();
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(TIS_ID);
+    programmeMembership.setStartDate(START_DATE);
+    Curriculum curriculum = new Curriculum(CURRICULUM_SUB_TYPE, CURRICULUM_SPECIALTY);
+    programmeMembership.setCurricula(List.of(curriculum));
+
+    ProgrammeMembership returnedPm = mapper.toEntity(event.recrd().getData());
+
+    assertThat("Unexpected Tis Id.", returnedPm.getTisId(), is(TIS_ID));
+    assertThat("Unexpected start date.", returnedPm.getStartDate(), is(START_DATE));
+    assertThat("Unexpected curricula.", returnedPm.getCurricula(), is(List.of(curriculum)));
+  }
+
+
+  /**
+   * Helper function to construct a programme membership event.
+   *
+   * @return The ProgrammeMembershipEvent.
+   */
+  ProgrammeMembershipEvent buildPmEvent() {
+    Map<String, String> dataMap = new HashMap<>();
+    dataMap.put("tisId", TIS_ID);
+    dataMap.put("startDate", START_DATE.toString());
+    dataMap.put("curricula",
+        "[{\"curriculumSubType\": \"" + CURRICULUM_SUB_TYPE + "\", "
+            + "\"curriculumSpecialty\": \"" + CURRICULUM_SPECIALTY + "\"}]");
+    RecordDto data = new RecordDto();
+    data.setData(dataMap);
+    return new ProgrammeMembershipEvent(TIS_ID, data);
+  }
+
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -24,7 +24,6 @@ package uk.nhs.tis.trainee.notifications.mapper;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +50,7 @@ class ProgrammeMembershipMapperTest {
   }
 
   @Test
-  void shouldMapProgrammeMembershipEventToProgrammeMembership() throws JsonProcessingException {
+  void shouldMapProgrammeMembershipEventToProgrammeMembership() {
     ProgrammeMembershipEvent event = buildPmEvent();
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(TIS_ID);
@@ -65,7 +64,6 @@ class ProgrammeMembershipMapperTest {
     assertThat("Unexpected start date.", returnedPm.getStartDate(), is(START_DATE));
     assertThat("Unexpected curricula.", returnedPm.getCurricula(), is(List.of(curriculum)));
   }
-
 
   /**
    * Helper function to construct a programme membership event.

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
-import uk.nhs.tis.trainee.notifications.dto.Curriculum;
-import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
+import uk.nhs.tis.trainee.notifications.model.Curriculum;
+import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
 
 class ProgrammeMembershipServiceTest {
 
@@ -54,11 +54,10 @@ class ProgrammeMembershipServiceTest {
   @ValueSource(strings = {MEDICAL_CURRICULUM_1, MEDICAL_CURRICULUM_2})
   void shouldNotExcludePmWithMedicalSubtypeAndNoExcludedSpecialties(String subtype) {
     Curriculum theCurriculum = new Curriculum(subtype, "some-specialty");
-    List<Curriculum> curricula = List.of(theCurriculum, IGNORED_CURRICULUM);
-    ProgrammeMembershipEvent event
-        = new ProgrammeMembershipEvent(null, null, curricula);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setCurricula(List.of(theCurriculum, IGNORED_CURRICULUM));
 
-    boolean isExcluded = service.isExcluded(event);
+    boolean isExcluded = service.isExcluded(programmeMembership);
 
     assertThat("Unexpected excluded value.", isExcluded, is(false));
   }
@@ -66,10 +65,10 @@ class ProgrammeMembershipServiceTest {
   @Test
   void shouldExcludePmWithNoMedicalSubtype() {
     List<Curriculum> curricula = List.of(IGNORED_CURRICULUM);
-    ProgrammeMembershipEvent event
-        = new ProgrammeMembershipEvent(null, null, curricula);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setCurricula(curricula);
 
-    boolean isExcluded = service.isExcluded(event);
+    boolean isExcluded = service.isExcluded(programmeMembership);
 
     assertThat("Unexpected excluded value.", isExcluded, is(true));
   }
@@ -77,10 +76,10 @@ class ProgrammeMembershipServiceTest {
   @ParameterizedTest
   @NullAndEmptySource
   void shouldExcludePmWithNoCurricula(List<Curriculum> curricula) {
-    ProgrammeMembershipEvent event
-        = new ProgrammeMembershipEvent(null, null, curricula);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setCurricula(curricula);
 
-    boolean isExcluded = service.isExcluded(event);
+    boolean isExcluded = service.isExcluded(programmeMembership);
 
     assertThat("Unexpected excluded value.", isExcluded, is(true));
   }
@@ -90,11 +89,10 @@ class ProgrammeMembershipServiceTest {
   void shouldExcludePmWithExcludedSpecialty(String specialty) {
     Curriculum theCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, specialty);
     Curriculum anotherCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "some-specialty");
-    List<Curriculum> curricula = List.of(theCurriculum, anotherCurriculum);
-    ProgrammeMembershipEvent event
-        = new ProgrammeMembershipEvent(null, null, curricula);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setCurricula(List.of(theCurriculum, anotherCurriculum));
 
-    boolean isExcluded = service.isExcluded(event);
+    boolean isExcluded = service.isExcluded(programmeMembership);
 
     assertThat("Unexpected excluded value.", isExcluded, is(true));
   }


### PR DESCRIPTION
The PM updates arrive as a different DTO from the COJ-signed type events. Ignore the latter (which were being processed), and handle the former.

Also: bumped up memory and CPU to stabilise service.

TIS21-5154