### PR TITLE
fix: ignore unmapped curriculum properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.3.3"
+version = "1.3.4"
 
 configurations {
   checkstyleConfig

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/Curriculum.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/Curriculum.java
@@ -21,12 +21,15 @@
 
 package uk.nhs.tis.trainee.notifications.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * A Programme membership's Curriculum.
  *
  * @param curriculumSubType   The Curriculum subtype.
  * @param curriculumSpecialty The Curriculum specialty.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record Curriculum(
     String curriculumSubType,
     String curriculumSpecialty

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -74,9 +74,11 @@ class ProgrammeMembershipMapperTest {
     Map<String, String> dataMap = new HashMap<>();
     dataMap.put("tisId", TIS_ID);
     dataMap.put("startDate", START_DATE.toString());
+    dataMap.put("another-pm-property", "some value");
     dataMap.put("curricula",
         "[{\"curriculumSubType\": \"" + CURRICULUM_SUB_TYPE + "\", "
-            + "\"curriculumSpecialty\": \"" + CURRICULUM_SPECIALTY + "\"}]");
+            + "\"curriculumSpecialty\": \"" + CURRICULUM_SPECIALTY + "\", "
+            + "\"another-curriculum-property\": \"some value\"}]");
     RecordDto data = new RecordDto();
     data.setData(dataMap);
     return new ProgrammeMembershipEvent(TIS_ID, data);


### PR DESCRIPTION
As per errors:

```
2023-11-09T14:34:52.184+00:00 | Caused by: java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "curriculumTisId" (class uk.nhs.tis.trainee.notifications.model.Curriculum), not marked as ignorable (2 known properties: "curriculumSpecialty", "curriculumSubType"]) | awslogs-tis-trainee-notifications/tis-trainee-notifications/0173351ca7d3429582e8365d9c8ccab6
-- | -- | --
  | 2023-11-09T14:34:52.184+00:00 | at [Source: (String)"[{"curriculumTisId":"98","curriculumName":"General Practice","curriculumSubType":"MEDICAL_CURRICULUM","curriculumSpecialty":"General Practice",
```
