### PR TITLE
fix: ignore old History records without tisReference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.5.1"
+version = "1.5.2"
 
 configurations {
   checkstyleConfig

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -115,6 +115,7 @@ public class ProgrammeMembershipService {
     List<HistoryDto> correspondence = historyService.findAllForTrainee(traineeId);
     for (NotificationType milestone : NotificationType.getProgrammeUpdateNotificationTypes()) {
       Optional<HistoryDto> sentItem = correspondence.stream()
+          .filter(c -> c.tisReference() != null)
           .filter(c ->
               c.tisReference().type().equals(TisReferenceType.PROGRAMME_MEMBERSHIP)
                   && c.subject().equals(milestone)


### PR DESCRIPTION
They are cluttering up the logs with errors.

NO-TICKET