### PR TITLE
feat: add notification ID to email headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.5.2"
+version = "1.6.0"
 
 configurations {
   checkstyleConfig

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -122,6 +123,9 @@ public class EmailService {
     String content = templateService.process(templateName, Set.of("content"), templateContext);
 
     MimeMessage mimeMessage = mailSender.createMimeMessage();
+    ObjectId notificationId = ObjectId.get();
+    mimeMessage.addHeader("NotificationId", notificationId.toString());
+
     MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, StandardCharsets.UTF_8.name());
     helper.setTo(recipient);
     helper.setFrom(sender);
@@ -134,7 +138,7 @@ public class EmailService {
     RecipientInfo recipientInfo = new RecipientInfo(traineeId, EMAIL, recipient);
     TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
         templateVersion, templateVariables);
-    History history = new History(null, null, notificationType, recipientInfo,
+    History history = new History(notificationId, null, notificationType, recipientInfo,
         templateInfo, Instant.now());
     historyService.save(history);
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
@@ -70,7 +70,7 @@ public class UserAccountService {
    * @param personId The person ID to get the user IDs for.
    * @return The found user IDs, or empty if not found.
    */
-  @Cacheable(USER_ID_CACHE)
+  @Cacheable(cacheNames = USER_ID_CACHE, unless = "#result.isEmpty()")
   public Set<String> getUserAccountIds(String personId) {
     log.info("User account not found in the cache.");
     cacheAllUserAccountIds();


### PR DESCRIPTION
We need to be able to relate failed emails to the captured notification history. To do so, the notification history ID should be sent in the email headers so that it can be read later.

Update the EmailService to generate the ObjectId for the history and add it to the email message's headers.

Fix an issue in the UserId cache config that causes empty results to be cached, this resulted in IDs not being matched if they have recently been updated. This should never happen in the real world, but could easily cause issues in dev/stage environments when testing.

TIS21-5444
TIS21-5426