### PR TITLE
feat: update history when emails fail

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -25,6 +25,10 @@
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/credential/revoked"
         },
         {
+          "name": "EMAIL_FAILURE_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/email-failure"
+        },
+        {
           "name": "FORM_UPDATED_QUEUE",
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/form/updated"
         },

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.6.0"
+version = "1.7.0"
 
 configurations {
   checkstyleConfig
@@ -61,6 +61,10 @@ dependencies {
   implementation "org.mapstruct:mapstruct:${mapstructVersion}"
   annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
   testAnnotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+
+  ext.mongockVersion = "5.3.6"
+  implementation("io.mongock:mongock-springboot-v3:${mongockVersion}")
+  implementation("io.mongock:mongodb-springdata-v4-driver:${mongockVersion}")
 
   // Sentry reporting
   ext.sentryVersion = "6.32.0"

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/EmailEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/EmailEvent.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.tis.trainee.notifications.dto;
 
+import java.util.List;
+
 /**
  * A representation of the Amazon SES email notification event.
  *
@@ -56,7 +58,7 @@ public record EmailEvent(String notificationType, Mail mail, Bounce bounce, Comp
    *
    * @param headers The headers sent with the email.
    */
-  public record Mail(MailHeader[] headers) {
+  public record Mail(List<MailHeader> headers) {
 
     /**
      * An email header.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/EmailEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/EmailEvent.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.dto;
+
+/**
+ * A representation of the Amazon SES email notification event.
+ *
+ * @param notificationType The notification type.
+ * @param mail             The mail details.
+ * @param bounce           The bounce details, if this is a bounce event.
+ * @param complaint        The complaint details, if this is a complain event.
+ */
+public record EmailEvent(String notificationType, Mail mail, Bounce bounce, Complaint complaint) {
+
+  /**
+   * A representation of a bounce event data from Amazon SES.
+   *
+   * @param bounceType    The type of bounce, e.g. Permanent or Transient.
+   * @param bounceSubType The subtype of the bounce, e.g. General or MailboxFull
+   */
+  public record Bounce(String bounceType, String bounceSubType) {
+
+  }
+
+  /**
+   * A representation of a complaint event from Amazon SES.
+   *
+   * @param complaintSubType      The complaint sub type, either null or OnAccountSuppressionList.
+   * @param complaintFeedbackType The type of feedback from an ISP complaint, may be null.
+   */
+  public record Complaint(String complaintSubType, String complaintFeedbackType) {
+
+  }
+
+  /**
+   * A representation of the mail details included in an Amazon SES event.
+   *
+   * @param headers The headers sent with the email.
+   */
+  public record Mail(MailHeader[] headers) {
+
+    /**
+     * An email header.
+     *
+     * @param name  The name of the header.
+     * @param value The value of the header.
+     */
+    public record MailHeader(String name, String value) {
+
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/EmailListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/EmailListener.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Bounce;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Complaint;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+
+/**
+ * A listener for email events.
+ */
+@Slf4j
+@Component
+public class EmailListener {
+
+  private final HistoryService historyService;
+
+  public EmailListener(HistoryService historySrvice) {
+    this.historyService = historySrvice;
+  }
+
+  /**
+   * Handle failure events, such as bounce and complaints.
+   *
+   * @param event The email event from SES.
+   */
+  @SqsListener("${application.queues.email-failure}")
+  void handleFailure(EmailEvent event) {
+    String notificationId = getNotificationId(event);
+    log.info("Handling failure for notification {}.", notificationId);
+
+    String reason = switch (event.notificationType()) {
+      case "Bounce" -> getReason(event.bounce());
+      case "Complaint" -> getReason(event.complaint());
+      default -> null;
+    };
+
+    if (reason != null) {
+      log.info("Updating notification {} with failure detail '{}'", notificationId, reason);
+      historyService.updateStatus(notificationId, NotificationStatus.FAILED, reason);
+    }
+  }
+
+  /**
+   * Get the notification ID from the email event.
+   *
+   * @param event The email event to get the notification ID from.
+   * @return The notification ID from the email event headers.
+   */
+  private String getNotificationId(EmailEvent event) {
+    return Arrays.stream(event.mail().headers())
+        .filter(header -> header.name().equals("NotificationId"))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("No notification ID found."))
+        .value();
+  }
+
+  /**
+   * Get the reason text for a bounce event.
+   *
+   * @param bounce The bounce to construct a message for.
+   * @return The reason message.
+   */
+  private String getReason(Bounce bounce) {
+    return String.format("Bounce: %s - %s", bounce.bounceType(), bounce.bounceSubType());
+  }
+
+  /**
+   * Get the reason text for a complaint event.
+   *
+   * @param complaint The complaint to construct a message for.
+   * @return The reason message.
+   */
+  private String getReason(Complaint complaint) {
+    // Check for nulls here as the complaint fields are optional.
+    String reason = complaint.complaintSubType() != null ? complaint.complaintSubType()
+        : complaint.complaintFeedbackType();
+    return String.format("Complaint: %s", reason != null ? reason : "Undetermined");
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/EmailListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/EmailListener.java
@@ -73,7 +73,7 @@ public class EmailListener {
    * @return The notification ID from the email event headers.
    */
   private String getNotificationId(EmailEvent event) {
-    return Arrays.stream(event.mail().headers())
+    return event.mail().headers().stream()
         .filter(header -> header.name().equals("NotificationId"))
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException("No notification ID found."))

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
@@ -27,6 +27,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
 import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 
 /**
  * A mapper to convert between notification history data types.
@@ -55,4 +56,8 @@ public interface HistoryMapper {
   @Mapping(target = "contact", source = "recipient.contact")
   @Mapping(target = "sentAt")
   HistoryDto toDto(History entity);
+
+  @Mapping(target = "status", source = "status")
+  @Mapping(target = "statusDetail", source = "detail")
+  History updateStatus(History entity, NotificationStatus status, String detail);
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatus.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatus.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.result.UpdateResult;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
+
+/**
+ * Populate the status field for all previously sent notifications.
+ */
+@Slf4j
+@ChangeUnit(id = "populateNotificationHistoryStatus", order = "1")
+public class PopulateNotificationHistoryStatus {
+
+  private static final String PROFILE_COLLECTION = "History";
+  private final MongoTemplate mongoTemplate;
+
+
+  public PopulateNotificationHistoryStatus(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  /**
+   * Populate notification history status with default value.
+   */
+  @Execution
+  public void migrate() {
+    Query query = Query.query(Criteria.where("status").exists(false));
+    Update update = Update.update("status", NotificationStatus.SENT);
+    try {
+      UpdateResult result = mongoTemplate.updateMulti(query, update, PROFILE_COLLECTION);
+      log.info("Status set on {} historic notifications.", result.getModifiedCount());
+    } catch (MongoException e) {
+      log.error("Unable to populate historic statuses due to an error: {} ", e.toString());
+    }
+  }
+
+  /**
+   * Do not attempt rollback, the collection should be left as-is.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn(
+        "Rollback requested but not available for 'populateNotificationHistoryStatus' migration.");
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
@@ -45,7 +45,9 @@ public record History(
     NotificationType type,
     RecipientInfo recipient,
     TemplateInfo template,
-    Instant sentAt) {
+    Instant sentAt,
+    NotificationStatus status,
+    String statusDetail) {
 
   /**
    * A representation of a notified recipient.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
@@ -19,20 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications;
-
-import io.mongock.runner.springboot.EnableMongock;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+package uk.nhs.tis.trainee.notifications.model;
 
 /**
- * An application for the management and sending of trainee notifications.
+ * An enumeration of possible notification statuses.
  */
-@EnableMongock
-@SpringBootApplication
-public class TisTraineeNotificationsApplication {
-
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeNotificationsApplication.class);
-  }
+public enum NotificationStatus {
+  FAILED, SENT
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -43,6 +43,7 @@ import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
 
 /**
@@ -141,7 +142,7 @@ public class EmailService {
     TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
         templateVersion, templateVariables);
     History history = new History(notificationId, null, notificationType, recipientInfo,
-        templateInfo, Instant.now());
+        templateInfo, Instant.now(), NotificationStatus.SENT, null);
     historyService.save(history);
 
     log.info("Sent template {} to {}.", templateName, recipient);

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -32,6 +32,7 @@ import uk.nhs.tis.trainee.notifications.mapper.HistoryMapper;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
 import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.repository.HistoryRepository;
 
 /**
@@ -67,6 +68,28 @@ public class HistoryService {
    */
   public History save(History history) {
     return repository.save(history);
+  }
+
+  /**
+   * Update the status of a notification.
+   *
+   * @param notificationId The notification to update the status of.
+   * @param status         The new status.
+   * @param detail         The detail of the status.
+   * @return The updated notification history, or empty if not found.
+   */
+  public Optional<History> updateStatus(String notificationId, NotificationStatus status,
+      String detail) {
+    Optional<History> optionalHistory = repository.findById(new ObjectId(notificationId));
+
+    if (optionalHistory.isEmpty()) {
+      log.info("Notification {} was not found.", notificationId);
+      return Optional.empty();
+    }
+
+    History history = optionalHistory.get();
+    history = mapper.updateStatus(history, status, detail);
+    return Optional.of(repository.save(history));
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -35,6 +35,7 @@ import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
 import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
 
@@ -107,7 +108,7 @@ public class NotificationService implements Job {
         jobDetails.get(TIS_ID).toString());
 
     History history = new History(objectId, tisReference, notificationType, recipientInfo,
-        templateInfo, sentAt);
+        templateInfo, sentAt, NotificationStatus.SENT, null);
 
     return historyService.save(history);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ application:
   queues:
     coj-received: ${COJ_RECEIVED_QUEUE}
     credential-revoked: ${CREDENTIAL_REVOKED_QUEUE}
+    email-failure: ${EMAIL_FAILURE_QUEUE}
     form-updated: ${FORM_UPDATED_QUEUE}
     programme-membership-updated: ${PROGRAMME_MEMBERSHIP_UPDATED_QUEUE}
     programme-membership-deleted: ${PROGRAMME_MEMBERSHIP_DELETED_QUEUE}
@@ -33,6 +34,9 @@ com:
     xray:
       emitters:
         daemon-address: ${AWS_XRAY_DAEMON_ADDRESS:}
+
+mongock:
+  migration-scan-package: uk.nhs.tis.trainee.notifications.migration
 
 sentry:
   dsn: ${SENTRY_DSN:}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
@@ -43,6 +43,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
@@ -51,6 +52,7 @@ import uk.nhs.tis.trainee.notifications.service.HistoryService;
 
 @WebMvcTest(controllers = HistoryResource.class)
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class HistoryResourceTest {
 
   private static final String TRAINEE_ID = "40";

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/EmailListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/EmailListenerTest.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Bounce;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Complaint;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Mail;
+import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Mail.MailHeader;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+
+class EmailListenerTest {
+
+  private static final String NOTIFICATION_ID = "40";
+
+  private EmailListener listener;
+  private HistoryService historyService;
+
+  @BeforeEach
+  void setUp() {
+    historyService = mock(HistoryService.class);
+    listener = new EmailListener(historyService);
+  }
+
+  @Test
+  void shouldThrowExceptionHandlingFailureWhenNoNotificationId() {
+    Mail mail = new Mail(new MailHeader[]{});
+    EmailEvent event = new EmailEvent("bounce", mail, null, null);
+
+    assertThrows(IllegalArgumentException.class, () -> listener.handleFailure(event));
+  }
+
+  @Test
+  void shouldHandleFailureWhenBounceEvent() {
+    Mail mail = new Mail(new MailHeader[]{new MailHeader("NotificationId", NOTIFICATION_ID)});
+    Bounce bounce = new Bounce("type1", "type2");
+    EmailEvent event = new EmailEvent("Bounce", mail, bounce, null);
+
+    listener.handleFailure(event);
+
+    verify(historyService).updateStatus(NOTIFICATION_ID, FAILED, "Bounce: type1 - type2");
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', nullValues = "null", textBlock = """
+      type1 | type2 | Complaint: type1
+      null  | type2 | Complaint: type2
+      null  | null  | Complaint: Undetermined
+      """)
+  void shouldHandleFailureWhenComplaintEvent(String subType, String feedbackType, String message) {
+    Mail mail = new Mail(new MailHeader[]{new MailHeader("NotificationId", NOTIFICATION_ID)});
+    Complaint complaint = new Complaint(subType, feedbackType);
+    EmailEvent event = new EmailEvent("Complaint", mail, null, complaint);
+
+    listener.handleFailure(event);
+
+    verify(historyService).updateStatus(NOTIFICATION_ID, FAILED, message);
+  }
+
+  @Test
+  void shouldNotHandleFailureWhenDeliveryEvent() {
+    Mail mail = new Mail(new MailHeader[]{new MailHeader("NotificationId", NOTIFICATION_ID)});
+    EmailEvent event = new EmailEvent("Delivery", mail, null, null);
+
+    listener.handleFailure(event);
+
+    verifyNoInteractions(historyService);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/EmailListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/EmailListenerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,7 +54,7 @@ class EmailListenerTest {
 
   @Test
   void shouldThrowExceptionHandlingFailureWhenNoNotificationId() {
-    Mail mail = new Mail(new MailHeader[]{});
+    Mail mail = new Mail(List.of());
     EmailEvent event = new EmailEvent("bounce", mail, null, null);
 
     assertThrows(IllegalArgumentException.class, () -> listener.handleFailure(event));
@@ -61,7 +62,7 @@ class EmailListenerTest {
 
   @Test
   void shouldHandleFailureWhenBounceEvent() {
-    Mail mail = new Mail(new MailHeader[]{new MailHeader("NotificationId", NOTIFICATION_ID)});
+    Mail mail = new Mail(List.of(new MailHeader("NotificationId", NOTIFICATION_ID)));
     Bounce bounce = new Bounce("type1", "type2");
     EmailEvent event = new EmailEvent("Bounce", mail, bounce, null);
 
@@ -77,7 +78,7 @@ class EmailListenerTest {
       null  | null  | Complaint: Undetermined
       """)
   void shouldHandleFailureWhenComplaintEvent(String subType, String feedbackType, String message) {
-    Mail mail = new Mail(new MailHeader[]{new MailHeader("NotificationId", NOTIFICATION_ID)});
+    Mail mail = new Mail(List.of(new MailHeader("NotificationId", NOTIFICATION_ID)));
     Complaint complaint = new Complaint(subType, feedbackType);
     EmailEvent event = new EmailEvent("Complaint", mail, null, complaint);
 
@@ -88,7 +89,7 @@ class EmailListenerTest {
 
   @Test
   void shouldNotHandleFailureWhenDeliveryEvent() {
-    Mail mail = new Mail(new MailHeader[]{new MailHeader("NotificationId", NOTIFICATION_ID)});
+    Mail mail = new Mail(List.of(new MailHeader("NotificationId", NOTIFICATION_ID)));
     EmailEvent event = new EmailEvent("Delivery", mail, null, null);
 
     listener.handleFailure(event);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
+
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.notifications.model.History;
+
+@SpringBootTest(properties = {"embedded.containers.enabled=true", "embedded.mongodb.enabled=true"})
+@ActiveProfiles({"mongodb", "test"})
+@Testcontainers(disabledWithoutDocker = true)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+class PopulateNotificationHistoryStatusIntegrationTest {
+
+  @SpyBean
+  private MongoTemplate mongoTemplate;
+
+  private PopulateNotificationHistoryStatus migrator;
+
+  @BeforeEach
+  void setUp() {
+    migrator = new PopulateNotificationHistoryStatus(mongoTemplate);
+  }
+
+  @Test
+  void shouldMigrateHistoryWithEmptyStatus() {
+    History history = new History(null, null, COJ_CONFIRMATION, null, null, Instant.now(), null,
+        null);
+    history = mongoTemplate.save(history);
+
+    migrator.migrate();
+
+    History migratedHistory = mongoTemplate.findById(history.id(), History.class);
+
+    assertThat("Unexpected status.", migratedHistory, notNullValue());
+    assertThat("Unexpected status.", migratedHistory.status(), is(SENT));
+  }
+
+  @Test
+  void shouldNotMigrateHistoryWithPopulatedStatus() {
+    History history = new History(null, null, COJ_CONFIRMATION, null, null, Instant.now(), FAILED,
+        null);
+    history = mongoTemplate.save(history);
+
+    migrator.migrate();
+
+    History migratedHistory = mongoTemplate.findById(history.id(), History.class);
+
+    assertThat("Unexpected status.", migratedHistory, notNullValue());
+    assertThat("Unexpected status.", migratedHistory.status(), is(FAILED));
+  }
+
+  @Test
+  void rollback() {
+    Mockito.clearInvocations(mongoTemplate);
+    migrator.rollback();
+    verifyNoInteractions(mongoTemplate);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -23,6 +23,7 @@ package uk.nhs.tis.trainee.notifications.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 
 import jakarta.activation.DataHandler;
 import jakarta.mail.Address;
@@ -332,6 +334,8 @@ class EmailServiceTest {
     assertThat("Unexpected notification id.", history.id(), notNullValue());
     assertThat("Unexpected notification type.", history.type(), is(notificationType));
     assertThat("Unexpected sent at.", history.sentAt(), notNullValue());
+    assertThat("Unexpected status.", history.status(), is(SENT));
+    assertThat("Unexpected status detail.", history.statusDetail(), nullValue());
 
     RecipientInfo recipient = history.recipient();
     assertThat("Unexpected recipient id.", recipient.id(), is(TRAINEE_ID));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
 
 import java.time.Duration;
@@ -42,11 +43,8 @@ import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -79,12 +77,6 @@ class HistoryServiceIntegrationTest {
 
   private static final Instant SENT_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
 
-  @MockBean
-  private QuartzAutoConfiguration quartzConfiguration;
-
-  @MockBean
-  private Scheduler scheduler;
-
   @Autowired
   private HistoryService service;
 
@@ -96,7 +88,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT);
+        templateInfo, SENT_AT, SENT, null);
     History savedHistory = service.save(history);
 
     assertThat("Unexpected ID.", savedHistory.id(), instanceOf(ObjectId.class));
@@ -129,7 +121,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT);
+        templateInfo, SENT_AT, SENT, null);
     service.save(history);
 
     List<HistoryDto> foundHistory = service.findAllForTrainee("notFound");
@@ -145,7 +137,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT);
+        templateInfo, SENT_AT, SENT, null);
     History savedHistory = service.save(history);
 
     List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
@@ -169,15 +161,15 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        now));
+        now, SENT, null));
 
     Instant before = SENT_AT.minus(Duration.ofDays(1));
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        before));
+        before, SENT, null));
 
     Instant after = SENT_AT.plus(Duration.ofDays(1));
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        after));
+        after, SENT, null));
 
     List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
 
@@ -211,7 +203,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now());
+        recipientInfo, templateInfo, Instant.now(), SENT, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(NOTIFICATION_ID.toString());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
@@ -37,9 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.Cache;
@@ -68,12 +66,6 @@ class UserAccountServiceIntegrationTest {
 
   @MockBean
   private MongoConfiguration mongoConfiguration;
-
-  @MockBean
-  private QuartzAutoConfiguration quartzConfiguration;
-
-  @MockBean
-  private Scheduler scheduler;
 
   @MockBean
   private CognitoIdentityProviderClient cognitoClient;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,6 +7,9 @@ application:
   queues:
     coj-received: dummy-value
 
+mongock:
+  enabled: false
+
 spring:
   cloud:
     aws:
@@ -24,3 +27,5 @@ spring:
     password:
   flyway:
     url: ${spring.datasource.url}
+  quartz:
+    auto-startup: false


### PR DESCRIPTION
When an email bounces or a complaint if received an event is emitted by SES which ends up on the email failure queue.
Create an event listener, which consumes messages from this queue and updates the stored history to reflect the failure status.

Create a migrator to append a status of `SENT` to all previous notification history documents. This is most likely false, as some of these emails will have failed. However, without additional data this is the best assumption we can make.

TIS21-5445
TIS21-5426