### PR TITLE
Feat/make notification details available

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -103,6 +103,14 @@
         {
           "name": "MYSQL_SSL",
           "valueFrom": "/tis/trainee/${environment}/mysql/ssl"
+        },
+        {
+          "name": "TRAINEE_DETAILS_HOST",
+          "valueFrom": "trainee-${environment}-lb-url"
+        },
+        {
+          "name": "TRAINEE_DETAILS_PORT",
+          "valueFrom": "tis-trainee-details-port-${environment}"
         }
       ],
       "logConfiguration": {

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,6 @@ gradle-app.setting
 ### Gradle Patch ###
 **/build/
 
+src/main/generated/*
+
 # End of https://www.gitignore.io/api/java,gradle

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,4 @@ gradle-app.setting
 ### Gradle Patch ###
 **/build/
 
-src/main/generated/*
-
 # End of https://www.gitignore.io/api/java,gradle

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.8.2"
+version = "1.9.0"
 
 configurations {
   checkstyleConfig

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.8.1"
+version = "1.8.2"
 
 configurations {
   checkstyleConfig

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/CojSignedEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/CojSignedEvent.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.tis.trainee.notifications.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.Instant;
 
 /**
@@ -38,6 +39,7 @@ public record CojSignedEvent(
    *
    * @param syncedAt The timestamp for the signed Conditions of Joining being received.
    */
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public record ConditionsOfJoining(Instant syncedAt) {
 
   }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
@@ -32,6 +32,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
 import org.mapstruct.ReportingPolicy;
+import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
 import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
 
@@ -64,6 +65,23 @@ public interface ProgrammeMembershipMapper {
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     return objectMapper.readValue(curriculumString,
+        new TypeReference<>() {
+        });
+  }
+
+  /**
+   * Map a serialized Conditions of Joining.
+   *
+   * @param cojString The serialized Conditions of Joining.
+   * @return The Conditions of Joining record.
+   * @throws JsonProcessingException if the CoJ is malformed.
+   */
+  default ConditionsOfJoining toConditionsOfJoining(String cojString)
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    return objectMapper.readValue(cojString,
         new TypeReference<>() {
         });
   }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
+import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
 
 /**
  * A programme membership.
@@ -37,4 +38,5 @@ public class ProgrammeMembership {
   private String programmeName;
   private LocalDate startDate;
   private List<Curriculum> curricula = new ArrayList<>();
+  private ConditionsOfJoining conditionsOfJoining;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -154,7 +154,7 @@ public class EmailService {
    * @param traineeId The trainee ID to get the account for.
    * @return The found account.
    */
-  private UserAccountDetails getRecipientAccount(String traineeId) {
+  public UserAccountDetails getRecipientAccount(String traineeId) {
     Set<String> userAccountIds = userAccountService.getUserAccountIds(traineeId);
 
     return switch (userAccountIds.size()) {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -66,6 +66,16 @@ public class NotificationService implements Job {
   private final String templateVersion;
   private final String serviceUrl;
 
+  /**
+   * Initialise the Notification Service.
+   *
+   * @param historyService  The History Service to use.
+   * @param emailService    The Email Service to use.
+   * @param restTemplate    The REST template.
+   * @param templateVersion The email template version.
+   * @param serviceUrl      The URL for the tis-trainee-details service to use for profile
+   *                        information.
+   */
   public NotificationService(HistoryService historyService, EmailService emailService,
       RestTemplate restTemplate,
       @Value("${application.template-versions.form-updated.email}") String templateVersion,

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -21,9 +21,14 @@
 
 package uk.nhs.tis.trainee.notifications.service;
 
+import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PERSON_ID_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NAME_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.START_DATE_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.TIS_ID_FIELD;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +36,11 @@ import org.bson.types.ObjectId;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
@@ -39,7 +48,6 @@ import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.MessageType;
 import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
-import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
 
 /**
  * A service for executing notification scheduling jobs.
@@ -48,14 +56,25 @@ import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
 @Component
 public class NotificationService implements Job {
 
-  public static final String DUMMY_EMAIL = "TODO get email";
+  public static final String API_GET_EMAIL = "/api/trainee-profile/account-details/{tisId}";
 
   private static final String TIS_ID = "tisId";
 
   private final HistoryService historyService;
+  private final EmailService emailService;
+  private final RestTemplate restTemplate;
+  private final String templateVersion;
+  private final String serviceUrl;
 
-  public NotificationService(HistoryService historyService) {
+  public NotificationService(HistoryService historyService, EmailService emailService,
+      RestTemplate restTemplate,
+      @Value("${application.template-versions.form-updated.email}") String templateVersion,
+      @Value("${service.trainee.url}") String serviceUrl) {
     this.historyService = historyService;
+    this.emailService = emailService;
+    this.restTemplate = restTemplate;
+    this.templateVersion = templateVersion;
+    this.serviceUrl = serviceUrl;
   }
 
   /**
@@ -65,27 +84,53 @@ public class NotificationService implements Job {
    */
   @Override
   public void execute(JobExecutionContext jobExecutionContext) {
-    //for now, simply log jobs to demonstrate that scheduling is correct
     String jobKey = jobExecutionContext.getJobDetail().getKey().toString();
     Map<String, String> result = new HashMap<>();
     JobDataMap jobDetails = jobExecutionContext.getJobDetail().getJobDataMap();
 
-    log.info("Sent {} notification for {}", jobKey, jobDetails.getString(TIS_ID));
-    Instant processedOn = Instant.now();
-    result.put("status", "sent " + processedOn.toString());
-    jobExecutionContext.setResult(result);
+    String personId = jobDetails.getString(PERSON_ID_FIELD);
 
-    saveNotificationSent(jobDetails, DUMMY_EMAIL, processedOn);
+    UserAccountDetails userAccountDetails = getAccountDetails(personId);
 
-    //MVP:
-    //get trainee name and job details (ProgrammeMembershipEvent, NotificationType)
-    //inject name, programme name and notification type (8-week, 4-week etc.) into basic template
-    //send email
+    if (userAccountDetails != null) {
+      String programmeName = jobDetails.getString(PROGRAMME_NAME_FIELD);
+      LocalDate startDate = (LocalDate) jobDetails.get(START_DATE_FIELD);
 
-    //MVP +1 iteration:
-    //use job details to check status of trainee (signed-up, submitted coj, submitted formR)
-    //inject these into full template
-    //send email
+      jobDetails.putIfAbsent("name", userAccountDetails.familyName());
+
+      log.info("Mock sent {} notification for {} ({}, starting {}) to {} using template {}", jobKey,
+          jobDetails.getString(TIS_ID_FIELD), programmeName, startDate, userAccountDetails.email(),
+          templateVersion);
+      Instant processedOn = Instant.now();
+      result.put("status", "sent " + processedOn.toString());
+      jobExecutionContext.setResult(result);
+
+      saveNotificationSent(jobDetails, userAccountDetails.email(), processedOn);
+    } else {
+      log.info("No notification could be sent, no TSS details found for tisId {}", personId);
+    }
+  }
+
+  /**
+   * Get the user account details from Cognito (if they have signed-up to TIS Self-Service), or from
+   * the Trainee Details profile if not.
+   *
+   * @param personId The person ID to search for.
+   * @return The user account details, or null if not found.
+   */
+  private UserAccountDetails getAccountDetails(String personId) {
+    try {
+      return emailService.getRecipientAccount(personId);
+    } catch (IllegalArgumentException e) {
+      //no TSS account (or duplicate accounts), so try to get from trainee-details profile.
+      try {
+        return restTemplate.getForObject(serviceUrl + API_GET_EMAIL, UserAccountDetails.class,
+            Map.of(TIS_ID_FIELD, personId));
+      } catch (RestClientException rce) {
+        //no trainee details profile
+        return null;
+      }
+    }
   }
 
   /**
@@ -106,7 +151,7 @@ public class NotificationService implements Job {
     TemplateInfo templateInfo
         = new TemplateInfo(notificationType.getTemplateName(), "v1.0.0",
         jobDetails.getWrappedMap());
-    TisReferenceInfo tisReference = new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP,
+    TisReferenceInfo tisReference = new TisReferenceInfo(PROGRAMME_MEMBERSHIP,
         jobDetails.get(TIS_ID).toString());
 
     History history = new History(objectId, tisReference, notificationType, recipientInfo,

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -157,7 +157,7 @@ public class ProgrammeMembershipService {
             notificationsAlreadySent);
 
         if (shouldSchedule) {
-          log.info("Scheduling notification {} for {}.", milestone,programmeMembership.getTisId());
+          log.info("Scheduling notification {} for {}.", milestone, programmeMembership.getTisId());
           Integer daysBeforeStart = getNotificationDaysBeforeStart(milestone);
           Date when = getScheduleDate(startDate, daysBeforeStart);
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -56,6 +56,10 @@ import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
 public class ProgrammeMembershipService {
   public static final String TIS_ID_FIELD = "tisId";
   public static final String PERSON_ID_FIELD = "personId";
+  public static final String PROGRAMME_NAME_FIELD = "programmeName";
+  public static final String START_DATE_FIELD = "startDate";
+  public static final String NOTIFICATION_TYPE_FIELD = "notificationType";
+  public static final String COJ_SYNCED_FIELD = "conditionsOfJoiningSyncedAt";
 
   private static final String TRIGGER_ID_PREFIX = "trigger-";
   private static final Integer PAST_MILESTONE_SCHEDULE_DELAY_HOURS = 1;
@@ -153,15 +157,20 @@ public class ProgrammeMembershipService {
             notificationsAlreadySent);
 
         if (shouldSchedule) {
+          log.info("Scheduling notification {} for {}.", milestone,programmeMembership.getTisId());
           Integer daysBeforeStart = getNotificationDaysBeforeStart(milestone);
           Date when = getScheduleDate(startDate, daysBeforeStart);
 
           JobDataMap jobDataMap = new JobDataMap();
           jobDataMap.put(TIS_ID_FIELD, programmeMembership.getTisId());
           jobDataMap.put(PERSON_ID_FIELD, programmeMembership.getPersonId());
-          jobDataMap.put("programmeName", programmeMembership.getProgrammeName());
-          jobDataMap.put("startDate", programmeMembership.getStartDate());
-          jobDataMap.put("notificationType", milestone);
+          jobDataMap.put(PROGRAMME_NAME_FIELD, programmeMembership.getProgrammeName());
+          jobDataMap.put(START_DATE_FIELD, programmeMembership.getStartDate());
+          jobDataMap.put(NOTIFICATION_TYPE_FIELD, milestone);
+          if (programmeMembership.getConditionsOfJoining() != null) {
+            jobDataMap.put(COJ_SYNCED_FIELD,
+                programmeMembership.getConditionsOfJoining().syncedAt());
+          }
           // Note the status of the trainee will be retrieved when the job is executed, as will
           // their name and email address, not now.
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,8 +60,8 @@ spring:
   datasource:
     driver: com.mysql.jdbc.Driver
     url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/notifications?useUnicode=true&characterEncoding=utf8&useSSL=${MYSQL_SSL:false}
-    username: ${MYSQL_USER:root}
-    password: ${MYSQL_PASSWORD:}
+    username: notifications
+    password: notifications
   flyway:
     baseline-version: 1 # version to start migration
     baseline-on-migrate: true
@@ -82,3 +82,9 @@ spring:
       initialize-schema: never
     jobStore:
       useProperties: true
+
+service:
+  trainee:
+    host: ${TRAINEE_DETAILS_HOST:localhost}
+    port: ${TRAINEE_DETAILS_PORT:8203}
+    url: http://${service.trainee.host}:${service.trainee.port}/trainee

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,8 +60,8 @@ spring:
   datasource:
     driver: com.mysql.jdbc.Driver
     url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/notifications?useUnicode=true&characterEncoding=utf8&useSSL=${MYSQL_SSL:false}
-    username: notifications
-    password: notifications
+    username: ${MYSQL_USER:root}
+    password: ${MYSQL_PASSWORD:}
   flyway:
     baseline-version: 1 # version to start migration
     baseline-on-migrate: true

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -24,12 +24,14 @@ package uk.nhs.tis.trainee.notifications.mapper;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.dto.RecordDto;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
@@ -41,6 +43,7 @@ class ProgrammeMembershipMapperTest {
   private static final LocalDate START_DATE = LocalDate.now();
   private static final String CURRICULUM_SUB_TYPE = "sub-type";
   private static final String CURRICULUM_SPECIALTY = "specialty";
+  private static final Instant COJ_SYNCED_AT = Instant.now();
 
   private ProgrammeMembershipMapper mapper;
 
@@ -63,6 +66,8 @@ class ProgrammeMembershipMapperTest {
     assertThat("Unexpected Tis Id.", returnedPm.getTisId(), is(TIS_ID));
     assertThat("Unexpected start date.", returnedPm.getStartDate(), is(START_DATE));
     assertThat("Unexpected curricula.", returnedPm.getCurricula(), is(List.of(curriculum)));
+    assertThat("Unexpected Conditions of joining.", returnedPm.getConditionsOfJoining(),
+        is(new ConditionsOfJoining(COJ_SYNCED_AT)));
   }
 
   /**
@@ -79,6 +84,10 @@ class ProgrammeMembershipMapperTest {
         "[{\"curriculumSubType\": \"" + CURRICULUM_SUB_TYPE + "\", "
             + "\"curriculumSpecialty\": \"" + CURRICULUM_SPECIALTY + "\", "
             + "\"another-curriculum-property\": \"some value\"}]");
+    dataMap.put("conditionsOfJoining",
+        "{\"signedAt\":\"2023-06-05T20:44:29.943Z\","
+            + "\"version\":\"GG9\","
+            + "\"syncedAt\":\"" + COJ_SYNCED_AT + "\"}");
     RecordDto data = new RecordDto();
     data.setData(dataMap);
     return new ProgrammeMembershipEvent(TIS_ID, data);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -21,65 +21,83 @@
 
 package uk.nhs.tis.trainee.notifications.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.quartz.JobBuilder.newJob;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.NOTIFICATION_TYPE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PERSON_ID_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NAME_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.START_DATE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.TIS_ID_FIELD;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
-import uk.nhs.tis.trainee.notifications.model.History;
-import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
-import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
-import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
-import uk.nhs.tis.trainee.notifications.model.MessageType;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
-import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
 
 class NotificationServiceTest {
 
+  private static final String TEMPLATE_VERSION = "template-version";
+  private static final String SERVICE_URL = "the-url";
   private static final String JOB_KEY_STRING = "job-key";
   private static final JobKey JOB_KEY = new JobKey(JOB_KEY_STRING);
   private static final String TIS_ID = "tis-id";
   private static final String PERSON_ID = "person-id";
+  private static final String PROGRAMME_NAME = "the programme";
+  private static final LocalDate START_DATE = LocalDate.now();
   private static final NotificationType NOTIFICATION_TYPE
       = NotificationType.PROGRAMME_UPDATED_WEEK_8;
+
+  private static final String USER_EMAIL = "email@address";
+  private static final String USER_FAMILY_NAME = "family-name";
+
   private JobDetail jobDetails;
 
   private NotificationService service;
   private HistoryService historyService;
+  private EmailService emailService;
+  private RestTemplate restTemplate;
   private JobExecutionContext jobExecutionContext;
 
   @BeforeEach
   void setUp() {
     jobExecutionContext = mock(JobExecutionContext.class);
+    emailService = mock(EmailService.class);
     historyService = mock(HistoryService.class);
+    restTemplate = mock(RestTemplate.class);
 
     JobDataMap jobDataMap = new JobDataMap();
     jobDataMap.put(TIS_ID_FIELD, TIS_ID);
     jobDataMap.put(PERSON_ID_FIELD, PERSON_ID);
-    jobDataMap.put("notificationType", NOTIFICATION_TYPE.toString());
+    jobDataMap.put(PROGRAMME_NAME_FIELD, PROGRAMME_NAME);
+    jobDataMap.put(NOTIFICATION_TYPE_FIELD, NOTIFICATION_TYPE.toString());
+    jobDataMap.put(START_DATE_FIELD, START_DATE);
     jobDetails = newJob(NotificationService.class)
         .withIdentity(JOB_KEY)
         .usingJobData(jobDataMap)
         .build();
 
-    service = new NotificationService(historyService);
+    service = new NotificationService(historyService, emailService, restTemplate, TEMPLATE_VERSION,
+        SERVICE_URL);
   }
 
   @Test
-  void shouldSetNotificationResultWhenExecuted() {
+  void shouldSetNotificationResultWhenSuccessfullyExecuted() {
+    UserAccountDetails userAccountDetails = new UserAccountDetails(USER_EMAIL, USER_FAMILY_NAME);
     when(jobExecutionContext.getJobDetail()).thenReturn(jobDetails);
+    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
 
     service.execute(jobExecutionContext);
 
@@ -87,28 +105,47 @@ class NotificationServiceTest {
   }
 
   @Test
-  void shouldSaveNotificationHistoryWhenExecuted() {
+  void shouldNotSetResultWhenUserDetailsCannotBeFound() {
     when(jobExecutionContext.getJobDetail()).thenReturn(jobDetails);
+
+    when(emailService.getRecipientAccount(any())).thenReturn(null);
+    when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(null);
 
     service.execute(jobExecutionContext);
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(jobExecutionContext, never()).setResult(any());
+  }
 
-    verify(historyService).save(historyCaptor.capture());
+  @Test
+  void shouldNotGetAccountDetailsFromApiWhenAlreadyFoundInCognito() {
+    UserAccountDetails userAccountDetails = new UserAccountDetails(USER_EMAIL, USER_FAMILY_NAME);
 
-    History savedHistory = historyCaptor.getValue();
+    when(jobExecutionContext.getJobDetail()).thenReturn(jobDetails);
+    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
 
-    RecipientInfo expectedRecipient
-        = new RecipientInfo(PERSON_ID, MessageType.EMAIL, NotificationService.DUMMY_EMAIL);
-    TemplateInfo expectedTemplate
-        = new TemplateInfo(NOTIFICATION_TYPE.getTemplateName(), "v1.0.0",
-        jobDetails.getJobDataMap().getWrappedMap());
-    TisReferenceInfo expectedTisReference
-        = new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_ID);
+    service.execute(jobExecutionContext);
 
-    assertThat("Unexpected recipientInfo.", savedHistory.recipient(), is(expectedRecipient));
-    assertThat("Unexpected templateInfo.", savedHistory.template(), is(expectedTemplate));
-    assertThat("Unexpected tisReference.", savedHistory.tisReference(),
-        is(expectedTisReference));
+    verify(emailService).getRecipientAccount(any());
+    verify(restTemplate, never()).getForObject(any(), any(), anyMap());
+  }
+
+  @Test
+  void shouldHandleRestClientExceptions() {
+    when(jobExecutionContext.getJobDetail()).thenReturn(jobDetails);
+
+    when(emailService.getRecipientAccount(any())).thenThrow(new IllegalArgumentException("error"));
+    when(restTemplate.getForObject(any(), any(), anyMap()))
+        .thenThrow(new RestClientException("error"));
+
+    assertDoesNotThrow(() -> service.execute(jobExecutionContext));
+  }
+
+  @Test
+  void shouldHandleCognitoExceptions() {
+    when(jobExecutionContext.getJobDetail()).thenReturn(jobDetails);
+
+    when(emailService.getRecipientAccount(any())).thenThrow(new IllegalArgumentException("error"));
+
+    assertDoesNotThrow(() -> service.execute(jobExecutionContext));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -33,12 +33,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.COJ_SYNCED_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PERSON_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NAME_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.START_DATE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.TIS_ID_FIELD;
-import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 
 import java.time.Instant;
 import java.time.LocalDate;


### PR DESCRIPTION
This PR allows the programme membership notification to have access to the email address (if the trainee is not registered on TSS), and also whether a CoJ has been signed against the PM in question.

No actual email is sent: the business rules for whether to send a notification or not are still to be revised in the next slice.

TIS21-5389