### PR TITLE
feat: include TisReferenceInfo in History

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.9.0"
+version = "1.9.1"
 
 configurations {
   checkstyleConfig

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -73,7 +73,7 @@ public class ConditionsOfJoiningListener {
 
     String traineeId = event.personId();
     emailService.sendMessageToExistingUser(traineeId, COJ_CONFIRMATION, templateVersion,
-        templateVariables);
+        templateVariables, null);
     log.info("COJ received notification sent for trainee {}.", traineeId);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/CredentialListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/CredentialListener.java
@@ -70,7 +70,7 @@ public class CredentialListener {
 
     String traineeId = event.traineeId();
     emailService.sendMessageToExistingUser(traineeId, CREDENTIAL_REVOKED, templateVersion,
-        templateVariables);
+        templateVariables, null);
     log.info("Credential revocation notification sent for trainee {}.", traineeId);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/FormListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/FormListener.java
@@ -72,7 +72,7 @@ public class FormListener {
 
     String traineeId = event.traineeId();
     emailService.sendMessageToExistingUser(traineeId, FORM_UPDATED, templateVersion,
-        templateVariables);
+        templateVariables, null);
     log.info("Form updated notification sent for trainee {}.", traineeId);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -43,6 +43,7 @@ import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
 
@@ -80,10 +81,12 @@ public class EmailService {
    * @param notificationType  The type of notification, which will determine the template used.
    * @param templateVersion   The version of the template to be sent.
    * @param templateVariables The variables to pass to the template.
+   * @param tisReferenceInfo  The TIS reference information (table and key).
    * @throws MessagingException When the message could not be sent.
    */
   public void sendMessageToExistingUser(String traineeId, NotificationType notificationType,
-      String templateVersion, Map<String, Object> templateVariables) throws MessagingException {
+      String templateVersion, Map<String, Object> templateVariables,
+      TisReferenceInfo tisReferenceInfo) throws MessagingException {
     if (traineeId == null) {
       throw new IllegalArgumentException("Unable to send notification as no trainee ID available");
     }
@@ -98,7 +101,7 @@ public class EmailService {
     templateVariables = new HashMap<>(templateVariables);
     templateVariables.putIfAbsent("name", userDetails.familyName());
     sendMessage(traineeId, userDetails.email(), notificationType, templateVersion,
-        templateVariables);
+        templateVariables, tisReferenceInfo);
   }
 
   /**
@@ -109,10 +112,12 @@ public class EmailService {
    * @param notificationType  The type of notification, which will determine the template used.
    * @param templateVersion   The version of the template to be sent.
    * @param templateVariables The variables to pass to the template.
+   * @param tisReferenceInfo  The TIS reference information (table and key).
    * @throws MessagingException When the message could not be sent.
    */
   private void sendMessage(String traineeId, String recipient, NotificationType notificationType,
-      String templateVersion, Map<String, Object> templateVariables) throws MessagingException {
+      String templateVersion, Map<String, Object> templateVariables,
+      TisReferenceInfo tisReferenceInfo) throws MessagingException {
     String templateName = templateService.getTemplatePath(EMAIL, notificationType, templateVersion);
     log.info("Sending template {} to {}.", templateName, recipient);
 
@@ -141,7 +146,7 @@ public class EmailService {
     RecipientInfo recipientInfo = new RecipientInfo(traineeId, EMAIL, recipient);
     TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
         templateVersion, templateVariables);
-    History history = new History(notificationId, null, notificationType, recipientInfo,
+    History history = new History(notificationId, tisReferenceInfo, notificationType, recipientInfo,
         templateInfo, Instant.now(), NotificationStatus.SENT, null);
     historyService.save(history);
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -127,7 +127,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     doAnswer(inv -> {
       inv.getArgument(3, Map.class).put("domain", URI.create(""));
       return inv.callRealMethod();
-    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any());
+    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any(), any());
 
     // Create a new listener instance to inject the spy.
     ConditionsOfJoiningListener listener = new ConditionsOfJoiningListener(emailService,

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -60,7 +60,7 @@ class ConditionsOfJoiningListenerTest {
   @Test
   void shouldThrowExceptionWhenCojReceivedAndSendingFails() throws MessagingException {
     doThrow(MessagingException.class).when(emailService)
-        .sendMessageToExistingUser(any(), any(), any(), any());
+        .sendMessageToExistingUser(any(), any(), any(), any(), any());
 
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(SYNCED_AT));
@@ -75,7 +75,7 @@ class ConditionsOfJoiningListenerTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    verify(emailService).sendMessageToExistingUser(eq(PERSON_ID), any(), any(), any());
+    verify(emailService).sendMessageToExistingUser(eq(PERSON_ID), any(), any(), any(), any());
   }
 
   @Test
@@ -85,7 +85,8 @@ class ConditionsOfJoiningListenerTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    verify(emailService).sendMessageToExistingUser(any(), eq(COJ_CONFIRMATION), any(), any());
+    verify(emailService).sendMessageToExistingUser(any(), eq(COJ_CONFIRMATION), any(), any(),
+        any());
   }
 
   @Test
@@ -95,7 +96,7 @@ class ConditionsOfJoiningListenerTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    verify(emailService).sendMessageToExistingUser(any(), any(), eq(VERSION), any());
+    verify(emailService).sendMessageToExistingUser(any(), any(), eq(VERSION), any(), any());
   }
 
   @Test
@@ -107,7 +108,7 @@ class ConditionsOfJoiningListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected synced at.", templateVariables.get("syncedAt"), nullValue());
@@ -122,7 +123,7 @@ class ConditionsOfJoiningListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected synced at.", templateVariables.get("syncedAt"), nullValue());
@@ -137,7 +138,7 @@ class ConditionsOfJoiningListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected synced at.", templateVariables.get("syncedAt"), is(SYNCED_AT));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
@@ -132,7 +132,7 @@ class CredentialListenerIntegrationTest {
     doAnswer(inv -> {
       inv.getArgument(3, Map.class).put("domain", URI.create(""));
       return inv.callRealMethod();
-    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any());
+    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any(), any());
 
     // Create a new listener instance to inject the spy.
     CredentialListener listener = new CredentialListener(emailService, templateVersion);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerTest.java
@@ -68,7 +68,7 @@ class CredentialListenerTest {
   void shouldThrowExceptionWhenCredentialRevokedAndSendingFails(String credentialType)
       throws MessagingException {
     doThrow(MessagingException.class).when(emailService)
-        .sendMessageToExistingUser(any(), any(), any(), any());
+        .sendMessageToExistingUser(any(), any(), any(), any(), any());
 
     CredentialEvent event = new CredentialEvent(CREDENTIAL_ID, credentialType, ISSUED_AT,
         TRAINEE_ID);
@@ -84,7 +84,7 @@ class CredentialListenerTest {
 
     listener.handleCredentialRevoked(event);
 
-    verify(emailService).sendMessageToExistingUser(eq(TRAINEE_ID), any(), any(), any());
+    verify(emailService).sendMessageToExistingUser(eq(TRAINEE_ID), any(), any(), any(), any());
   }
 
   @ParameterizedTest
@@ -96,7 +96,8 @@ class CredentialListenerTest {
 
     listener.handleCredentialRevoked(event);
 
-    verify(emailService).sendMessageToExistingUser(any(), eq(CREDENTIAL_REVOKED), any(), any());
+    verify(emailService).sendMessageToExistingUser(any(), eq(CREDENTIAL_REVOKED), any(), any(),
+        any());
   }
 
   @ParameterizedTest
@@ -108,7 +109,7 @@ class CredentialListenerTest {
 
     listener.handleCredentialRevoked(event);
 
-    verify(emailService).sendMessageToExistingUser(any(), any(), eq(VERSION), any());
+    verify(emailService).sendMessageToExistingUser(any(), any(), eq(VERSION), any(), any());
   }
 
   @ParameterizedTest
@@ -122,7 +123,7 @@ class CredentialListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected credential type.", templateVariables.get("credentialType"),
@@ -139,7 +140,7 @@ class CredentialListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected issued at.", templateVariables.get("issuedAt"), is(ISSUED_AT));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
@@ -135,7 +135,7 @@ class FormListenerIntegrationTest {
     doAnswer(inv -> {
       inv.getArgument(3, Map.class).put("domain", URI.create(""));
       return inv.callRealMethod();
-    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any());
+    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any(), any());
 
     FormListener listener = new FormListener(emailService, templateVersion);
     listener.handleFormUpdate(event);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerTest.java
@@ -65,7 +65,7 @@ class FormListenerTest {
   @Test
   void shouldThrowExceptionWhenFormUpdatedAndSendingFails() throws MessagingException {
     doThrow(MessagingException.class).when(emailService)
-        .sendMessageToExistingUser(any(), any(), any(), any());
+        .sendMessageToExistingUser(any(), any(), any(), any(), any());
 
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_LIFECYCLE_STATE, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
@@ -80,7 +80,7 @@ class FormListenerTest {
 
     listener.handleFormUpdate(event);
 
-    verify(emailService).sendMessageToExistingUser(eq(PERSON_ID), any(), any(), any());
+    verify(emailService).sendMessageToExistingUser(eq(PERSON_ID), any(), any(), any(), any());
   }
 
   @Test
@@ -90,7 +90,7 @@ class FormListenerTest {
 
     listener.handleFormUpdate(event);
 
-    verify(emailService).sendMessageToExistingUser(any(), eq(FORM_UPDATED), any(), any());
+    verify(emailService).sendMessageToExistingUser(any(), eq(FORM_UPDATED), any(), any(), any());
   }
 
   @Test
@@ -100,7 +100,7 @@ class FormListenerTest {
 
     listener.handleFormUpdate(event);
 
-    verify(emailService).sendMessageToExistingUser(any(), any(), eq(VERSION), any());
+    verify(emailService).sendMessageToExistingUser(any(), any(), eq(VERSION), any(), any());
   }
 
   @Test
@@ -112,7 +112,7 @@ class FormListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected form name.", templateVariables.get("formName"), is(FORM_NAME));
@@ -127,7 +127,7 @@ class FormListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected lifecycle state.", templateVariables.get("lifecycleState"),
@@ -143,7 +143,7 @@ class FormListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected form type.", templateVariables.get("formType"), is(FORM_TYPE));
@@ -158,7 +158,7 @@ class FormListenerTest {
 
     ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
-        templateVarsCaptor.capture());
+        templateVarsCaptor.capture(), any());
 
     Map<String, Object> templateVariables = templateVarsCaptor.getValue();
     assertThat("Unexpected form updated at.", templateVariables.get("eventDate"),

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -83,7 +83,7 @@ class EmailServiceIntegrationTest {
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
         new UserAccountDetails(RECIPIENT, null));
 
-    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of());
+    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
@@ -100,7 +100,7 @@ class EmailServiceIntegrationTest {
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
         new UserAccountDetails(RECIPIENT, null));
 
-    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of());
+    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
@@ -117,7 +117,7 @@ class EmailServiceIntegrationTest {
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
         new UserAccountDetails(RECIPIENT, null));
 
-    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of());
+    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
@@ -139,7 +139,7 @@ class EmailServiceIntegrationTest {
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
         new UserAccountDetails(RECIPIENT, "Gilliam"));
 
-    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of());
+    service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());
@@ -162,7 +162,7 @@ class EmailServiceIntegrationTest {
         new UserAccountDetails(RECIPIENT, "Gilliam"));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion,
-        Map.of("name", "Maillig"));
+        Map.of("name", "Maillig"), null);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
     verify(mailSender).send(messageCaptor.capture());


### PR DESCRIPTION
Not used by the CoJ, Credential or Form listeners at this point, but will be needed to port the current temporary custom history logging for programme notifications into the EmailService. The TisReferenceInfo is needed to determine what notifications have already been sent to a trainee.

Temporary custom history logging code is here: https://github.com/Health-Education-England/tis-trainee-notifications/blob/317d520bf3bdcba3ae0858ba39396ef120360e30/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java#L154
Use of this data is here: https://github.com/Health-Education-England/tis-trainee-notifications/blob/317d520bf3bdcba3ae0858ba39396ef120360e30/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java#L126

TIS21-5389