### PR TITLE
fix: do not save notification history for unsent email

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.9.2"
+version = "1.9.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -148,8 +148,8 @@ public class EmailService {
       RecipientInfo recipientInfo = new RecipientInfo(traineeId, EMAIL, recipient);
       TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
           templateVersion, templateVariables);
-      History history = new History(notificationId, tisReferenceInfo, notificationType, recipientInfo,
-          templateInfo, Instant.now(), NotificationStatus.SENT, null);
+      History history = new History(notificationId, tisReferenceInfo, notificationType,
+          recipientInfo, templateInfo, Instant.now(), NotificationStatus.SENT, null);
       historyService.save(history);
 
       log.info("Sent template {} to {}.", templateName, recipient);

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -143,20 +143,20 @@ public class EmailService {
 
     if (!doNotSendJustLog) {
       mailSender.send(helper.getMimeMessage());
+
+      // Store the notification history.
+      RecipientInfo recipientInfo = new RecipientInfo(traineeId, EMAIL, recipient);
+      TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
+          templateVersion, templateVariables);
+      History history = new History(notificationId, tisReferenceInfo, notificationType, recipientInfo,
+          templateInfo, Instant.now(), NotificationStatus.SENT, null);
+      historyService.save(history);
+
+      log.info("Sent template {} to {}.", templateName, recipient);
     } else {
       log.info("For now, just logging mail to '{}' with subject '{}' and content '{}'", recipient,
           subject, content);
     }
-
-    // Store the notification history.
-    RecipientInfo recipientInfo = new RecipientInfo(traineeId, EMAIL, recipient);
-    TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
-        templateVersion, templateVariables);
-    History history = new History(notificationId, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.now(), NotificationStatus.SENT, null);
-    historyService.save(history);
-
-    log.info("Sent template {} to {}.", templateName, recipient);
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -406,6 +406,7 @@ class EmailServiceTest {
     service.sendMessage(TRAINEE_ID, RECIPIENT, NOTIFICATION_TYPE, "", new HashMap<>(), null, true);
 
     verify(mailSender, never()).send((MimeMessage) any());
+    verify(historyService, never()).save(any());
   }
 
   @Test
@@ -417,5 +418,6 @@ class EmailServiceTest {
     service.sendMessage(TRAINEE_ID, RECIPIENT, NOTIFICATION_TYPE, "", new HashMap<>(), null, false);
 
     verify(mailSender).send((MimeMessage) any());
+    verify(historyService).save(any());
   }
 }


### PR DESCRIPTION
Context:
https://hee-nhs-tis.slack.com/archives/C03G3UK3U82/p1708525663884759

I think we need to rerun the DeleteUnusedPmUpdateHistory migration as well to strip out the junk. Not sure if we can hack that by simply removing it from the mongockChangeLog, or if we should create another copy of that migration?

NO-TICKET