### PR TITLE
Feat/placement12 w

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -37,6 +37,14 @@
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/form/updated"
         },
         {
+          "name": "PLACEMENT_UPDATED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/placement/updated"
+        },
+        {
+          "name": "PLACEMENT_DELETED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/placement/deleted"
+        },
+        {
           "name": "PROGRAMME_MEMBERSHIP_UPDATED_QUEUE",
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/programme-membership/updated"
         },

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/PlacementEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/PlacementEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,39 +19,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.model;
+package uk.nhs.tis.trainee.notifications.dto;
 
-import java.util.EnumSet;
-import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 
 /**
- * An enumeration of possible notification types.
+ * A Placement event.
+ *
+ * @param tisId The TIS ID of the Placement.
+ * @param recrd The record DTO map.
  */
-@Getter
-@AllArgsConstructor
-public enum NotificationType {
+public record PlacementEvent(
+    String tisId,
+    @JsonProperty("record") RecordDto recrd) implements Serializable {
 
-  COJ_CONFIRMATION("coj-confirmation"),
-  CREDENTIAL_REVOKED("credential-revoked"),
-  FORM_UPDATED("form-updated"),
-  PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
-  PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
-  PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),
-  PROGRAMME_UPDATED_WEEK_1("programme-updated-week-1"),
-  PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0"),
-  WELCOME("welcome");
-
-  /**
-   * The set of Programme Updated notification types.
-   */
-  @Getter
-  private static final Set<NotificationType> programmeUpdateNotificationTypes = EnumSet.of(
-      PROGRAMME_UPDATED_WEEK_8,
-      PROGRAMME_UPDATED_WEEK_4,
-      PROGRAMME_UPDATED_WEEK_1,
-      PROGRAMME_UPDATED_WEEK_0);
-
-  private final String templateName;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/UserDetails.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/UserDetails.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -22,11 +22,21 @@
 package uk.nhs.tis.trainee.notifications.dto;
 
 /**
- * Account details for an individual user.
+ * User details for an individual user.
  *
- * @param email      The account's registered email.
- * @param familyName The user's family name.
+ * @param isRegistered  Boolean of whether the user registered the account on Cognito.
+ * @param email         The account's registered email.
+ * @param title         The user's title.
+ * @param familyName    The user's family name.
+ * @param givenName     The user's given name.
+ * @param gmcNumber     The user's GMC number.
  */
-public record UserAccountDetails(String email, String familyName) {
+public record UserDetails(
+    Boolean isRegistered,
+    String email,
+    String title,
+    String familyName,
+    String givenName,
+    String gmcNumber) {
 
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/PlacementListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/PlacementListener.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.SchedulerException;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.notifications.dto.PlacementEvent;
+import uk.nhs.tis.trainee.notifications.mapper.PlacementMapper;
+import uk.nhs.tis.trainee.notifications.model.Placement;
+import uk.nhs.tis.trainee.notifications.service.PlacementService;
+
+/**
+ * A listener for Placement events.
+ */
+@Slf4j
+@Component
+public class PlacementListener {
+
+  private final PlacementService placementService;
+  private final PlacementMapper mapper;
+
+  /**
+   * Construct a listener for placement events.
+   *
+   * @param placementService The placement service.
+   */
+  public PlacementListener(PlacementService placementService,
+                           PlacementMapper mapper) {
+    this.placementService = placementService;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Handle Placement update events.
+   *
+   * @param event The placement event.
+   */
+  @SqsListener("${application.queues.placement-updated}")
+  public void handlePlacementUpdate(PlacementEvent event)
+      throws SchedulerException {
+    log.info("Handling placement update event {}.", event);
+    if (event.recrd() != null && event.recrd().getData() != null) {
+      Placement placement = mapper.toEntity(event.recrd().getData());
+      placementService.addNotifications(placement);
+    } else {
+      log.info("Ignoring non placement update event: {}", event);
+    }
+  }
+
+  /**
+   * Handle Placement delete events.
+   *
+   * @param event The placement event.
+   */
+  @SqsListener("${application.queues.placement-deleted}")
+  public void handlePlacementDelete(PlacementEvent event)
+      throws SchedulerException {
+    log.info("Handling placement delete event {}.", event);
+    if (event.recrd() != null && event.recrd().getData() != null) {
+      Placement placement = mapper.toEntity(event.recrd().getData());
+      placement.setTisId(event.tisId()); //delete messages used to have empty record data
+      placementService.deleteNotifications(placement);
+    } else {
+      log.info("Ignoring non placement delete event: {}", event);
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/PlacementMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/PlacementMapper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,39 +19,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.model;
+package uk.nhs.tis.trainee.notifications.mapper;
 
-import java.util.EnumSet;
-import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import java.util.Map;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants.ComponentModel;
+import org.mapstruct.ReportingPolicy;
+import uk.nhs.tis.trainee.notifications.model.Placement;
 
 /**
- * An enumeration of possible notification types.
+ * A mapper to map between TIS Data and Placement Data.
  */
-@Getter
-@AllArgsConstructor
-public enum NotificationType {
-
-  COJ_CONFIRMATION("coj-confirmation"),
-  CREDENTIAL_REVOKED("credential-revoked"),
-  FORM_UPDATED("form-updated"),
-  PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
-  PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
-  PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),
-  PROGRAMME_UPDATED_WEEK_1("programme-updated-week-1"),
-  PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0"),
-  WELCOME("welcome");
+@Mapper(componentModel = ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PlacementMapper {
 
   /**
-   * The set of Programme Updated notification types.
+   * Map a record data map to a Placement.
+   *
+   * @param recordData The map to convert.
+   * @return The mapped Placement.
    */
-  @Getter
-  private static final Set<NotificationType> programmeUpdateNotificationTypes = EnumSet.of(
-      PROGRAMME_UPDATED_WEEK_8,
-      PROGRAMME_UPDATED_WEEK_4,
-      PROGRAMME_UPDATED_WEEK_1,
-      PROGRAMME_UPDATED_WEEK_0);
-
-  private final String templateName;
+  @Mapping(target = "tisId", source = "recordData.id")
+  @Mapping(target = "personId", source = "recordData.traineeId")
+  @Mapping(target = "startDate", source = "recordData.dateFrom")
+  @Mapping(target = "placementType", source = "recordData.placementType")
+  @Mapping(target = "owner", source = "recordData.owner")
+  Placement toEntity(Map<String, String> recordData);
 }
+
+

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/HrefType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/HrefType.java
@@ -16,42 +16,23 @@
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 package uk.nhs.tis.trainee.notifications.model;
 
-import java.util.EnumSet;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * An enumeration of possible notification types.
+ * A list of HREF types that may be used by local office contacts.
  */
 @Getter
 @AllArgsConstructor
-public enum NotificationType {
+public enum HrefType {
+  PROTOCOL_EMAIL("email"),
+  ABSOLUTE_URL("url"),
+  NON_HREF("NON_HREF");
 
-  COJ_CONFIRMATION("coj-confirmation"),
-  CREDENTIAL_REVOKED("credential-revoked"),
-  FORM_UPDATED("form-updated"),
-  PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
-  PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
-  PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),
-  PROGRAMME_UPDATED_WEEK_1("programme-updated-week-1"),
-  PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0"),
-  WELCOME("welcome");
-
-  /**
-   * The set of Programme Updated notification types.
-   */
-  @Getter
-  private static final Set<NotificationType> programmeUpdateNotificationTypes = EnumSet.of(
-      PROGRAMME_UPDATED_WEEK_8,
-      PROGRAMME_UPDATED_WEEK_4,
-      PROGRAMME_UPDATED_WEEK_1,
-      PROGRAMME_UPDATED_WEEK_0);
-
-  private final String templateName;
+  private final String hrefTypeName;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/LocalOfficeContactType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/LocalOfficeContactType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -16,42 +16,26 @@
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 package uk.nhs.tis.trainee.notifications.model;
 
-import java.util.EnumSet;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * An enumeration of possible notification types.
+ * An enumeration of possible local office contact types.
  */
 @Getter
 @AllArgsConstructor
-public enum NotificationType {
+public enum LocalOfficeContactType {
 
-  COJ_CONFIRMATION("coj-confirmation"),
-  CREDENTIAL_REVOKED("credential-revoked"),
-  FORM_UPDATED("form-updated"),
-  PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
-  PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
-  PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),
-  PROGRAMME_UPDATED_WEEK_1("programme-updated-week-1"),
-  PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0"),
-  WELCOME("welcome");
+  LTFT("Less Than Full Time"),
+  ONBOARDING_SUPPORT("Onboarding Support"),
+  SPONSORSHIP("Sponsorship"),
+  DEFERRAL("Deferral"),
+  TSS_SUPPORT("TIS Self-Service Support");
 
-  /**
-   * The set of Programme Updated notification types.
-   */
-  @Getter
-  private static final Set<NotificationType> programmeUpdateNotificationTypes = EnumSet.of(
-      PROGRAMME_UPDATED_WEEK_8,
-      PROGRAMME_UPDATED_WEEK_4,
-      PROGRAMME_UPDATED_WEEK_1,
-      PROGRAMME_UPDATED_WEEK_0);
-
-  private final String templateName;
+  private final String contactTypeName;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/Placement.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/Placement.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,37 +21,19 @@
 
 package uk.nhs.tis.trainee.notifications.model;
 
-import java.util.EnumSet;
-import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import java.time.LocalDate;
+import lombok.Data;
 
 /**
- * An enumeration of possible notification types.
+ * A placement.
  */
-@Getter
-@AllArgsConstructor
-public enum NotificationType {
+@Data
+public class Placement {
 
-  COJ_CONFIRMATION("coj-confirmation"),
-  CREDENTIAL_REVOKED("credential-revoked"),
-  FORM_UPDATED("form-updated"),
-  PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
-  PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
-  PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),
-  PROGRAMME_UPDATED_WEEK_1("programme-updated-week-1"),
-  PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0"),
-  WELCOME("welcome");
-
-  /**
-   * The set of Programme Updated notification types.
-   */
-  @Getter
-  private static final Set<NotificationType> programmeUpdateNotificationTypes = EnumSet.of(
-      PROGRAMME_UPDATED_WEEK_8,
-      PROGRAMME_UPDATED_WEEK_4,
-      PROGRAMME_UPDATED_WEEK_1,
-      PROGRAMME_UPDATED_WEEK_0);
-
-  private final String templateName;
+  private String tisId;
+  private String personId;
+  private LocalDate startDate;
+  private String placementType;
+  private String owner;
+  private String specialty;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -39,7 +39,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
-import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
@@ -91,7 +91,7 @@ public class EmailService {
       throw new IllegalArgumentException("Unable to send notification as no trainee ID available");
     }
 
-    UserAccountDetails userDetails = getRecipientAccount(traineeId);
+    UserDetails userDetails = getRecipientAccount(traineeId);
 
     if (Strings.isBlank(userDetails.email())) {
       String message = "Could not find email address for user '%s'".formatted(traineeId);
@@ -99,7 +99,8 @@ public class EmailService {
     }
 
     templateVariables = new HashMap<>(templateVariables);
-    templateVariables.putIfAbsent("name", userDetails.familyName());
+    templateVariables.putIfAbsent("familyName", userDetails.familyName());
+    templateVariables.putIfAbsent("givenName", userDetails.givenName());
     sendMessage(traineeId, userDetails.email(), notificationType, templateVersion,
         templateVariables, tisReferenceInfo, false);
   }
@@ -165,7 +166,7 @@ public class EmailService {
    * @param traineeId The trainee ID to get the account for.
    * @return The found account.
    */
-  public UserAccountDetails getRecipientAccount(String traineeId) {
+  public UserDetails getRecipientAccount(String traineeId) {
     Set<String> userAccountIds = userAccountService.getUserAccountIds(traineeId);
 
     return switch (userAccountIds.size()) {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -21,27 +21,35 @@
 
 package uk.nhs.tis.trainee.notifications.service;
 
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
+import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.NOTIFICATION_TYPE_FIELD;
-import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PERSON_ID_FIELD;
-import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NAME_FIELD;
-import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.START_DATE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.TIS_ID_FIELD;
 
 import jakarta.mail.MessagingException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
 
@@ -52,12 +60,14 @@ import uk.nhs.tis.trainee.notifications.model.NotificationType;
 @Component
 public class NotificationService implements Job {
 
-  public static final String API_GET_EMAIL = "/api/trainee-profile/account-details/{tisId}";
-
+  public static final String API_TRAINEE_DETAILS = "/api/trainee-profile/account-details/{tisId}";
+  private static final String TRIGGER_ID_PREFIX = "trigger-";
+  protected static final Integer PAST_MILESTONE_SCHEDULE_DELAY_HOURS = 1;
   private final EmailService emailService;
   private final RestTemplate restTemplate;
   private final String templateVersion;
   private final String serviceUrl;
+  private final Scheduler scheduler;
 
   /**
    * Initialise the Notification Service.
@@ -69,10 +79,12 @@ public class NotificationService implements Job {
    *                        information.
    */
   public NotificationService(EmailService emailService, RestTemplate restTemplate,
+      Scheduler scheduler,
       @Value("${application.template-versions.form-updated.email}") String templateVersion,
       @Value("${service.trainee.url}") String serviceUrl) {
     this.emailService = emailService;
     this.restTemplate = restTemplate;
+    this.scheduler = scheduler;
     this.templateVersion = templateVersion;
     this.serviceUrl = serviceUrl;
   }
@@ -84,32 +96,58 @@ public class NotificationService implements Job {
    */
   @Override
   public void execute(JobExecutionContext jobExecutionContext) {
+    boolean justLogEmail = true;
     String jobKey = jobExecutionContext.getJobDetail().getKey().toString();
     Map<String, String> result = new HashMap<>();
     JobDataMap jobDetails = jobExecutionContext.getJobDetail().getJobDataMap();
 
-    String personId = jobDetails.getString(PERSON_ID_FIELD);
+    // get job details according to notification type
+    String personId = "";
+    String jobName = "";
+    TisReferenceInfo tisReferenceInfo = null;
+    LocalDate startDate = null;
+    NotificationType notificationType =
+        NotificationType.valueOf(jobDetails.get(NOTIFICATION_TYPE_FIELD).toString());
 
-    UserAccountDetails userAccountDetails = getAccountDetails(personId);
+    if (NotificationType.getProgrammeUpdateNotificationTypes().contains(notificationType)) {
+      personId = jobDetails.getString(ProgrammeMembershipService.PERSON_ID_FIELD);
+      jobName = jobDetails.getString(ProgrammeMembershipService.PROGRAMME_NAME_FIELD);
+      startDate = (LocalDate) jobDetails.get(ProgrammeMembershipService.START_DATE_FIELD);
+      tisReferenceInfo = new TisReferenceInfo(PROGRAMME_MEMBERSHIP,
+          jobDetails.get(ProgrammeMembershipService.TIS_ID_FIELD).toString());
+
+    } else if (notificationType == NotificationType.PLACEMENT_UPDATED_WEEK_12) {
+      personId = jobDetails.getString(PlacementService.PERSON_ID_FIELD);
+      jobName = jobDetails.getString(PlacementService.PLACEMENT_TYPE_FIELD);
+      startDate = (LocalDate) jobDetails.get(PlacementService.START_DATE_FIELD);
+      tisReferenceInfo = new TisReferenceInfo(PLACEMENT,
+          jobDetails.get(PlacementService.TIS_ID_FIELD).toString());
+      String localOfficeName = jobDetails.getString(PlacementService.PLACEMENT_OWNER_FIELD);
+      String specialty = jobDetails.getString(PlacementService.PLACEMENT_SPECIALTY_FIELD);
+      justLogEmail = !isInPilot(localOfficeName, specialty, startDate);
+    }
+
+    UserDetails userCognitoAccountDetails = getCognitoAccountDetails(personId);
+    UserDetails userTraineeDetails = getTraineeDetails(personId);
+    UserDetails userAccountDetails = mapUserDetails(userCognitoAccountDetails, userTraineeDetails);
 
     if (userAccountDetails != null) {
-      String programmeName = jobDetails.getString(PROGRAMME_NAME_FIELD);
-      LocalDate startDate = (LocalDate) jobDetails.get(START_DATE_FIELD);
-      NotificationType notificationType
-          = NotificationType.valueOf(jobDetails.get(NOTIFICATION_TYPE_FIELD).toString());
-      TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(PROGRAMME_MEMBERSHIP,
-          jobDetails.get(TIS_ID_FIELD).toString());
-      jobDetails.putIfAbsent("name", userAccountDetails.familyName());
+      jobDetails.putIfAbsent("isRegistered", userAccountDetails.isRegistered());
+      jobDetails.putIfAbsent("title", userAccountDetails.title());
+      jobDetails.putIfAbsent("familyName", userAccountDetails.familyName());
+      jobDetails.putIfAbsent("givenName", userAccountDetails.givenName());
+      jobDetails.putIfAbsent("email", userAccountDetails.email());
+      jobDetails.putIfAbsent("gmcNumber", userAccountDetails.gmcNumber());
 
       try {
         emailService.sendMessage(personId, userAccountDetails.email(), notificationType,
-            templateVersion, jobDetails.getWrappedMap(), tisReferenceInfo, true);
+            templateVersion, jobDetails.getWrappedMap(), tisReferenceInfo, justLogEmail);
       } catch (MessagingException e) {
         throw new RuntimeException(e);
       }
 
       log.info("Sent {} notification for {} ({}, starting {}) to {} using template {}", jobKey,
-          jobDetails.getString(TIS_ID_FIELD), programmeName, startDate, userAccountDetails.email(),
+          jobDetails.getString(TIS_ID_FIELD), jobName, startDate, userAccountDetails.email(),
           templateVersion);
       Instant processedOn = Instant.now();
       result.put("status", "sent " + processedOn.toString());
@@ -120,24 +158,147 @@ public class NotificationService implements Job {
   }
 
   /**
-   * Get the user account details from Cognito (if they have signed-up to TIS Self-Service), or from
-   * the Trainee Details profile if not.
+   * Schedule a notification.
    *
-   * @param personId The person ID to search for.
+   * @param jobId      The job id. This must be unique for programme membership / placement and
+   *                   notification milestone.
+   * @param jobDataMap The map of job data.
+   * @param when       The date to schedule the notification to be sent.
+   * @throws SchedulerException if the job could not be scheduled.
+   */
+  public void scheduleNotification(String jobId, JobDataMap jobDataMap, Date when)
+      throws SchedulerException {
+    JobDetail job = newJob(NotificationService.class)
+        .withIdentity(jobId)
+        .usingJobData(jobDataMap)
+        .storeDurably(false)
+        .build();
+
+    Trigger trigger = newTrigger()
+        .withIdentity(TRIGGER_ID_PREFIX + jobId)
+        .startAt(when)
+        .build();
+
+    Date scheduledDate = scheduler.scheduleJob(job, trigger);
+    log.info("Notification for {} scheduled for {}", jobId, scheduledDate);
+  }
+
+  /**
+   * Remove a scheduled notification if it exists.
+   *
+   * @param jobId The job id key to remove.
+   * @throws SchedulerException if the scheduler failed in its duties (non-existent jobs do not
+   *                            trigger this exception).
+   */
+  public void removeNotification(String jobId) throws SchedulerException {
+    JobKey jobKey = new JobKey(jobId);
+    // Delete the job and unschedule its triggers.
+    // We do not simply remove the trigger, since a replacement job may have different data
+    // (e.g. programme name).
+    scheduler.deleteJob(jobKey);
+    log.info("Removed any stale notification scheduled for {}", jobId);
+  }
+
+  /**
+   * Get a future schedule for a notification from the start date and day offset.
+   *
+   * @param startDate       The starting date.
+   * @param daysBeforeStart The number of days prior to the start date.
+   * @return The notification scheduling date and time.
+   */
+  public Date getScheduleDate(LocalDate startDate, int daysBeforeStart) {
+    Date milestone;
+    LocalDate milestoneDate = startDate.minusDays(daysBeforeStart);
+    if (!milestoneDate.isAfter(LocalDate.now())) {
+      // 'Missed' milestones: schedule to be sent soon, but not immediately
+      // in case of human editing 'jitter'.
+      milestone = Date.from(Instant.now()
+          .plus(PAST_MILESTONE_SCHEDULE_DELAY_HOURS, ChronoUnit.HOURS));
+    } else {
+      // Future milestone.
+      milestone = Date.from(milestoneDate
+          .atStartOfDay()
+          .atZone(ZoneId.systemDefault())
+          .toInstant());
+    }
+    return milestone;
+  }
+
+  /**
+   * Map the user details from Cognito and trainee-profile. (Map gmcNumber from the Trainee Details
+   * profile, map email and familyName from Cognito if they have signed-up to TIS Self-Service, or
+   * from the Trainee Details profile if not)
+   *
+   * @param userCognitoAccountDetails The registered user account details from Cognito.
+   * @param userTraineeDetails        The user account details from Trainee Profile.
    * @return The user account details, or null if not found.
    */
-  private UserAccountDetails getAccountDetails(String personId) {
+  public UserDetails mapUserDetails(UserDetails userCognitoAccountDetails,
+      UserDetails userTraineeDetails) {
+    if (userCognitoAccountDetails != null && userTraineeDetails != null) {
+      return new UserDetails(true,
+          userCognitoAccountDetails.email(),
+          userTraineeDetails.title(),
+          userCognitoAccountDetails.familyName(),
+          userCognitoAccountDetails.givenName(),
+          userTraineeDetails.gmcNumber());
+    } else if (userTraineeDetails != null) {
+      //no TSS account or duplicate accounts in Cognito
+      return new UserDetails(false,
+          userTraineeDetails.email(),
+          userTraineeDetails.title(),
+          userTraineeDetails.familyName(),
+          userTraineeDetails.givenName(),
+          userTraineeDetails.gmcNumber());
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Get the user account details from Cognito if they have signed-up to TIS Self-Service.
+   *
+   * @param personId The person ID to search for.
+   * @return The user account details, or null if not found or duplicate.
+   */
+  private UserDetails getCognitoAccountDetails(String personId) {
     try {
       return emailService.getRecipientAccount(personId);
     } catch (IllegalArgumentException e) {
-      //no TSS account (or duplicate accounts), so try to get from trainee-details profile.
-      try {
-        return restTemplate.getForObject(serviceUrl + API_GET_EMAIL, UserAccountDetails.class,
-            Map.of(TIS_ID_FIELD, personId));
-      } catch (RestClientException rce) {
-        //no trainee details profile
-        return null;
-      }
+      //no TSS account or duplicate accounts
+      return null;
     }
+  }
+
+  /**
+   * Get the user details from the Trainee Details profile if not.
+   *
+   * @param personId The person ID to search for.
+   * @return The user trainee profile details, or null if not found.
+   */
+  private UserDetails getTraineeDetails(String personId) {
+    try {
+      return restTemplate.getForObject(serviceUrl + API_TRAINEE_DETAILS, UserDetails.class,
+          Map.of(TIS_ID_FIELD, personId));
+    } catch (RestClientException rce) {
+      log.warn("Exception occur when requesting trainee account-details endpoint for trainee "
+          + personId + ": " + rce);
+      //no trainee details profile
+      return null;
+    }
+  }
+
+  /**
+   * TEMPORARY (I hope). Identifies placements that fall within the pilot group 2024.
+   *
+   * @param localOffice The placement local office.
+   * @param specialty   The placement specialty.
+   * @param startDate   The placement start date.
+   * @return true if the placement is in the pilot group, otherwise false.
+   */
+  protected boolean isInPilot(String localOffice, String specialty, LocalDate startDate) {
+
+    // for now, say no-one is in pilot
+    return false;
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -1,0 +1,290 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static uk.nhs.tis.trainee.notifications.model.HrefType.ABSOLUTE_URL;
+import static uk.nhs.tis.trainee.notifications.model.HrefType.NON_HREF;
+import static uk.nhs.tis.trainee.notifications.model.HrefType.PROTOCOL_EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobDataMap;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.model.Placement;
+import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
+
+/**
+ * A service for Placement.
+ */
+
+@Slf4j
+@Service
+public class PlacementService {
+
+  public static final String TIS_ID_FIELD = "tisId";
+  public static final String PERSON_ID_FIELD = "personId";
+  public static final String START_DATE_FIELD = "startDate";
+  public static final String PLACEMENT_TYPE_FIELD = "placementType";
+  public static final String PLACEMENT_SPECIALTY_FIELD = "specialty";
+  public static final String NOTIFICATION_TYPE_FIELD = "notificationType";
+  public static final String PLACEMENT_OWNER_FIELD = "localOfficeName";
+  public static final String PLACEMENT_OWNER_CONTACT_FIELD = "localOfficeContact";
+  public static final String CONTACT_TYPE_FIELD = "contactTypeName";
+  public static final String CONTACT_FIELD = "contact";
+  public static final String CONTACT_HREF_FIELD = "contactHref";
+
+  public static final List<String> PLACEMENT_TYPES_TO_ACT_ON
+      = List.of("In post", "In post - Acting up", "In Post - Extension");
+  public static final String API_GET_OWNER_CONTACT =
+      "/api/local-office-contact-by-lo-name/{localOfficeName}";
+  protected static final String DEFAULT_NO_CONTACT_MESSAGE = "your local office";
+  protected static final String INVALID_CONTACT_HREF = "NOT_HREF";
+
+  private final HistoryService historyService;
+  private final NotificationService notificationService;
+  private final RestTemplate restTemplate;
+  private final String serviceUrl;
+
+  /**
+   * Initialise the Placement Service.
+   *
+   * @param historyService      The history Service to use.
+   * @param notificationService The notification Service to use.
+   * @param restTemplate        The REST template.
+   * @param serviceUrl          The URL for the tis-trainee-reference service to use
+   */
+  public PlacementService(HistoryService historyService,
+      NotificationService notificationService,
+      RestTemplate restTemplate,
+      @Value("${service.reference.url}") String serviceUrl) {
+    this.historyService = historyService;
+    this.notificationService = notificationService;
+    this.restTemplate = restTemplate;
+    this.serviceUrl = serviceUrl;
+  }
+
+  /**
+   * Determines whether a placement is excluded or not, on the basis of placement type.
+   *
+   * <p>Excluded means the trainee will not be notified (contacted) in respect of this
+   * placement.
+   *
+   * <p>Placement will only be included if the placement type begin with `In Post`.
+   *
+   * @param placement the Placement.
+   * @return true if the placement is excluded.
+   */
+  public boolean isExcluded(Placement placement) {
+    return (PLACEMENT_TYPES_TO_ACT_ON.stream()
+        .noneMatch(placement.getPlacementType()::equalsIgnoreCase));
+  }
+
+  /**
+   * Get a map of 12 week notifications and the instant they were sent for a given trainee and
+   * placement from the notification history.
+   *
+   * @param traineeId   The trainee TIS ID.
+   * @param placementId The placement TIS ID.
+   * @return The map of notification types and when they were sent.
+   */
+  private Map<NotificationType, Instant> getNotificationsSent(String traineeId,
+      String placementId) {
+    EnumMap<NotificationType, Instant> notifications = new EnumMap<>(NotificationType.class);
+    List<HistoryDto> correspondence = historyService.findAllForTrainee(traineeId);
+
+    Optional<HistoryDto> sentItem = correspondence.stream()
+        .filter(c -> c.tisReference() != null)
+        .filter(c ->
+            c.tisReference().type().equals(TisReferenceType.PLACEMENT)
+                && c.subject().equals(PLACEMENT_UPDATED_WEEK_12)
+                && c.tisReference().id().equals(placementId))
+        .findFirst();
+    sentItem.ifPresent(
+        historyDto -> notifications.put(PLACEMENT_UPDATED_WEEK_12, historyDto.sentAt()));
+
+    return notifications;
+  }
+
+  /**
+   * Set up notifications for an updated placement.
+   *
+   * @param placement The updated placement.
+   * @throws SchedulerException if any one of the notification jobs could not be scheduled.
+   */
+  public void addNotifications(Placement placement)
+      throws SchedulerException {
+
+    deleteNotifications(placement); //first delete any stale notifications
+
+    boolean isExcluded = isExcluded(placement);
+    log.info("Placement {}: excluded {}.", placement.getTisId(), isExcluded);
+
+    if (!isExcluded) {
+      Map<NotificationType, Instant> notificationsAlreadySent
+          = getNotificationsSent(placement.getPersonId(), placement.getTisId());
+
+      LocalDate startDate = placement.getStartDate();
+
+      boolean shouldSchedule = shouldScheduleNotification(notificationsAlreadySent);
+
+      if (shouldSchedule) {
+        log.info("Scheduling notification {} for {}.",
+            PLACEMENT_UPDATED_WEEK_12, placement.getTisId());
+        Integer daysBeforeStart = getNotificationDaysBeforeStart(PLACEMENT_UPDATED_WEEK_12);
+        Date when = notificationService.getScheduleDate(startDate, daysBeforeStart);
+
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put(TIS_ID_FIELD, placement.getTisId());
+        jobDataMap.put(PERSON_ID_FIELD, placement.getPersonId());
+        jobDataMap.put(START_DATE_FIELD, placement.getStartDate());
+        jobDataMap.put(PLACEMENT_TYPE_FIELD, placement.getPlacementType());
+        jobDataMap.put(PLACEMENT_SPECIALTY_FIELD, placement.getSpecialty());
+        jobDataMap.put(PLACEMENT_OWNER_FIELD, placement.getOwner());
+
+        String contact = getOwnerContact(placement.getOwner(), LocalOfficeContactType.TSS_SUPPORT);
+        jobDataMap.put(PLACEMENT_OWNER_CONTACT_FIELD, contact);
+        jobDataMap.put(CONTACT_HREF_FIELD, getHrefTypeForContact(contact));
+
+        jobDataMap.put(NOTIFICATION_TYPE_FIELD, PLACEMENT_UPDATED_WEEK_12);
+        // Note the status of the trainee will be retrieved when the job is executed, as will
+        // their name and email address, not now.
+
+        String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + placement.getTisId();
+        try {
+          notificationService.scheduleNotification(jobId, jobDataMap, when);
+        } catch (SchedulerException e) {
+          log.error("Failed to schedule notification {}: {}", jobId, e.toString());
+          throw (e); //to allow message to be requeue-ed
+        }
+      }
+    }
+  }
+
+  /**
+   * Remove notifications for a placement.
+   *
+   * @param placement The placement.
+   * @throws SchedulerException if any one of the notification jobs could not be removed.
+   */
+  public void deleteNotifications(Placement placement)
+      throws SchedulerException {
+    String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + placement.getTisId();
+    notificationService.removeNotification(jobId); //remove existing notification if it exists
+  }
+
+  /**
+   * Get the number of days in advance of the placement start to send the notification.
+   *
+   * @param notificationType The notification type.
+   * @return The number of days before the placement start for the notification, or null if not a
+   *     placement update notification type.
+   */
+  public Integer getNotificationDaysBeforeStart(NotificationType notificationType) {
+    if (notificationType.equals(PLACEMENT_UPDATED_WEEK_12)) {
+      return 84;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Helper function to determine whether a notification should be scheduled.
+   *
+   * @return true if it should be scheduled, false otherwise.
+   */
+  private boolean shouldScheduleNotification(
+      Map<NotificationType, Instant> notificationsAlreadySent) {
+
+    //do not resend any notification
+    return (!notificationsAlreadySent.containsKey(PLACEMENT_UPDATED_WEEK_12));
+  }
+
+  /**
+   * Get placement owner contact from Trainee Reference Service.
+   *
+   * @param localOfficeName The owner name to search for.
+   * @return The specific contact type contact of the owner, or null if not found.
+   */
+  private String getOwnerContact(String localOfficeName, LocalOfficeContactType contactType) {
+    if (localOfficeName != null) {
+      try {
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> ownerContactList
+            = restTemplate.getForObject(serviceUrl + API_GET_OWNER_CONTACT,
+            List.class, Map.of(PLACEMENT_OWNER_FIELD, localOfficeName));
+        if (ownerContactList != null) {
+          Optional<Map<String, String>> ownerContact = ownerContactList.stream()
+              .filter(c ->
+                  c.get(CONTACT_TYPE_FIELD).equalsIgnoreCase(contactType.getContactTypeName()))
+              .findFirst();
+          return ownerContact.map(oc -> oc.get(CONTACT_FIELD))
+              .orElse(DEFAULT_NO_CONTACT_MESSAGE);
+        } else {
+          log.warn("Null response when requesting reference local-office-contact-by-lo-name '{}'",
+              localOfficeName);
+        }
+      } catch (RestClientException rce) {
+        log.warn("Exception occurred when requesting reference local-office-contact-by-lo-name "
+            + "endpoint: " + rce);
+      }
+    }
+    //no matched owner, or other problems retrieving contact
+    return DEFAULT_NO_CONTACT_MESSAGE;
+  }
+
+  /**
+   * Return a href type for a contact. It is assumed to be either a URL or an email address. There
+   * is minimal checking that it is a validly formatted email address.
+   *
+   * @param contact The contact string, expected to be either an email address or a URL.
+   * @return "email" if it looks like an email address, "url" if it looks like a URL, and "NOT_HREF"
+   *     otherwise.
+   */
+  private String getHrefTypeForContact(String contact) {
+    try {
+      new URL(contact);
+      return ABSOLUTE_URL.getHrefTypeName();
+    } catch (MalformedURLException e) {
+      if (contact.contains("@") && !contact.contains(" ")) {
+        return PROTOCOL_EMAIL.getHrefTypeName();
+      } else {
+        return NON_HREF.getHrefTypeName();
+      }
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
@@ -39,7 +39,7 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeTy
 import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
 import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
-import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 
 /**
  * A service providing user account data.
@@ -52,6 +52,7 @@ public class UserAccountService {
 
   private static final String ATTRIBUTE_EMAIL = "email";
   private static final String ATTRIBUTE_FAMILY_NAME = "family_name";
+  private static final String ATTRIBUTE_GIVEN_NAME = "given_name";
 
   private final CognitoIdentityProviderClient cognitoClient;
   private final String userPoolId;
@@ -118,7 +119,7 @@ public class UserAccountService {
    * @param userAccountId The user ID to get the details of.
    * @return The found user account details.
    */
-  public UserAccountDetails getUserDetails(String userAccountId) {
+  public UserDetails getUserDetails(String userAccountId) {
     log.info("Getting user details for account {}", userAccountId);
     AdminGetUserRequest request = AdminGetUserRequest.builder()
         .userPoolId(userPoolId)
@@ -128,7 +129,12 @@ public class UserAccountService {
     Map<String, String> attributes = response.userAttributes().stream()
         .collect(Collectors.toMap(AttributeType::name, AttributeType::value));
 
-    return new UserAccountDetails(attributes.get(ATTRIBUTE_EMAIL),
-        attributes.get(ATTRIBUTE_FAMILY_NAME));
+    return new UserDetails(
+        true,
+        attributes.get(ATTRIBUTE_EMAIL),
+        null,
+        attributes.get(ATTRIBUTE_FAMILY_NAME),
+        attributes.get(ATTRIBUTE_GIVEN_NAME),
+        null);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ application:
     credential-revoked: ${CREDENTIAL_REVOKED_QUEUE}
     email-failure: ${EMAIL_FAILURE_QUEUE}
     form-updated: ${FORM_UPDATED_QUEUE}
+    placement-updated: ${PLACEMENT_UPDATED_QUEUE}
+    placement-deleted: ${PLACEMENT_DELETED_QUEUE}
     programme-membership-updated: ${PROGRAMME_MEMBERSHIP_UPDATED_QUEUE}
     programme-membership-deleted: ${PROGRAMME_MEMBERSHIP_DELETED_QUEUE}
   template-versions:
@@ -91,3 +93,7 @@ service:
     host: ${TRAINEE_DETAILS_HOST:localhost}
     port: ${TRAINEE_DETAILS_PORT:8203}
     url: http://${service.trainee.host}:${service.trainee.port}/trainee
+  reference:
+    host: ${TRAINEE_REFERENCE_HOST:localhost}
+    port: ${TRAINEE_REFERENCE_PORT:8205}
+    url: http://${service.trainee.host}:${service.reference.port}/reference

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">Placement confirmation: 12 weeks to go</th:block>
+<h2>Content</h2>
+<th:block th:fragment="content">
+  <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
+  <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span>,</p>
+  <p th:if="${not #strings.isEmpty(gmcNumber)}">GMC <span th:text="${gmcNumber}"></span></p>
+  <p>
+    We appreciate this must be a busy time for you but please set some time aside to read this letter as it contains some vital information regarding your training placement.
+  </p>
+  <p>
+    The NHS England team can now confirm your placement within a <b><span th:text="${localOfficeName}"></span></b> programme.
+  </p>
+  <p>
+    Please note your allocation and grade progression if appropriate will be subject to you receiving a satisfactory ARCP outcome, and your continued registration/licence to practise with the GMC for the duration of your training.
+  </p>
+  <th:block th:switch="${isRegistered}"
+  ><p th:case="true">
+    We have a registered account for you on TIS Self Service against the email address <b><span th:text="${email}"></span></b>. To access your upcoming placement details please log in to TIS Self Service: <a href="https://trainee.tis.nhs.uk/home">https://trainee.tis.nhs.uk/home</a>
+  </p>
+  <p th:case="false">
+    We have no TIS Self Service account associated to your record. Please create one by clicking the link below.
+    <br/>
+    Please ensure you use the email address we have against our records <b><span th:text="${email}"></span></b>
+    <br/>
+    <a href="https://trainee.tis.nhs.uk/">https://trainee.tis.nhs.uk/</a>.
+  </p>
+  </th:block>
+  <p>
+    If your email address is likely to change, then please ensure that you update our team via <th:block th:switch="${contactHref}"
+  ><span th:case="url"><a th:href="${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
+  ><span th:case="email"><a th:href="'mailto:' + ${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
+  ><span th:case="*"><span th:text="${localOfficeContact}"></span></span
+  ></th:block> or see our <a href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/">FAQ</a> for details.
+  </p>
+  <p>
+    The placement information reflects what we have recorded on our Training Information System (TIS) as your next placement- <b>please bear in mind that the end date may not be when you finish your rotation, but instead be a change in Grade, WTE or Post number on our system.</b>
+  </p>
+  <p>
+    Further details on the specialist area of your placement will be confirmed by your employing organisation. This is because we are only able to confirm details that relate specifically to your college recognised curriculum.
+  </p>
+  <p>
+    An example of this would be If you have preference a specific post with your Training Programme Director but does not relate to sub-specialty training. This may be a job in a specific location or department
+  </p>
+  <p>
+    Kind Regards,
+  </p>
+  <p>
+    <span th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : _"></span>
+  </p>
+  <p>
+    Workforce, Training and Education
+  </p>
+  <p>
+    NHS England
+  </p>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/greeting/v1.0.0.html
+++ b/src/main/resources/templates/fragments/greeting/v1.0.0.html
@@ -5,6 +5,6 @@
     <title>Greeting</title>
   </head>
   <body>
-    <p>Dear <span th:text="${not #strings.isEmpty(name)} ? |Dr ${name}| : _">Doctor</span>,</p>
+    <p>Dear <span th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</span>,</p>
   </body>
 </html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -23,7 +23,6 @@ package uk.nhs.tis.trainee.notifications.event;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -59,7 +58,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.ActiveProfiles;
 import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent;
 import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
-import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
@@ -78,7 +77,10 @@ class ConditionsOfJoiningListenerIntegrationTest {
   private static final String PERSON_ID = "40";
   private static final String USER_ID = UUID.randomUUID().toString();
   private static final String EMAIL = "anthony.gilliam@tis.nhs.uk";
+  private static final String TITLE = "Mr";
   private static final String FAMILY_NAME = "Gilliam";
+  private static final String GIVEN_NAME = "Anthony";
+  private static final String GMC = "111111";
   private static final Instant SYNCED_AT = Instant.parse("2023-08-01T00:00:00Z");
   private static final String APP_DOMAIN = "https://local.notifications.com";
   private static final String NEXT_STEPS_LINK = APP_DOMAIN + "/programmes";
@@ -120,7 +122,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, missingValue));
+        new UserDetails(true, EMAIL, TITLE, missingValue, missingValue, GMC));
 
     // Spy on the email service and inject a missing domain.
     EmailService emailService = spy(this.emailService);
@@ -166,7 +168,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(SYNCED_AT));
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, FAMILY_NAME));
+        new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
 
@@ -206,7 +208,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, FAMILY_NAME));
+        new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
 
@@ -242,7 +244,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, null));
+        new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
 
@@ -280,7 +282,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(SYNCED_AT));
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, null));
+        new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
 
@@ -318,7 +320,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, null));
+        new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
 
@@ -354,7 +356,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(SYNCED_AT));
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, FAMILY_NAME));
+        new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
 
@@ -377,8 +379,8 @@ class ConditionsOfJoiningListenerIntegrationTest {
     assertThat("Unexpected template version.", templateInfo.version(), is(templateVersion));
 
     Map<String, Object> storedVariables = templateInfo.variables();
-    assertThat("Unexpected template variable count.", storedVariables.size(), is(3));
-    assertThat("Unexpected template variable.", storedVariables.get("name"), is(FAMILY_NAME));
+    assertThat("Unexpected template variable count.", storedVariables.size(), is(4));
+    assertThat("Unexpected template variable.", storedVariables.get("familyName"), is(FAMILY_NAME));
     assertThat("Unexpected template variable.", storedVariables.get("syncedAt"), is(SYNCED_AT));
     assertThat("Unexpected template variable.", storedVariables.get("domain"),
         is(URI.create(APP_DOMAIN)));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
@@ -23,7 +23,6 @@ package uk.nhs.tis.trainee.notifications.event;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -59,7 +58,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.ActiveProfiles;
 import uk.nhs.tis.trainee.notifications.dto.FormUpdateEvent;
-import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
 import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
@@ -77,7 +76,10 @@ class FormListenerIntegrationTest {
   private static final String PERSON_ID = "40";
   private static final String USER_ID = UUID.randomUUID().toString();
   private static final String EMAIL = "anthony.gilliam@tis.nhs.uk";
+  private static final String TITLE = "Mr";
   private static final String FAMILY_NAME = "Gilliam";
+  private static final String GIVEN_NAME = "Anthony";
+  private static final String GMC = "111111";
 
   private static final Instant FORM_UPDATED_AT = Instant.parse("2023-08-01T00:00:00Z");
   private static final String APP_DOMAIN = "https://local.notifications.com";
@@ -128,7 +130,7 @@ class FormListenerIntegrationTest {
         missingValue, null, FORM_CONTENT);
 
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, missingValue));
+        new UserDetails(true, EMAIL, TITLE, missingValue, missingValue, GMC));
 
     // Spy on the email service and inject a missing domain.
     EmailService emailService = spy(this.emailService);
@@ -174,7 +176,7 @@ class FormListenerIntegrationTest {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_SUBMITTED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, FAMILY_NAME));
+        new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);
 
@@ -218,7 +220,7 @@ class FormListenerIntegrationTest {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_UNSUBMITTED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, FAMILY_NAME));
+        new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);
 
@@ -262,7 +264,7 @@ class FormListenerIntegrationTest {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_DELETED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, FAMILY_NAME));
+        new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);
 
@@ -303,7 +305,7 @@ class FormListenerIntegrationTest {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_SUBMITTED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
-        new UserAccountDetails(EMAIL, FAMILY_NAME));
+        new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);
 
@@ -326,8 +328,8 @@ class FormListenerIntegrationTest {
     assertThat("Unexpected template version.", templateInfo.version(), is(templateVersion));
 
     Map<String, Object> storedVariables = templateInfo.variables();
-    assertThat("Unexpected template variable count.", storedVariables.size(), is(6));
-    assertThat("Unexpected template variable.", storedVariables.get("name"), is(FAMILY_NAME));
+    assertThat("Unexpected template variable count.", storedVariables.size(), is(7));
+    assertThat("Unexpected template variable.", storedVariables.get("familyName"), is(FAMILY_NAME));
     assertThat("Unexpected template variable.", storedVariables.get("lifecycleState"),
         is(FORM_SUBMITTED));
     assertThat("Unexpected template variable.", storedVariables.get("formType"), is(FORM_TYPE));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/PlacementListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/PlacementListenerTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.Mapping;
+import org.mockito.ArgumentCaptor;
+import org.quartz.SchedulerException;
+import uk.nhs.tis.trainee.notifications.dto.PlacementEvent;
+import uk.nhs.tis.trainee.notifications.dto.RecordDto;
+import uk.nhs.tis.trainee.notifications.mapper.PlacementMapper;
+import uk.nhs.tis.trainee.notifications.model.Placement;
+import uk.nhs.tis.trainee.notifications.service.PlacementService;
+
+class PlacementListenerTest {
+
+  private static final String TIS_ID = "123";
+  private static final String TRAINEE_ID = "abc";
+  private static final LocalDate START_DATE = LocalDate.now();
+
+  private PlacementListener listener;
+  private PlacementService placementService;
+  private PlacementMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    placementService = mock(PlacementService.class);
+    mapper = mock(PlacementMapper.class);
+    listener = new PlacementListener(placementService, mapper);
+  }
+
+  @Test
+  void shouldNotThrowAnExceptionOnNonRecordEvents() {
+    PlacementEvent event = new PlacementEvent(TIS_ID, null);
+
+    assertDoesNotThrow(() -> listener.handlePlacementUpdate(event));
+    assertDoesNotThrow(() -> listener.handlePlacementDelete(event));
+  }
+
+  @Test
+  void shouldNotThrowAnExceptionOnNonRecordDataEvents() {
+    RecordDto recordDto = new RecordDto();
+    PlacementEvent event = new PlacementEvent(TIS_ID, recordDto);
+
+    assertDoesNotThrow(() -> listener.handlePlacementUpdate(event));
+    assertDoesNotThrow(() -> listener.handlePlacementDelete(event));
+  }
+
+  @Test
+  void shouldAddNotifications() throws SchedulerException {
+    PlacementEvent event = buildPlacementEvent();
+
+    listener.handlePlacementUpdate(event);
+
+    verify(placementService).addNotifications(any());
+  }
+
+  @Test
+  void shouldDeleteNotifications() throws SchedulerException {
+    PlacementEvent event = buildPlacementEvent();
+    Placement placementToDelete = new Placement();
+
+    when(mapper.toEntity(any())).thenReturn(placementToDelete);
+
+    ArgumentCaptor<Placement> placementCaptor = ArgumentCaptor.forClass(Placement.class);
+
+    listener.handlePlacementDelete(event);
+
+    verify(placementService).deleteNotifications(placementCaptor.capture());
+
+    Placement placement = placementCaptor.getValue();
+    assertThat("Unexpected placement id", placement.getTisId(), is(TIS_ID));
+  }
+
+  /**
+   * Helper function to construct a programme membership event.
+   *
+   * @return The ProgrammeMembershipEvent.
+   */
+  PlacementEvent buildPlacementEvent() {
+    Map<String, String> dataMap = new HashMap<>();
+    dataMap.put("id", TIS_ID);
+    dataMap.put("startDate", START_DATE.toString());
+    dataMap.put("traineeId", TRAINEE_ID);
+    RecordDto data = new RecordDto();
+    data.setData(dataMap);
+    return new PlacementEvent(TIS_ID, data);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -1,0 +1,679 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.notifications.model.HrefType.ABSOLUTE_URL;
+import static uk.nhs.tis.trainee.notifications.model.HrefType.NON_HREF;
+import static uk.nhs.tis.trainee.notifications.model.HrefType.PROTOCOL_EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.CONTACT_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.CONTACT_HREF_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.CONTACT_TYPE_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.DEFAULT_NO_CONTACT_MESSAGE;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.PERSON_ID_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.PLACEMENT_OWNER_CONTACT_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.PLACEMENT_OWNER_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.PLACEMENT_TYPE_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.START_DATE_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.TIS_ID_FIELD;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.quartz.JobDataMap;
+import org.quartz.SchedulerException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
+import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
+import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.model.Placement;
+import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
+
+class PlacementServiceTest {
+
+  private static final String SERVICE_URL =
+      "http://localhost:0000/reference/api/local-office-contact/{owner}";
+  private static final String IN_POST = "In Post";
+  private static final String In_POST_ACTING_UP = "In Post - Acting up";
+  private static final String IN_POST_EXTENSION = "In Post - Extension";
+  private static final String EXCLUDED_PLACEMENT_TYPE = "RANDOM TYPE";
+
+  private static final String TIS_ID = "123";
+  private static final String OWNER = "North West";
+  private static final String OWNER_CONTACT = "north.west@nhs.net";
+  private static final String PERSON_ID = "abc";
+  private static final LocalDate START_DATE = LocalDate.now().plusYears(1);
+  //set a year in the future to allow all notifications to be scheduled
+
+  HistoryService historyService;
+  PlacementService service;
+  NotificationService notificationService;
+  RestTemplate restTemplate;
+
+  @BeforeEach
+  void setUp() {
+    historyService = mock(HistoryService.class);
+    notificationService = mock(NotificationService.class);
+    restTemplate = mock(RestTemplate.class);
+    service = new PlacementService(historyService, notificationService, restTemplate, SERVICE_URL);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {IN_POST, In_POST_ACTING_UP, IN_POST_EXTENSION})
+  void shouldNotExcludePlacementWithInPostPlacementType(String placementType) {
+    Placement placement = new Placement();
+    placement.setPlacementType(placementType);
+
+    boolean isExcluded = service.isExcluded(placement);
+
+    assertThat("Unexpected excluded value.", isExcluded, is(false));
+  }
+
+  @Test
+  void shouldExcludePlacementNotWithInPostPlacementType() {
+    Placement placement = new Placement();
+    placement.setPlacementType(EXCLUDED_PLACEMENT_TYPE);
+
+    boolean isExcluded = service.isExcluded(placement);
+
+    assertThat("Unexpected excluded value.", isExcluded, is(true));
+  }
+
+  @Test
+  void shouldRemoveStaleNotifications() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    List<Map<String, String>> localOfficeContacts = new ArrayList<>();
+    localOfficeContacts.add(Map.of("contact", OWNER_CONTACT));
+    when(restTemplate.getForObject(SERVICE_URL, List.class,
+        Map.of(PLACEMENT_OWNER_FIELD, "North West"))).thenReturn(localOfficeContacts);
+
+    service.addNotifications(placement);
+
+    String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + TIS_ID;
+    verify(notificationService).removeNotification(jobId);
+  }
+
+  @Test
+  void shouldNotAddNotificationsIfExcluded() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(EXCLUDED_PLACEMENT_TYPE);
+
+    service.addNotifications(placement);
+
+    verify(notificationService, never()).scheduleNotification(any(), any(), any());
+  }
+
+  @Test
+  void shouldAddNotificationsIfNotExcluded() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    NotificationType milestone = PLACEMENT_UPDATED_WEEK_12;
+    LocalDate expectedDate = START_DATE
+        .minusDays(service.getNotificationDaysBeforeStart(milestone));
+    Date expectedWhen = Date.from(expectedDate
+        .atStartOfDay()
+        .atZone(ZoneId.systemDefault())
+        .toInstant());
+
+    when(notificationService
+        .getScheduleDate(START_DATE, service.getNotificationDaysBeforeStart(milestone)))
+        .thenReturn(expectedWhen);
+    service.addNotifications(placement);
+
+    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    verify(notificationService).scheduleNotification(
+        stringCaptor.capture(),
+        jobDataMapCaptor.capture(),
+        dateCaptor.capture()
+    );
+
+    //verify the details of the last notification added
+    String jobId = stringCaptor.getValue();
+    String expectedJobId = milestone + "-" + TIS_ID;
+    assertThat("Unexpected job id.", jobId, is(expectedJobId));
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected tisId.", jobDataMap.get(TIS_ID_FIELD), is(TIS_ID));
+    assertThat("Unexpected personId.", jobDataMap.get(PERSON_ID_FIELD), is(PERSON_ID));
+    assertThat("Unexpected start date.", jobDataMap.get(START_DATE_FIELD), is(START_DATE));
+    assertThat("Unexpected placement type.", jobDataMap.get(PLACEMENT_TYPE_FIELD),
+        is(IN_POST));
+    assertThat("Unexpected placement owner.", jobDataMap.get(PLACEMENT_OWNER_FIELD),
+        is(OWNER));
+
+    Date when = dateCaptor.getValue();
+    assertThat("Unexpected start time", when, is(expectedWhen));
+  }
+
+  @Test
+  void shouldIgnoreNonPlacementSentNotifications() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    List<HistoryDto> sentNotifications = new ArrayList<>();
+    sentNotifications.add(new HistoryDto("id",
+        new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_ID),
+        MessageType.EMAIL,
+        PLACEMENT_UPDATED_WEEK_12, null, //to avoid masking the test condition
+        "email address",
+        Instant.MIN, Instant.MAX, SENT, null));
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
+
+    service.addNotifications(placement);
+
+    verify(notificationService)
+        .scheduleNotification(any(), any(), any());
+  }
+
+  @Test
+  void shouldIgnoreOtherTypesOfPlacementUpdateSentNotifications() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    List<HistoryDto> sentNotifications = new ArrayList<>();
+    sentNotifications.add(new HistoryDto("id",
+        new TisReferenceInfo(TisReferenceType.PLACEMENT, "another id"),
+        MessageType.EMAIL,
+        NotificationType.PROGRAMME_UPDATED_WEEK_8, null,
+        "email address",
+        Instant.MIN, Instant.MAX, SENT, null));
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(any(), any(), any());
+  }
+
+  @Test
+  void shouldIgnoreDifferentPlacementUpdateSentNotifications() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    List<HistoryDto> sentNotifications = new ArrayList<>();
+    sentNotifications.add(new HistoryDto("id",
+        new TisReferenceInfo(TisReferenceType.PLACEMENT, "another id"),
+        MessageType.EMAIL,
+        PLACEMENT_UPDATED_WEEK_12, null,
+        "email address",
+        Instant.MIN, Instant.MAX, SENT, null));
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(any(), any(), any());
+  }
+
+  @Test
+  void shouldNotResendPlacementNotification() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    List<HistoryDto> sentNotifications = new ArrayList<>();
+    sentNotifications.add(new HistoryDto("id",
+        new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_ID),
+        MessageType.EMAIL,
+        PLACEMENT_UPDATED_WEEK_12, null,
+        "email address",
+        Instant.MIN, Instant.MAX, SENT, null));
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
+
+    service.addNotifications(placement);
+
+    verify(notificationService, never()).scheduleNotification(any(), any(), any());
+  }
+
+  @Test
+  void shouldScheduleMissedNotification() throws SchedulerException {
+    LocalDate dateToday = LocalDate.now();
+
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(dateToday);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    Date expectedLaterThan = Date.from(Instant.now());
+    when(notificationService
+        .getScheduleDate(dateToday, 84))
+        .thenReturn(expectedLaterThan);
+    service.addNotifications(placement);
+
+    //the zero-day notification should be scheduled, but no other missed notifications
+    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    verify(notificationService).scheduleNotification(
+        any(),
+        any(),
+        dateCaptor.capture()
+    );
+
+    Date when = dateCaptor.getValue();
+    assertThat("Unexpected start time", when, is(expectedLaterThan));
+  }
+
+  @Test
+  void shouldNotFailOnHistoryWithoutTisReferenceInfo()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    List<HistoryDto> sentNotifications = new ArrayList<>();
+    sentNotifications.add(new HistoryDto("id",
+        null,
+        MessageType.EMAIL,
+        PLACEMENT_UPDATED_WEEK_12, null,
+        "email address",
+        Instant.MIN, Instant.MAX, SENT, null));
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
+
+    service.addNotifications(placement);
+
+    assertDoesNotThrow(() -> service.addNotifications(placement),
+        "Unexpected addNotifications failure");
+  }
+
+  @Test
+  void shouldUseDefaultLocalOfficeContactIfReferenceServiceReturnsNull()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected local office contact.",
+        jobDataMap.get(PLACEMENT_OWNER_CONTACT_FIELD), is(DEFAULT_NO_CONTACT_MESSAGE));
+  }
+
+  @Test
+  void shouldUseDefaultLocalOfficeContactIfReferenceServiceFailure()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    doThrow(new RestClientException("error"))
+        .when(restTemplate).getForObject(any(), any(), anyMap());
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected local office contact.",
+        jobDataMap.get(PLACEMENT_OWNER_CONTACT_FIELD), is(DEFAULT_NO_CONTACT_MESSAGE));
+  }
+
+  @Test
+  void shouldUseDefaultLocalOfficeContactIfNoContactOfCorrectType()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, "some other contact type");
+    contact1.put(CONTACT_FIELD, "incorrect contact");
+    contacts.add(contact1);
+
+    when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(contacts);
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected local office contact.",
+        jobDataMap.get(PLACEMENT_OWNER_CONTACT_FIELD), is(DEFAULT_NO_CONTACT_MESSAGE));
+  }
+
+  @Test
+  void shouldUseDefaultLocalOfficeContactIfNoLocalOffice()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(null);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected local office contact.",
+        jobDataMap.get(PLACEMENT_OWNER_CONTACT_FIELD), is(DEFAULT_NO_CONTACT_MESSAGE));
+  }
+
+  @Test
+  void shouldUseTssSupportLocalOfficeContactIfAvailable()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, "some other contact type");
+    contact1.put(CONTACT_FIELD, "incorrect contact");
+    contacts.add(contact1);
+    Map<String, String> contact2 = new HashMap<>();
+    contact2.put(CONTACT_TYPE_FIELD, LocalOfficeContactType.TSS_SUPPORT.getContactTypeName());
+    contact2.put(CONTACT_FIELD, "correct contact");
+    contacts.add(contact2);
+
+    when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(contacts);
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected local office contact.",
+        jobDataMap.get(PLACEMENT_OWNER_CONTACT_FIELD), is("correct contact"));
+  }
+
+  @Test
+  void shouldIncludeMailtoHrefForEmailContact()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, LocalOfficeContactType.TSS_SUPPORT.getContactTypeName());
+    contact1.put(CONTACT_FIELD, "some@email.com");
+    contacts.add(contact1);
+
+    when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(contacts);
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected contact href.",
+        jobDataMap.get(CONTACT_HREF_FIELD), is(PROTOCOL_EMAIL.getHrefTypeName()));
+  }
+
+  @Test
+  void shouldIncludeBlankHrefForUrlContact()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, LocalOfficeContactType.TSS_SUPPORT.getContactTypeName());
+    contact1.put(CONTACT_FIELD, "https://a.validwebsite.com");
+    contacts.add(contact1);
+
+    when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(contacts);
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected contact href.",
+        jobDataMap.get(CONTACT_HREF_FIELD), is(ABSOLUTE_URL.getHrefTypeName()));
+  }
+
+  @Test
+  void shouldIncludeNonHrefForNonEmailNonUrlContact()
+      throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, LocalOfficeContactType.TSS_SUPPORT.getContactTypeName());
+    contact1.put(CONTACT_FIELD, "one@email.com, another@email.com");
+    contacts.add(contact1);
+
+    when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(contacts);
+
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(
+        any(),
+        jobDataMapCaptor.capture(),
+        any()
+    );
+
+    JobDataMap jobDataMap = jobDataMapCaptor.getValue();
+    assertThat("Unexpected contact href.",
+        jobDataMap.get(CONTACT_HREF_FIELD), is(NON_HREF.getHrefTypeName()));
+  }
+
+  @Test
+  void shouldIgnoreHistoryWithoutTisReferenceInfo() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    List<HistoryDto> sentNotifications = new ArrayList<>();
+    sentNotifications.add(new HistoryDto("id",
+        null,
+        MessageType.EMAIL,
+        PLACEMENT_UPDATED_WEEK_12, null,
+        "email address",
+        Instant.MIN, Instant.MAX, SENT, null));
+
+    when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
+
+    service.addNotifications(placement);
+
+    verify(notificationService).scheduleNotification(any(), any(), any());
+  }
+
+  @Test
+  void shouldRethrowSchedulerExceptions() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setPersonId(PERSON_ID);
+    placement.setStartDate(START_DATE);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    doThrow(new SchedulerException())
+        .when(notificationService).scheduleNotification(any(), any(), any());
+
+    assertThrows(SchedulerException.class,
+        () -> service.addNotifications(placement));
+  }
+
+  @Test
+  void shouldDeleteNotifications() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+
+    service.deleteNotifications(placement);
+
+    String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + TIS_ID;
+    verify(notificationService).removeNotification(jobId);
+  }
+
+  @Test
+  void shouldHandleUnknownNotificationTypesForNotificationDays() {
+    assertThat("Unexpected days before start.",
+        service.getNotificationDaysBeforeStart(NotificationType.COJ_CONFIRMATION), nullValue());
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
@@ -49,7 +49,7 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRe
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
 import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
-import uk.nhs.tis.trainee.notifications.dto.UserAccountDetails;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 
 class UserAccountServiceTest {
 
@@ -57,11 +57,13 @@ class UserAccountServiceTest {
 
   private static final String USER_ID_1 = UUID.randomUUID().toString();
   private static final String PERSON_ID_1 = "1";
+  private static final String GMC_NUMBER = "111111";
 
   private static final String USER_ID_2 = UUID.randomUUID().toString();
   private static final String PERSON_ID_2 = "2";
   private static final String EMAIL = "anthony.gilliam@tis.nhs.uk";
   private static final String FAMILY_NAME = "Gilliam";
+  private static final String GIVEN_NAME = "Anthony";
 
   private static final String ATTRIBUTE_PERSON_ID = "custom:tisId";
   private static final String ATTRIBUTE_USER_ID = "sub";
@@ -187,15 +189,20 @@ class UserAccountServiceTest {
     AdminGetUserResponse response = AdminGetUserResponse.builder()
         .userAttributes(
             AttributeType.builder().name("email").value(EMAIL).build(),
-            AttributeType.builder().name("family_name").value(FAMILY_NAME).build()
+            AttributeType.builder().name("family_name").value(FAMILY_NAME).build(),
+            AttributeType.builder().name("given_name").value(GIVEN_NAME).build()
         ).build();
 
     when(cognitoClient.adminGetUser(any(AdminGetUserRequest.class))).thenReturn(response);
 
-    UserAccountDetails userDetails = service.getUserDetails(USER_ID_1);
+    UserDetails userDetails = service.getUserDetails(USER_ID_1);
 
+    assertThat("Unexpected isRegistered.", userDetails.isRegistered(), is(true));
     assertThat("Unexpected email.", userDetails.email(), is(EMAIL));
+    assertThat("Unexpected title.", userDetails.title(), is(nullValue()));
     assertThat("Unexpected family name.", userDetails.familyName(), is(FAMILY_NAME));
+    assertThat("Unexpected given name.", userDetails.givenName(), is(GIVEN_NAME));
+    assertThat("Unexpected gmc number.", userDetails.gmcNumber(), is(nullValue()));
   }
 
   @Test
@@ -203,7 +210,7 @@ class UserAccountServiceTest {
     AdminGetUserResponse response = AdminGetUserResponse.builder().build();
     when(cognitoClient.adminGetUser(any(AdminGetUserRequest.class))).thenReturn(response);
 
-    UserAccountDetails userDetails = service.getUserDetails(USER_ID_1);
+    UserDetails userDetails = service.getUserDetails(USER_ID_1);
 
     assertThat("Unexpected email.", userDetails.email(), nullValue());
     assertThat("Unexpected family name.", userDetails.familyName(), nullValue());


### PR DESCRIPTION
- Add Placement confirmation notifications 12 weeks before start date.
- Get placement update message from trainee-sync with local office name (owner) added. Related [Ops ](https://github.com/Health-Education-England/TIS-OPS/commit/09d6a88bfe6b6b446724ee1a8ee22e87ae8afe4d)setting and changes from [trainee-sync](https://github.com/Health-Education-England/tis-trainee-sync/commit/3f0f23db84a5ecda62e61e36824835f70db60614) have been pushed to Prod
- Add "title", "givenName", "gmcNumber" to "UserDetails" Dto as required data in the placement notification email. Related endpoint from [trainee-details](https://github.com/Health-Education-England/tis-trainee-details/commit/81fafcadd771bf2441046ef109c3c3314834a073) has been pushed to Prod.
- Move common schedule related method to notificationService.java, so they are shared to be used by placement and pm notifications

Dependency:
It depends on the trainee-reference PR (https://github.com/Health-Education-England/tis-trainee-reference/pull/296) for the local office owner contact endpoint. 
TODO: Need a small tweak to show "mailto:" in front of the contact depends if it is an email or a website [this has been done]

**Please note that the Placement confirmation notifications should NOT be sent out until Naz agree with a data with LO.**

TIS21-5219
TIS21-5730
TIS21-5731
TIS21-5732