### PR TITLE
Feat/welcome notification

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -5,6 +5,10 @@
       "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-notifications:latest",
       "secrets": [
         {
+          "name": "ACCOUNT_CONFIRMED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/account/confirmed"
+        },
+        {
           "name": "APP_DOMAIN",
           "valueFrom": "/tis/trainee/${environment}/app-domain"
         },

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ associated document for details of how to provide the region.
 
 | Name                    | Description                                                        | Default   |
 |-------------------------|--------------------------------------------------------------------|-----------|
+| ACCOUNT_CONFIRMED_QUEUE | The queue URL for account confirmation events.                     |           |
 | APP_DOMAIN              | The domain to be used for links in email notifications. (Optional) |           |
 | AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host. (Optional)                               |           |
 | COGNITO_USER_POOL_ID    | The user pool to get user details from.                            |           |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.9.4"
+version = "1.10.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResource.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.tis.trainee.notifications.api.util.AuthTokenUtil;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+
+/**
+ * A controller providing trainees access to their notification history.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/history/trainee")
+public class TraineeHistoryResource {
+
+  private final HistoryService service;
+
+  /**
+   * Create an instance of the trainee history controller.
+   *
+   * @param service The service used to access notification history.
+   */
+  public TraineeHistoryResource(HistoryService service) {
+    this.service = service;
+  }
+
+
+  /**
+   * Get the notification history for the authorized trainee.
+   *
+   * @param token The authorization token from the request header.
+   * @return The found history, may be empty.
+   */
+  @GetMapping
+  ResponseEntity<List<HistoryDto>> getTraineeHistory(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+    log.info("Retrieving notification history for the authorized trainee.");
+
+    String traineeId;
+    try {
+      traineeId = AuthTokenUtil.getTraineeTisId(token);
+
+      if (traineeId == null) {
+        log.warn("The trainee ID was not found in the token.");
+        return ResponseEntity.badRequest().build();
+      }
+    } catch (IOException e) {
+      log.warn("Unable to read the trainee ID from the token.", e);
+      return ResponseEntity.badRequest().build();
+    }
+
+    log.info("Retrieving notification history for trainee {}.", traineeId);
+    List<HistoryDto> history = service.findAllForTrainee(traineeId);
+    log.info("Found {} notifications for trainee {}.", history.size(), traineeId);
+    return ResponseEntity.ok(history);
+  }
+
+  /**
+   * Get the historic notification with the given ID.
+   *
+   * @param notificationId The ID of the notification to get.
+   * @return The found notification.
+   */
+  @GetMapping("/message/{notificationId}")
+  ResponseEntity<String> getHistoricalMessage(@PathVariable String notificationId,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+    log.info("Retrieving notification message for the authorized trainee.");
+
+    String traineeId;
+    try {
+      traineeId = AuthTokenUtil.getTraineeTisId(token);
+
+      if (traineeId == null) {
+        log.warn("The trainee ID was not found in the token.");
+        return ResponseEntity.badRequest().build();
+      }
+    } catch (IOException e) {
+      log.warn("Unable to read the trainee ID from the token.", e);
+      return ResponseEntity.badRequest().build();
+    }
+
+    log.info("Rebuilding message for notification {}.", notificationId);
+    Optional<String> message = service.rebuildMessage(traineeId, notificationId);
+
+    return message.map(msg -> ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(msg))
+        .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/AccountConfirmedEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/AccountConfirmedEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,11 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.model;
+package uk.nhs.tis.trainee.notifications.dto;
+
+import java.util.UUID;
 
 /**
- * An enumeration of possible notification statuses.
+ * An event published when a user account is confirmed.
+ *
+ * @param userId    The user account ID.
+ * @param traineeId The linked trainee ID.
+ * @param email     The user account's email address.
  */
-public enum NotificationStatus {
-  FAILED, SENT, UNREAD
+public record AccountConfirmedEvent(UUID userId, String traineeId, String email) {
+
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/UserAccountListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/UserAccountListener.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.WELCOME;
+
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.notifications.dto.AccountConfirmedEvent;
+import uk.nhs.tis.trainee.notifications.service.InAppService;
+
+/**
+ * A listener for user account events.
+ */
+@Slf4j
+@Component
+public class UserAccountListener {
+
+  private final InAppService inAppService;
+  private final String templateVersion;
+
+  public UserAccountListener(InAppService inAppService,
+      @Value("${application.template-versions.welcome.in-app}") String templateVersion) {
+    this.inAppService = inAppService;
+    this.templateVersion = templateVersion;
+  }
+
+  /**
+   * Handle account confirmation events.
+   *
+   * @param event The account confirmation event.
+   */
+  @SqsListener("${application.queues.account-confirmed}")
+  public void handleAccountConfirmation(AccountConfirmedEvent event) {
+    log.info("Handling account confirmation event for user {}.", event.userId());
+    inAppService.createNotifications(event.traineeId(), WELCOME, templateVersion);
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/MessageType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/MessageType.java
@@ -21,30 +21,18 @@
 
 package uk.nhs.tis.trainee.notifications.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * An enumeration of possible message types.
  */
+@Getter
+@AllArgsConstructor
 public enum MessageType {
 
+  IN_APP("in-app"),
   EMAIL("email");
 
   private final String templatePath;
-
-  /**
-   * Create an enumeration of a possible message type.
-   *
-   * @param templatePath The resource sub-path for templates of this type.
-   */
-  MessageType(String templatePath) {
-    this.templatePath = templatePath;
-  }
-
-  /**
-   * Get the resource sub-path for templates of this type.
-   *
-   * @return The template sub-path.
-   */
-  public String getTemplatePath() {
-    return templatePath;
-  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
@@ -23,10 +23,14 @@ package uk.nhs.tis.trainee.notifications.model;
 
 import java.util.EnumSet;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
  * An enumeration of possible notification types.
  */
+@Getter
+@AllArgsConstructor
 public enum NotificationType {
 
   COJ_CONFIRMATION("coj-confirmation"),
@@ -35,38 +39,18 @@ public enum NotificationType {
   PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
   PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),
   PROGRAMME_UPDATED_WEEK_1("programme-updated-week-1"),
-  PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0");
-
-  private final String templateName;
-
-  /**
-   * Create an enumeration of a possible notification type.
-   *
-   * @param templateName The name of the template for this type of notification.
-   */
-  NotificationType(String templateName) {
-    this.templateName = templateName;
-  }
-
-  /**
-   * Get the name for templates of this type.
-   *
-   * @return The template name.
-   */
-  public String getTemplateName() {
-    return templateName;
-  }
+  PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0"),
+  WELCOME("welcome");
 
   /**
    * The set of Programme Updated notification types.
    */
-  static final Set<NotificationType> programmeUpdateNotificationTypes = EnumSet.of(
+  @Getter
+  private static final Set<NotificationType> programmeUpdateNotificationTypes = EnumSet.of(
       PROGRAMME_UPDATED_WEEK_8,
       PROGRAMME_UPDATED_WEEK_4,
       PROGRAMME_UPDATED_WEEK_1,
       PROGRAMME_UPDATED_WEEK_0);
 
-  public static Set<NotificationType> getProgrammeUpdateNotificationTypes() {
-    return programmeUpdateNotificationTypes;
-  }
+  private final String templateName;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -117,7 +117,35 @@ public class HistoryService {
       return Optional.empty();
     }
 
-    History history = optionalHistory.get();
+    return rebuildMessage(optionalHistory.get());
+  }
+
+  /**
+   * Rebuild the message for a given trainee's notification.
+   *
+   * @param traineeId      The ID of the trainee.
+   * @param notificationId The ID of the notification.
+   * @return The rebuilt message, or empty if the notification was not found.
+   */
+  public Optional<String> rebuildMessage(String traineeId, String notificationId) {
+    Optional<History> optionalHistory = repository.findByIdAndRecipient_Id(
+        new ObjectId(notificationId), traineeId);
+
+    if (optionalHistory.isEmpty()) {
+      log.info("Notification {} was not found for trainee {}.", notificationId, traineeId);
+      return Optional.empty();
+    }
+
+    return rebuildMessage(optionalHistory.get());
+  }
+
+  /**
+   * Rebuild the message for a given notification history.
+   *
+   * @param history The historical notification.
+   * @return The rebuilt message, or empty if the notification was not found.
+   */
+  private Optional<String> rebuildMessage(History history) {
     MessageType messageType = history.recipient().type();
     TemplateInfo templateInfo = history.template();
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
+
+import java.time.Instant;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+
+/**
+ * A service for managing in-app notifications.
+ */
+@Slf4j
+@Service
+public class InAppService {
+
+  private final HistoryService historyService;
+
+  public InAppService(HistoryService historyService) {
+    this.historyService = historyService;
+  }
+
+  /**
+   * Create an in-app notification.
+   *
+   * @param traineeId        The trainee ID to associate the notification with.
+   * @param notificationType The type of notification.
+   * @param templateVersion  The version of the template to use.
+   */
+  public void createNotifications(String traineeId, NotificationType notificationType,
+      String templateVersion) {
+    log.info("Creating in-app {} notification for trainee {}.", notificationType, traineeId);
+    RecipientInfo recipient = new RecipientInfo(traineeId, IN_APP, null);
+    TemplateInfo template = new TemplateInfo(notificationType.getTemplateName(), templateVersion,
+        Map.of());
+
+    History history = new History(null, null, notificationType, recipient, template, Instant.now(),
+        UNREAD, "");
+    historyService.save(history);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ application:
     sender: ${EMAIL_SENDER}
   environment: ${ENVIRONMENT:local}
   queues:
+    account-confirmed: ${ACCOUNT_CONFIRMED_QUEUE}
     coj-received: ${COJ_RECEIVED_QUEUE}
     credential-revoked: ${CREDENTIAL_REVOKED_QUEUE}
     email-failure: ${EMAIL_FAILURE_QUEUE}
@@ -27,6 +28,8 @@ application:
       email: v1.0.0
     form-updated:
       email: v1.0.0
+    welcome:
+      in-app: v1.0.0
   timezone: Europe/London
 
 com:

--- a/src/main/resources/templates/in-app/welcome/v1.0.0.html
+++ b/src/main/resources/templates/in-app/welcome/v1.0.0.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Welcome Notification</title>
+  </head>
+  <body>
+    <h1>In-App Notification</h1>
+    <h2>Subject</h2>
+    <th:block th:fragment="subject">Welcome to TIS Self-Service</th:block>
+    <h2>Content</h2>
+    <th:block th:fragment="content">Welcome to TIS Self-Service
+
+Our goal is to improve your training experience by making TIS Self-Service a one-stop-shop for your training-related admin tasks.
+
+We are in the Private Beta phase of delivery so expect more features soon.</th:block>
+  </body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/TestJwtUtil.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/TestJwtUtil.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,36 +19,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.repository;
+package uk.nhs.tis.trainee.notifications;
 
-import java.util.List;
-import java.util.Optional;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
-import uk.nhs.tis.trainee.notifications.model.History;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
- * A repository of historical notifications.
+ * A utility for generating test JWT tokens.
  */
-@Repository
-public interface HistoryRepository extends
-    MongoRepository<History, ObjectId> {
+public class TestJwtUtil {
+
+  public static final String TIS_ID_ATTRIBUTE = "custom:tisId";
 
   /**
-   * Find all history for the given recipient ID.
+   * Generate a token with the given payload.
    *
-   * @param recipientId The ID of the recipient to get the history for.
-   * @return The found history, empty if none found.
+   * @param payload The payload to inject in to the token.
+   * @return The generated token.
    */
-  List<History> findAllByRecipient_IdOrderBySentAtDesc(String recipientId);
+  public static String generateToken(String payload) {
+    String encodedPayload = Base64.getUrlEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    return String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+  }
 
   /**
-   * Find a specific history record associated with the given recipient ID.
+   * Generate a token with the TIS ID attribute as the payload.
    *
-   * @param id          The ID of the history record.
-   * @param recipientId The ID of the recipient to get the history for.
-   * @return The found history, empty if none found.
+   * @param traineeTisId The TIS ID to inject in to the payload.
+   * @return The generated token.
    */
-  Optional<History> findByIdAndRecipient_Id(ObjectId id, String recipientId);
+  public static String generateTokenForTisId(String traineeTisId) {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, traineeTisId);
+    return generateToken(payload);
+  }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResourceTest.java
@@ -1,0 +1,204 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.api;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.CREDENTIAL_REVOKED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.nhs.tis.trainee.notifications.TestJwtUtil;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
+import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+
+@WebMvcTest(controllers = TraineeHistoryResource.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TraineeHistoryResourceTest {
+
+  private static final String TRAINEE_ID = "40";
+  private static final String TRAINEE_CONTACT_1 = "test1@tis.nhs.uk";
+  private static final String TRAINEE_CONTACT_2 = "test2@tis.nhs.uk";
+  private static final String TRAINEE_CONTACT_3 = "test3@tis.nhs.uk";
+  private static final String TIS_REFERENCE_ID = UUID.randomUUID().toString();
+
+  private static final String NOTIFICATION_ID = ObjectId.get().toString();
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private HistoryService service;
+
+  @Test
+  void shouldReturnBadRequestWhenGettingTraineeHistoryWithoutToken() throws Exception {
+    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenGettingTraineeHistoryWithInvalidToken() throws Exception {
+    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenGettingTraineeHistoryWithNoIdInToken() throws Exception {
+    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldReturnEmptyArrayWhenNoTraineeHistoryFound() throws Exception {
+    when(service.findAllForTrainee(TRAINEE_ID)).thenReturn(List.of());
+
+    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  void shouldReturnTraineeHistoryArrayWhenHistoryFound() throws Exception {
+    TisReferenceInfo tisReferenceProgramme
+        = new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceForm
+        = new TisReferenceInfo(TisReferenceType.FORMR_PARTA, TIS_REFERENCE_ID);
+    HistoryDto history1 = new HistoryDto("1", tisReferenceProgramme, EMAIL, COJ_CONFIRMATION,
+        TRAINEE_CONTACT_1, Instant.MIN, SENT, null);
+    HistoryDto history2 = new HistoryDto("2", tisReferenceProgramme, EMAIL, CREDENTIAL_REVOKED,
+        TRAINEE_CONTACT_2, Instant.EPOCH, FAILED, null);
+    HistoryDto history3 = new HistoryDto("3", tisReferenceForm, EMAIL, FORM_UPDATED,
+        TRAINEE_CONTACT_3, Instant.MAX, FAILED, "Additional detail");
+
+    when(service.findAllForTrainee(TRAINEE_ID)).thenReturn(List.of(history1, history2, history3));
+
+    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(3)))
+        .andExpect(jsonPath("$[0].id").value("1"))
+        .andExpect(jsonPath("$[0].tisReference.id").value(TIS_REFERENCE_ID))
+        .andExpect(jsonPath("$[0].tisReference.type")
+            .value(TisReferenceType.PROGRAMME_MEMBERSHIP.toString()))
+        .andExpect(jsonPath("$[0].type").value(EMAIL.toString()))
+        .andExpect(jsonPath("$[0].subject").value(COJ_CONFIRMATION.toString()))
+        .andExpect(jsonPath("$[0].contact").value(TRAINEE_CONTACT_1))
+        .andExpect(jsonPath("$[0].sentAt").value(Instant.MIN.toString()))
+        .andExpect(jsonPath("$[0].status").value(SENT.toString()))
+        .andExpect(jsonPath("$[0].statusDetail").doesNotExist())
+        .andExpect(jsonPath("$[1].id").value("2"))
+        .andExpect(jsonPath("$[1].tisReference.id").value(TIS_REFERENCE_ID))
+        .andExpect(jsonPath("$[1].tisReference.type")
+            .value(TisReferenceType.PROGRAMME_MEMBERSHIP.toString()))
+        .andExpect(jsonPath("$[1].type").value(EMAIL.toString()))
+        .andExpect(jsonPath("$[1].subject").value(CREDENTIAL_REVOKED.toString()))
+        .andExpect(jsonPath("$[1].contact").value(TRAINEE_CONTACT_2))
+        .andExpect(jsonPath("$[1].sentAt").value(Instant.EPOCH.toString()))
+        .andExpect(jsonPath("$[1].status").value(FAILED.toString()))
+        .andExpect(jsonPath("$[1].statusDetail").doesNotExist())
+        .andExpect(jsonPath("$[2].id").value("3"))
+        .andExpect(jsonPath("$[2].tisReference.id").value(TIS_REFERENCE_ID))
+        .andExpect(jsonPath("$[2].tisReference.type")
+            .value(TisReferenceType.FORMR_PARTA.toString()))
+        .andExpect(jsonPath("$[2].type").value(EMAIL.toString()))
+        .andExpect(jsonPath("$[2].subject").value(FORM_UPDATED.toString()))
+        .andExpect(jsonPath("$[2].contact").value(TRAINEE_CONTACT_3))
+        .andExpect(jsonPath("$[2].sentAt").value(Instant.MAX.toString()))
+        .andExpect(jsonPath("$[2].status").value(FAILED.toString()))
+        .andExpect(jsonPath("$[2].statusDetail").value("Additional detail"));
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenGettingNotificationMessageWithoutToken() throws Exception {
+    mockMvc.perform(get("/api/history/trainee/message/{notificationId}", NOTIFICATION_ID))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenGettingNotificationMessageWithInvalidToken() throws Exception {
+    mockMvc.perform(get("/api/history/trainee/message/{notificationId}", NOTIFICATION_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenGettingNotificationMessageWithNoIdInToken() throws Exception {
+    mockMvc.perform(get("/api/history/trainee/message/{notificationId}", NOTIFICATION_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenNoNotificationMessageFound() throws Exception {
+    when(service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID)).thenReturn(Optional.empty());
+
+    mockMvc.perform(get("/api/history/trainee/message/{notificationId}", NOTIFICATION_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void shouldReturnRebuiltMessageWhenNotificationFound() throws Exception {
+    String message = """
+        <html>
+          <p>Rebuilt message</p>
+        </html>""";
+    when(service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID)).thenReturn(Optional.of(message));
+
+    mockMvc.perform(get("/api/history/trainee/message/{notificationId}", NOTIFICATION_ID)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.TEXT_HTML))
+        .andExpect(content().string(message));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/util/AuthTokenUtilTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/util/AuthTokenUtilTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.api.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+class AuthTokenUtilTest {
+
+  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
+
+  @Test
+  void getTraineeTisIdShouldThrowExceptionWhenTokenPayloadNotMap() {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("[]".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    assertThrows(IOException.class, () -> AuthTokenUtil.getTraineeTisId(token));
+  }
+
+  @Test
+  void getTraineeTisIdShouldReturnNullWhenTisIdNotInToken() throws IOException {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("{}".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    String tisId = AuthTokenUtil.getTraineeTisId(token);
+
+    assertThat("Unexpected trainee TIS ID", tisId, nullValue());
+  }
+
+  @Test
+  void getTraineeTisIdShouldReturnIdWhenTisIdInToken() throws IOException {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, "40");
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    String tisId = AuthTokenUtil.getTraineeTisId(token);
+
+    assertThat("Unexpected trainee TIS ID", tisId, is("40"));
+  }
+
+  @Test
+  void getTraineeTisIdShouldHandleUrlCharactersInToken() {
+    // The payload is specifically crafted to include an underscore, the ID is 12.
+    String token = "aGVhZGVy.eyJjdXN0b206dGlzSWQiOiAiMTIiLCJuYW1lIjogIkpvaG4gRG_DqyJ9.c2lnbmF0dXJl";
+    String tisId = assertDoesNotThrow(() -> AuthTokenUtil.getTraineeTisId(token));
+    assertThat("Unexpected trainee TIS ID.", tisId, is("12"));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/UserAccountListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/UserAccountListenerTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.event;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.WELCOME;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.tis.trainee.notifications.dto.AccountConfirmedEvent;
+import uk.nhs.tis.trainee.notifications.service.InAppService;
+
+class UserAccountListenerTest {
+
+  private static final String VERSION = "v1.2.3";
+  private static final UUID USER_ID = UUID.randomUUID();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String EMAIL = "trainee@example.com";
+
+  private UserAccountListener listener;
+  private InAppService inAppService;
+
+  @BeforeEach
+  void setUp() {
+    inAppService = mock(InAppService.class);
+    listener = new UserAccountListener(inAppService, VERSION);
+  }
+
+  @Test
+  void shouldCreateWelcomeNotificationWhenAccountConfirmed() {
+    AccountConfirmedEvent event = new AccountConfirmedEvent(USER_ID, TRAINEE_ID, EMAIL);
+
+    listener.handleAccountConfirmation(event);
+
+    verify(inAppService).createNotifications(TRAINEE_ID, WELCOME, VERSION);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
 
@@ -216,6 +217,115 @@ class HistoryServiceIntegrationTest {
     Element emailHeader = body.children().get(0);
     assertThat("Unexpected element tag.", emailHeader.tagName(), is("h1"));
     assertThat("Unexpected email header.", emailHeader.text(), is("Email Message"));
+
+    Element subjectHeader = body.children().get(1);
+    assertThat("Unexpected element tag.", subjectHeader.tagName(), is("h2"));
+    assertThat("Unexpected subject header.", subjectHeader.text(), is("Subject"));
+
+    Element bodyHeader = body.children().get(2);
+    assertThat("Unexpected element tag.", bodyHeader.tagName(), is("h2"));
+    assertThat("Unexpected body header.", bodyHeader.text(), is("Content"));
+  }
+
+  @ParameterizedTest
+  @MethodSource(
+      "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getInAppTemplateTypeAndVersions")
+  void shouldRebuildInAppMessageWhenNotificationFound(NotificationType notificationType,
+      String version) {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(), version,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
+        recipientInfo, templateInfo, Instant.now(), SENT, null);
+    service.save(history);
+
+    Optional<String> message = service.rebuildMessage(NOTIFICATION_ID.toString());
+
+    assertThat("Unexpected message presence.", message.isPresent(), is(true));
+
+    Document content = Jsoup.parse(message.get());
+    Element body = content.body();
+
+    Element emailHeader = body.children().get(0);
+    assertThat("Unexpected element tag.", emailHeader.tagName(), is("h1"));
+    assertThat("Unexpected email header.", emailHeader.text(), is("In-App Notification"));
+
+    Element subjectHeader = body.children().get(1);
+    assertThat("Unexpected element tag.", subjectHeader.tagName(), is("h2"));
+    assertThat("Unexpected subject header.", subjectHeader.text(), is("Subject"));
+
+    Element bodyHeader = body.children().get(2);
+    assertThat("Unexpected element tag.", bodyHeader.tagName(), is("h2"));
+    assertThat("Unexpected body header.", bodyHeader.text(), is("Content"));
+  }
+
+  @Test
+  void shouldNotRebuildMessageForTraineeWhenNotificationNotFound() {
+    Optional<String> message = service.rebuildMessage(TRAINEE_ID, ObjectId.get().toString());
+
+    assertThat("Unexpected message.", message, is(Optional.empty()));
+  }
+
+  @ParameterizedTest
+  @MethodSource(
+      "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getEmailTemplateTypeAndVersions")
+  void shouldRebuildEmailMessageForTraineeWhenNotificationFound(NotificationType notificationType,
+      String version) {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(), version,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
+        recipientInfo, templateInfo, Instant.now(), SENT, null);
+    service.save(history);
+
+    Optional<String> message = service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID.toString());
+
+    assertThat("Unexpected message presence.", message.isPresent(), is(true));
+
+    Document content = Jsoup.parse(message.get());
+    Element body = content.body();
+
+    Element emailHeader = body.children().get(0);
+    assertThat("Unexpected element tag.", emailHeader.tagName(), is("h1"));
+    assertThat("Unexpected email header.", emailHeader.text(), is("Email Message"));
+
+    Element subjectHeader = body.children().get(1);
+    assertThat("Unexpected element tag.", subjectHeader.tagName(), is("h2"));
+    assertThat("Unexpected subject header.", subjectHeader.text(), is("Subject"));
+
+    Element bodyHeader = body.children().get(2);
+    assertThat("Unexpected element tag.", bodyHeader.tagName(), is("h2"));
+    assertThat("Unexpected body header.", bodyHeader.text(), is("Content"));
+  }
+
+  @ParameterizedTest
+  @MethodSource(
+      "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getInAppTemplateTypeAndVersions")
+  void shouldRebuildInAppMessageForTraineeWhenNotificationFound(NotificationType notificationType,
+      String version) {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(), version,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
+        recipientInfo, templateInfo, Instant.now(), SENT, null);
+    service.save(history);
+
+    Optional<String> message = service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID.toString());
+
+    assertThat("Unexpected message presence.", message.isPresent(), is(true));
+
+    Document content = Jsoup.parse(message.get());
+    Element body = content.body();
+
+    Element emailHeader = body.children().get(0);
+    assertThat("Unexpected element tag.", emailHeader.tagName(), is("h1"));
+    assertThat("Unexpected email header.", emailHeader.text(), is("In-App Notification"));
 
     Element subjectHeader = body.children().get(1);
     assertThat("Unexpected element tag.", subjectHeader.tagName(), is("h2"));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
@@ -1,0 +1,171 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+
+class InAppServiceTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String VERSION = "V1.2.3";
+
+  private InAppService service;
+  private HistoryService historyService;
+
+  @BeforeEach
+  void setUp() {
+    historyService = mock(HistoryService.class);
+    service = new InAppService(historyService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldCreateNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    verify(historyService).save(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldNotSetIdWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected history ID.", history.id(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldNotSetTisReferenceWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected TIS reference info.", history.tisReference(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldSetNotificationTypeWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected notification type.", history.type(), is(notificationType));
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldSetRecipientInfoWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    RecipientInfo recipient = history.recipient();
+    assertThat("Unexpected recipient ID.", recipient.id(), is(TRAINEE_ID));
+    assertThat("Unexpected recipient type.", recipient.type(), is(IN_APP));
+    assertThat("Unexpected recipient contact.", recipient.contact(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldSetTemplateInfoWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    TemplateInfo template = history.template();
+    assertThat("Unexpected template name.", template.name(),
+        is(notificationType.getTemplateName()));
+    assertThat("Unexpected template version.", template.version(), is(VERSION));
+    assertThat("Unexpected template variables.", template.variables(), is(Map.of()));
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldSetSentAtWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    long diffSeconds = Instant.now().getEpochSecond() - history.sentAt().getEpochSecond();
+    assertThat("Unexpected sentAt time difference.", diffSeconds, lessThan(10L));
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldSetStatusWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected status.", history.status(), is(UNREAD));
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldSetStatusDetailWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected status detail.", history.statusDetail(), is(""));
+  }
+}


### PR DESCRIPTION
# feat: welcome notification on account confirm
Create an in-app welcome notification when a user's account is
confirmed.

TIS21-5682
TIS21-5683

---

# feat: add trainee facing endpoints
Add trainee facing endpoints for retrieving the history list and
notification message. The trainee's ID will be taken from their
authorization token.

TIS21-5682
TIS21-5685