### PR TITLE
feat: allow trainees to update notification status

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.10.0"
+version = "1.11.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/HistoryDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/HistoryDto.java
@@ -35,12 +35,13 @@ import uk.nhs.tis.trainee.notifications.model.NotificationType;
  * @param type         The type of notification e.g. EMAIL
  * @param subject      The subject of the notification e.g. COJ_CONFIRMATION
  * @param contact      The contact details used to send the notification.
- * @param sentAt       The timestamp the notification was sent at.
+ * @param sentAt       The timestamp that the notification was sent at.
+ * @param readAt       The timestamp that the notification was read at.
  * @param status       The status of the notification history e.g. SENT or FAILED.
  * @param statusDetail Any additional detail about the status.
  */
 public record HistoryDto(String id, TisReferenceInfo tisReference, MessageType type,
-                         NotificationType subject, String contact, Instant sentAt,
+                         NotificationType subject, String contact, Instant sentAt, Instant readAt,
                          NotificationStatus status, String statusDetail) {
 
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
@@ -21,6 +21,9 @@
 
 package uk.nhs.tis.trainee.notifications.mapper;
 
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.READ;
+
+import java.time.Instant;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -55,11 +58,32 @@ public interface HistoryMapper {
   @Mapping(target = "subject", source = "type")
   @Mapping(target = "contact", source = "recipient.contact")
   @Mapping(target = "sentAt")
+  @Mapping(target = "readAt")
   @Mapping(target = "status")
   @Mapping(target = "statusDetail")
   HistoryDto toDto(History entity);
 
+  /**
+   * Update the status of the given history entity.
+   *
+   * @param entity The history to update the status of.
+   * @param status The new status.
+   * @param detail Any relevant status detail.
+   * @return The updated history entity.
+   */
   @Mapping(target = "status", source = "status")
   @Mapping(target = "statusDetail", source = "detail")
+  @Mapping(target = "readAt", expression = "java(calculateReadAt(entity, status))")
   History updateStatus(History entity, NotificationStatus status, String detail);
+
+  /**
+   * Calculate the readAt field based on the entity and status.
+   *
+   * @param entity The entity to calculate the readAt for.
+   * @param status The notification status.
+   * @return The readAt value to use for the entity.
+   */
+  default Instant calculateReadAt(History entity, NotificationStatus status) {
+    return entity.readAt() == null && status.equals(READ) ? Instant.now() : entity.readAt();
+  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
@@ -31,11 +31,14 @@ import org.springframework.data.mongodb.core.mapping.Field;
 /**
  * A representation of a historical notification.
  *
- * @param id        A unique identifier for the notification.
- * @param type      The type of notification sent.
- * @param recipient The recipient information the notification was sent to.
- * @param template  The template information used to generate the notification.
- * @param sentAt    The timestamp that the notification was sent at.
+ * @param id           A unique identifier for the notification.
+ * @param type         The type of notification sent.
+ * @param recipient    The recipient information the notification was sent to.
+ * @param template     The template information used to generate the notification.
+ * @param sentAt       The timestamp that the notification was sent at.
+ * @param readAt       The timestamp that the notification was read at.
+ * @param status       The status of the notification history e.g. SENT or FAILED.
+ * @param statusDetail Any additional detail about the status.
  */
 @Document(collection = "History")
 public record History(
@@ -46,6 +49,7 @@ public record History(
     RecipientInfo recipient,
     TemplateInfo template,
     Instant sentAt,
+    Instant readAt,
     NotificationStatus status,
     String statusDetail) {
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
@@ -25,5 +25,5 @@ package uk.nhs.tis.trainee.notifications.model;
  * An enumeration of possible notification statuses.
  */
 public enum NotificationStatus {
-  FAILED, SENT, UNREAD
+  ARCHIVED, FAILED, READ, SENT, UNREAD
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -113,7 +113,7 @@ public class EmailService {
    * @param templateVersion   The version of the template to be sent.
    * @param templateVariables The variables to pass to the template.
    * @param tisReferenceInfo  The TIS reference information (table and key).
-   * @param doNotSendJustLog Do not actually send the mail, simply log the action.
+   * @param doNotSendJustLog  Do not actually send the mail, simply log the action.
    * @throws MessagingException When the message could not be sent.
    */
   public void sendMessage(String traineeId, String recipient, NotificationType notificationType,
@@ -149,7 +149,7 @@ public class EmailService {
       TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
           templateVersion, templateVariables);
       History history = new History(notificationId, tisReferenceInfo, notificationType,
-          recipientInfo, templateInfo, Instant.now(), NotificationStatus.SENT, null);
+          recipientInfo, templateInfo, Instant.now(), null, NotificationStatus.SENT, null);
       historyService.save(history);
 
       log.info("Sent template {} to {}.", templateName, recipient);

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
@@ -61,7 +61,7 @@ public class InAppService {
         Map.of());
 
     History history = new History(null, null, notificationType, recipient, template, Instant.now(),
-        UNREAD, "");
+        null, UNREAD, "");
     historyService.save(history);
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
@@ -89,11 +89,11 @@ class HistoryResourceTest {
     TisReferenceInfo tisReferenceForm
         = new TisReferenceInfo(TisReferenceType.FORMR_PARTA, TIS_REFERENCE_ID);
     HistoryDto history1 = new HistoryDto("1", tisReferenceProgramme, EMAIL, COJ_CONFIRMATION,
-        TRAINEE_CONTACT_1, Instant.MIN, SENT, null);
+        TRAINEE_CONTACT_1, Instant.MIN, Instant.MAX, SENT, null);
     HistoryDto history2 = new HistoryDto("2", tisReferenceProgramme, EMAIL, CREDENTIAL_REVOKED,
-        TRAINEE_CONTACT_2, Instant.EPOCH, FAILED, null);
+        TRAINEE_CONTACT_2, Instant.EPOCH, Instant.EPOCH, FAILED, null);
     HistoryDto history3 = new HistoryDto("3", tisReferenceForm, EMAIL, FORM_UPDATED,
-        TRAINEE_CONTACT_3, Instant.MAX, FAILED, "Additional detail");
+        TRAINEE_CONTACT_3, Instant.MAX, Instant.MIN, FAILED, "Additional detail");
 
     when(service.findAllForTrainee(TRAINEE_ID)).thenReturn(List.of(history1, history2, history3));
 
@@ -110,6 +110,7 @@ class HistoryResourceTest {
         .andExpect(jsonPath("$[0].subject").value(COJ_CONFIRMATION.toString()))
         .andExpect(jsonPath("$[0].contact").value(TRAINEE_CONTACT_1))
         .andExpect(jsonPath("$[0].sentAt").value(Instant.MIN.toString()))
+        .andExpect(jsonPath("$[0].readAt").value(Instant.MAX.toString()))
         .andExpect(jsonPath("$[0].status").value(SENT.toString()))
         .andExpect(jsonPath("$[0].statusDetail").doesNotExist())
         .andExpect(jsonPath("$[1].id").value("2"))
@@ -120,6 +121,7 @@ class HistoryResourceTest {
         .andExpect(jsonPath("$[1].subject").value(CREDENTIAL_REVOKED.toString()))
         .andExpect(jsonPath("$[1].contact").value(TRAINEE_CONTACT_2))
         .andExpect(jsonPath("$[1].sentAt").value(Instant.EPOCH.toString()))
+        .andExpect(jsonPath("$[1].readAt").value(Instant.EPOCH.toString()))
         .andExpect(jsonPath("$[1].status").value(FAILED.toString()))
         .andExpect(jsonPath("$[1].statusDetail").doesNotExist())
         .andExpect(jsonPath("$[2].id").value("3"))
@@ -130,6 +132,7 @@ class HistoryResourceTest {
         .andExpect(jsonPath("$[2].subject").value(FORM_UPDATED.toString()))
         .andExpect(jsonPath("$[2].contact").value(TRAINEE_CONTACT_3))
         .andExpect(jsonPath("$[2].sentAt").value(Instant.MAX.toString()))
+        .andExpect(jsonPath("$[2].readAt").value(Instant.MIN.toString()))
         .andExpect(jsonPath("$[2].status").value(FAILED.toString()))
         .andExpect(jsonPath("$[2].statusDetail").value("Additional detail"));
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResourceTest.java
@@ -24,11 +24,14 @@ package uk.nhs.tis.trainee.notifications.api;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.READ;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.CREDENTIAL_REVOKED;
@@ -40,6 +43,9 @@ import java.util.Optional;
 import java.util.UUID;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -51,6 +57,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.tis.trainee.notifications.TestJwtUtil;
 import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
 import uk.nhs.tis.trainee.notifications.service.HistoryService;
 
@@ -75,20 +82,20 @@ class TraineeHistoryResourceTest {
 
   @Test
   void shouldReturnBadRequestWhenGettingTraineeHistoryWithoutToken() throws Exception {
-    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID))
+    mockMvc.perform(get("/api/history/trainee"))
         .andExpect(status().isBadRequest());
   }
 
   @Test
   void shouldReturnBadRequestWhenGettingTraineeHistoryWithInvalidToken() throws Exception {
-    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+    mockMvc.perform(get("/api/history/trainee")
             .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]")))
         .andExpect(status().isBadRequest());
   }
 
   @Test
   void shouldReturnBadRequestWhenGettingTraineeHistoryWithNoIdInToken() throws Exception {
-    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+    mockMvc.perform(get("/api/history/trainee")
             .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}")))
         .andExpect(status().isBadRequest());
   }
@@ -97,7 +104,7 @@ class TraineeHistoryResourceTest {
   void shouldReturnEmptyArrayWhenNoTraineeHistoryFound() throws Exception {
     when(service.findAllForTrainee(TRAINEE_ID)).thenReturn(List.of());
 
-    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+    mockMvc.perform(get("/api/history/trainee")
             .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -112,15 +119,15 @@ class TraineeHistoryResourceTest {
     TisReferenceInfo tisReferenceForm
         = new TisReferenceInfo(TisReferenceType.FORMR_PARTA, TIS_REFERENCE_ID);
     HistoryDto history1 = new HistoryDto("1", tisReferenceProgramme, EMAIL, COJ_CONFIRMATION,
-        TRAINEE_CONTACT_1, Instant.MIN, SENT, null);
+        TRAINEE_CONTACT_1, Instant.MIN, Instant.MAX, SENT, null);
     HistoryDto history2 = new HistoryDto("2", tisReferenceProgramme, EMAIL, CREDENTIAL_REVOKED,
-        TRAINEE_CONTACT_2, Instant.EPOCH, FAILED, null);
+        TRAINEE_CONTACT_2, Instant.EPOCH, Instant.EPOCH, FAILED, null);
     HistoryDto history3 = new HistoryDto("3", tisReferenceForm, EMAIL, FORM_UPDATED,
-        TRAINEE_CONTACT_3, Instant.MAX, FAILED, "Additional detail");
+        TRAINEE_CONTACT_3, Instant.MAX, Instant.MIN, FAILED, "Additional detail");
 
     when(service.findAllForTrainee(TRAINEE_ID)).thenReturn(List.of(history1, history2, history3));
 
-    mockMvc.perform(get("/api/history/trainee", TRAINEE_ID)
+    mockMvc.perform(get("/api/history/trainee")
             .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -134,6 +141,7 @@ class TraineeHistoryResourceTest {
         .andExpect(jsonPath("$[0].subject").value(COJ_CONFIRMATION.toString()))
         .andExpect(jsonPath("$[0].contact").value(TRAINEE_CONTACT_1))
         .andExpect(jsonPath("$[0].sentAt").value(Instant.MIN.toString()))
+        .andExpect(jsonPath("$[0].readAt").value(Instant.MAX.toString()))
         .andExpect(jsonPath("$[0].status").value(SENT.toString()))
         .andExpect(jsonPath("$[0].statusDetail").doesNotExist())
         .andExpect(jsonPath("$[1].id").value("2"))
@@ -144,6 +152,7 @@ class TraineeHistoryResourceTest {
         .andExpect(jsonPath("$[1].subject").value(CREDENTIAL_REVOKED.toString()))
         .andExpect(jsonPath("$[1].contact").value(TRAINEE_CONTACT_2))
         .andExpect(jsonPath("$[1].sentAt").value(Instant.EPOCH.toString()))
+        .andExpect(jsonPath("$[1].readAt").value(Instant.EPOCH.toString()))
         .andExpect(jsonPath("$[1].status").value(FAILED.toString()))
         .andExpect(jsonPath("$[1].statusDetail").doesNotExist())
         .andExpect(jsonPath("$[2].id").value("3"))
@@ -154,6 +163,7 @@ class TraineeHistoryResourceTest {
         .andExpect(jsonPath("$[2].subject").value(FORM_UPDATED.toString()))
         .andExpect(jsonPath("$[2].contact").value(TRAINEE_CONTACT_3))
         .andExpect(jsonPath("$[2].sentAt").value(Instant.MAX.toString()))
+        .andExpect(jsonPath("$[2].readAt").value(Instant.MIN.toString()))
         .andExpect(jsonPath("$[2].status").value(FAILED.toString()))
         .andExpect(jsonPath("$[2].statusDetail").value("Additional detail"));
   }
@@ -200,5 +210,74 @@ class TraineeHistoryResourceTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.TEXT_HTML))
         .andExpect(content().string(message));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"archive", "mark-read", "mark-unread"})
+  void shouldReturnBadRequestWhenUpdatingStatusWithoutToken(String path) throws Exception {
+    mockMvc.perform(
+            put("/api/history/trainee/notification/{notificationId}/{path}", NOTIFICATION_ID, path))
+        .andExpect(status().isBadRequest());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"archive", "mark-read", "mark-unread"})
+  void shouldReturnBadRequestWhenUpdatingStatusWithInvalidToken(String path) throws Exception {
+    mockMvc.perform(
+            put("/api/history/trainee/notification/{notificationId}/{path}", NOTIFICATION_ID, path)
+                .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"archive", "mark-read", "mark-unread"})
+  void shouldReturnBadRequestWhenUpdatingStatusWithNoIdInToken(String path) throws Exception {
+    mockMvc.perform(
+            put("/api/history/trainee/notification/{notificationId}/{path}", NOTIFICATION_ID, path)
+                .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}")))
+        .andExpect(status().isBadRequest());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"archive", "mark-read", "mark-unread"})
+  void shouldReturnNotFoundWhenUpdatingStatusAndNotificationNotFound(String path) throws Exception {
+    when(service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, READ, "")).thenReturn(Optional.empty());
+
+    mockMvc.perform(
+            put("/api/history/trainee/notification/{notificationId}/{path}", NOTIFICATION_ID, path)
+                .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
+        .andExpect(status().isNotFound());
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      archive     | ARCHIVED
+      mark-read   | READ
+      mark-unread | UNREAD
+      """)
+  void shouldReturnUpdatedStatusWhenNotificationFound(String path, NotificationStatus status)
+      throws Exception {
+    TisReferenceInfo tisReference
+        = new TisReferenceInfo(TisReferenceType.FORMR_PARTA, TIS_REFERENCE_ID);
+    HistoryDto history = new HistoryDto("1", tisReference, IN_APP, FORM_UPDATED,
+        TRAINEE_CONTACT_1, Instant.MIN, Instant.MAX, status, "Additional detail");
+    when(service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, status, "")).thenReturn(
+        Optional.of(history));
+
+    mockMvc.perform(
+            put("/api/history/trainee/notification/{notificationId}/{path}", NOTIFICATION_ID, path)
+                .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(TRAINEE_ID)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value("1"))
+        .andExpect(jsonPath("$.tisReference.id").value(TIS_REFERENCE_ID))
+        .andExpect(jsonPath("$.tisReference.type").value(TisReferenceType.FORMR_PARTA.toString()))
+        .andExpect(jsonPath("$.type").value(IN_APP.toString()))
+        .andExpect(jsonPath("$.subject").value(FORM_UPDATED.toString()))
+        .andExpect(jsonPath("$.contact").value(TRAINEE_CONTACT_1))
+        .andExpect(jsonPath("$.sentAt").value(Instant.MIN.toString()))
+        .andExpect(jsonPath("$.readAt").value(Instant.MAX.toString()))
+        .andExpect(jsonPath("$.status").value(status.toString()))
+        .andExpect(jsonPath("$.statusDetail").value("Additional detail"));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapperTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
+
+class HistoryMapperTest {
+
+  private HistoryMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new HistoryMapperImpl();
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationStatus.class)
+  void shouldUseExistingReadAtWhenPopulated(NotificationStatus status) {
+    Instant existingReadAt = Instant.now().minus(Duration.ofDays(1));
+    History entity = new History(null, null, null, null, null, null, existingReadAt, null, null);
+
+    Instant readAt = mapper.calculateReadAt(entity, status);
+    assertThat("Unexpected readAt timestamp.", readAt, is(existingReadAt));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = "READ")
+  void shouldNotGenerateReadAtWhenStatusNotReadAndNotPopulated(NotificationStatus status) {
+    History entity = new History(null, null, null, null, null, null, null, null, null);
+
+    Instant readAt = mapper.calculateReadAt(entity, status);
+    assertThat("Unexpected readAt timestamp.", readAt, nullValue());
+  }
+
+  @Test
+  void shouldGenerateReadAtWhenStatusReadAndNotPopulated() {
+    History entity = new History(null, null, null, null, null, null, null, null, null);
+
+    Instant readAt = mapper.calculateReadAt(entity, NotificationStatus.READ);
+    assertThat("Unexpected readAt timestamp.", readAt, notNullValue());
+
+    long diffSeconds = Instant.now().getEpochSecond() - readAt.getEpochSecond();
+    assertThat("Unexpected readAt timestamp drift.", diffSeconds, lessThan(10L));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
@@ -30,6 +30,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
 
+import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,8 +61,8 @@ class PopulateNotificationHistoryStatusIntegrationTest {
 
   @Test
   void shouldMigrateHistoryWithEmptyStatus() {
-    History history = new History(null, null, COJ_CONFIRMATION, null, null, Instant.now(), null,
-        null);
+    History history = new History(null, null, COJ_CONFIRMATION, null, null, Instant.now(),
+        Instant.now().plus(Duration.ofDays(1)), null, null);
     history = mongoTemplate.save(history);
 
     migrator.migrate();
@@ -74,8 +75,8 @@ class PopulateNotificationHistoryStatusIntegrationTest {
 
   @Test
   void shouldNotMigrateHistoryWithPopulatedStatus() {
-    History history = new History(null, null, COJ_CONFIRMATION, null, null, Instant.now(), FAILED,
-        null);
+    History history = new History(null, null, COJ_CONFIRMATION, null, null, Instant.now(),
+        Instant.now().plus(Duration.ofDays(1)), FAILED, null);
     history = mongoTemplate.save(history);
 
     migrator.migrate();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -77,6 +77,8 @@ class HistoryServiceIntegrationTest {
   private static final String TIS_REFERENCE_ID = UUID.randomUUID().toString();
 
   private static final Instant SENT_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+  private static final Instant READ_AT = Instant.now().plus(Duration.ofDays(1))
+      .truncatedTo(ChronoUnit.MILLIS);
 
   @Autowired
   private HistoryService service;
@@ -89,12 +91,13 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, SENT, null);
+        templateInfo, SENT_AT, READ_AT, SENT, null);
     History savedHistory = service.save(history);
 
     assertThat("Unexpected ID.", savedHistory.id(), instanceOf(ObjectId.class));
     assertThat("Unexpected type.", savedHistory.type(), is(FORM_UPDATED));
     assertThat("Unexpected sent at.", savedHistory.sentAt(), is(SENT_AT));
+    assertThat("Unexpected read at.", savedHistory.readAt(), is(READ_AT));
 
     RecipientInfo savedRecipientInfo = savedHistory.recipient();
     assertThat("Unexpected recipient id.", savedRecipientInfo.id(), is(TRAINEE_ID));
@@ -122,7 +125,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, SENT, null);
+        templateInfo, SENT_AT, READ_AT, SENT, null);
     service.save(history);
 
     List<HistoryDto> foundHistory = service.findAllForTrainee("notFound");
@@ -138,7 +141,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, SENT, null);
+        templateInfo, SENT_AT, READ_AT, SENT, null);
     History savedHistory = service.save(history);
 
     List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
@@ -151,6 +154,7 @@ class HistoryServiceIntegrationTest {
     assertThat("Unexpected history subject.", historyDto.subject(), is(FORM_UPDATED));
     assertThat("Unexpected history contact.", historyDto.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected history sent at.", historyDto.sentAt(), is(SENT_AT));
+    assertThat("Unexpected history read at.", historyDto.readAt(), is(READ_AT));
   }
 
   @Test
@@ -162,15 +166,15 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        now, SENT, null));
+        now, now, SENT, null));
 
     Instant before = SENT_AT.minus(Duration.ofDays(1));
-    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        before, SENT, null));
-
     Instant after = SENT_AT.plus(Duration.ofDays(1));
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        after, SENT, null));
+        before, after, SENT, null));
+
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
+        after, before, SENT, null));
 
     List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
 
@@ -204,7 +208,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), SENT, null);
+        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(NOTIFICATION_ID.toString());
@@ -238,7 +242,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), SENT, null);
+        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(NOTIFICATION_ID.toString());
@@ -279,7 +283,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), SENT, null);
+        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID.toString());
@@ -313,7 +317,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), SENT, null);
+        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID.toString());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
@@ -147,6 +147,18 @@ class InAppServiceTest {
 
   @ParameterizedTest
   @EnumSource(NotificationType.class)
+  void shouldNotSetReadAtWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, notificationType, VERSION);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected readAt timestamp.", history.readAt(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
   void shouldSetStatusWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, notificationType, VERSION);
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -235,7 +235,7 @@ class ProgrammeMembershipServiceTest {
         MessageType.EMAIL,
         NotificationType.PROGRAMME_UPDATED_WEEK_8,
         "email address",
-        Instant.MIN, SENT, null));
+        Instant.MIN, Instant.MAX, SENT, null));
 
     when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
 
@@ -287,7 +287,7 @@ class ProgrammeMembershipServiceTest {
         MessageType.EMAIL,
         notificationType,
         "email address",
-        Instant.MIN, SENT, null));
+        Instant.MIN, Instant.MAX, SENT, null));
 
     when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
 
@@ -313,7 +313,7 @@ class ProgrammeMembershipServiceTest {
         MessageType.EMAIL,
         NotificationType.PROGRAMME_UPDATED_WEEK_8, //to avoid masking the test condition
         "email address",
-        Instant.MIN, SENT, null));
+        Instant.MIN, Instant.MAX, SENT, null));
 
     when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
 
@@ -339,7 +339,7 @@ class ProgrammeMembershipServiceTest {
         MessageType.EMAIL,
         NotificationType.PROGRAMME_UPDATED_WEEK_8,
         "email address",
-        Instant.MIN, SENT, null));
+        Instant.MIN, Instant.MAX, SENT, null));
 
     when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
 
@@ -429,7 +429,7 @@ class ProgrammeMembershipServiceTest {
         MessageType.EMAIL,
         NotificationType.PROGRAMME_UPDATED_WEEK_0,
         "email address",
-        Instant.MIN, SENT, null));
+        Instant.MIN, Instant.MAX, SENT, null));
 
     when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
 
@@ -455,7 +455,7 @@ class ProgrammeMembershipServiceTest {
         MessageType.EMAIL,
         NotificationType.PROGRAMME_UPDATED_WEEK_0,
         "email address",
-        Instant.MIN, SENT, null));
+        Instant.MIN, Instant.MAX, SENT, null));
 
     when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
 
@@ -481,7 +481,7 @@ class ProgrammeMembershipServiceTest {
         MessageType.EMAIL,
         NotificationType.PROGRAMME_UPDATED_WEEK_8,
         "email address",
-        Instant.MIN, SENT, null));
+        Instant.MIN, Instant.MAX, SENT, null));
 
     when(historyService.findAllForTrainee(PERSON_ID)).thenReturn(sentNotifications);
 


### PR DESCRIPTION
Trainees should be able to update their notification status to mark in-app notifications as read, unread or archived.
This should be implemented as individual endpoints so that they are restricted on what the status can be set to and removing the possibility of modifying any other fields.

When the notification is marked as read, a new `readAt` field should record the timestamp. Other status changes will not modify that field further and will not be separately recorded. Only the initial reading of the notification matters for data purposes.

TIS21-5682
TIS21-5686