### PR TITLE
fix: return plain text trainee in-app messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.11.0"
+version = "1.11.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResource.java
@@ -126,7 +126,7 @@ public class TraineeHistoryResource {
     }
 
     log.info("Archiving notification {}.", notificationId);
-    Optional<HistoryDto> history = service.updateStatus(traineeId, notificationId, ARCHIVED, "");
+    Optional<HistoryDto> history = service.updateStatus(traineeId, notificationId, ARCHIVED);
     return ResponseEntity.of(history);
   }
 
@@ -148,7 +148,7 @@ public class TraineeHistoryResource {
     }
 
     log.info("Marking notification {} as read.", notificationId);
-    Optional<HistoryDto> history = service.updateStatus(traineeId, notificationId, READ, "");
+    Optional<HistoryDto> history = service.updateStatus(traineeId, notificationId, READ);
     return ResponseEntity.of(history);
   }
 
@@ -170,7 +170,7 @@ public class TraineeHistoryResource {
     }
 
     log.info("Marking notification {} as unread.", notificationId);
-    Optional<HistoryDto> history = service.updateStatus(traineeId, notificationId, UNREAD, "");
+    Optional<HistoryDto> history = service.updateStatus(traineeId, notificationId, UNREAD);
     return ResponseEntity.of(history);
   }
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/TraineeHistoryResourceTest.java
@@ -241,7 +241,7 @@ class TraineeHistoryResourceTest {
   @ParameterizedTest
   @ValueSource(strings = {"archive", "mark-read", "mark-unread"})
   void shouldReturnNotFoundWhenUpdatingStatusAndNotificationNotFound(String path) throws Exception {
-    when(service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, READ, "")).thenReturn(Optional.empty());
+    when(service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, READ)).thenReturn(Optional.empty());
 
     mockMvc.perform(
             put("/api/history/trainee/notification/{notificationId}/{path}", NOTIFICATION_ID, path)
@@ -261,7 +261,7 @@ class TraineeHistoryResourceTest {
         = new TisReferenceInfo(TisReferenceType.FORMR_PARTA, TIS_REFERENCE_ID);
     HistoryDto history = new HistoryDto("1", tisReference, IN_APP, FORM_UPDATED,
         TRAINEE_CONTACT_1, Instant.MIN, Instant.MAX, status, "Additional detail");
-    when(service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, status, "")).thenReturn(
+    when(service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, status)).thenReturn(
         Optional.of(history));
 
     mockMvc.perform(

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -41,6 +41,8 @@ import org.bson.types.ObjectId;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -327,16 +329,9 @@ class HistoryServiceIntegrationTest {
     Document content = Jsoup.parse(message.get());
     Element body = content.body();
 
-    Element emailHeader = body.children().get(0);
-    assertThat("Unexpected element tag.", emailHeader.tagName(), is("h1"));
-    assertThat("Unexpected email header.", emailHeader.text(), is("In-App Notification"));
+    assertThat("Unexpected child count.", body.childNodeSize(), is(1));
 
-    Element subjectHeader = body.children().get(1);
-    assertThat("Unexpected element tag.", subjectHeader.tagName(), is("h2"));
-    assertThat("Unexpected subject header.", subjectHeader.text(), is("Subject"));
-
-    Element bodyHeader = body.children().get(2);
-    assertThat("Unexpected element tag.", bodyHeader.tagName(), is("h2"));
-    assertThat("Unexpected body header.", bodyHeader.text(), is("Content"));
+    Node contentNode = body.childNode(0);
+    assertThat("Unexpected node type.", contentNode, instanceOf(TextNode.class));
   }
 }


### PR DESCRIPTION
In-App messages viewed by the trainee should be plain text rather than the complete HTML as seen by admins.
Update the HistoryService to set the `content` selector for trainee in-app messages.

Remove the redundant `details` parameter from the trainee update status functions.

TIS21-5682
TIS21-5685