### PR TITLE
fix: null status details instead of empty string

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.11.1"
+version = "1.11.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -122,7 +122,7 @@ public class HistoryService {
       return Optional.empty();
     }
 
-    return updateStatus(optionalHistory.get(), status, "");
+    return updateStatus(optionalHistory.get(), status, null);
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
@@ -61,7 +61,7 @@ public class InAppService {
         Map.of());
 
     History history = new History(null, null, notificationType, recipient, template, Instant.now(),
-        null, UNREAD, "");
+        null, UNREAD, null);
     historyService.save(history);
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -284,7 +284,7 @@ class HistoryServiceTest {
     HistoryDto history = updatedHistory.get();
 
     assertThat("Unexpected status.", history.status(), is(status));
-    assertThat("Unexpected status detail.", history.statusDetail(), is(""));
+    assertThat("Unexpected status detail.", history.statusDetail(), nullValue());
 
     // Check other fields are unchanged.
     assertThat("Unexpected ID.", history.id(), is(notificationId.toString()));
@@ -336,7 +336,7 @@ class HistoryServiceTest {
     HistoryDto history = updatedHistory.get();
 
     assertThat("Unexpected status.", history.status(), is(status));
-    assertThat("Unexpected status detail.", history.statusDetail(), is(""));
+    assertThat("Unexpected status detail.", history.statusDetail(), nullValue());
 
     // Check other fields are unchanged.
     assertThat("Unexpected ID.", history.id(), is(notificationId.toString()));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
@@ -178,6 +178,6 @@ class InAppServiceTest {
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
-    assertThat("Unexpected status detail.", history.statusDetail(), is(""));
+    assertThat("Unexpected status detail.", history.statusDetail(), nullValue());
   }
 }


### PR DESCRIPTION
The status detail is left blank is several scenarios, however it is currently set to an empty string but should be set to null.

TIS21-5682