### PR TITLE
fix: ignore past placements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.12.1"
+version = "1.12.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -72,8 +72,7 @@ public class PlacementService {
       = List.of("In post", "In post - Acting up", "In Post - Extension");
   public static final String API_GET_OWNER_CONTACT =
       "/api/local-office-contact-by-lo-name/{localOfficeName}";
-  protected static final String DEFAULT_NO_CONTACT_MESSAGE = "your local office";
-  protected static final String INVALID_CONTACT_HREF = "NOT_HREF";
+  protected static final String DEFAULT_NO_CONTACT_MESSAGE = "your local deanery office";
 
   private final HistoryService historyService;
   private final NotificationService notificationService;
@@ -163,7 +162,7 @@ public class PlacementService {
 
       LocalDate startDate = placement.getStartDate();
 
-      boolean shouldSchedule = shouldScheduleNotification(notificationsAlreadySent);
+      boolean shouldSchedule = shouldScheduleNotification(notificationsAlreadySent, startDate);
 
       if (shouldSchedule) {
         log.info("Scheduling notification {} for {}.",
@@ -231,8 +230,11 @@ public class PlacementService {
    * @return true if it should be scheduled, false otherwise.
    */
   private boolean shouldScheduleNotification(
-      Map<NotificationType, Instant> notificationsAlreadySent) {
+      Map<NotificationType, Instant> notificationsAlreadySent, LocalDate startDate) {
 
+    if (startDate == null || startDate.isBefore(LocalDate.now())) {
+      return false;
+    }
     //do not resend any notification
     return (!notificationsAlreadySent.containsKey(PLACEMENT_UPDATED_WEEK_12));
   }

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
@@ -6,7 +6,7 @@
 <body>
 <h1>Email Message</h1>
 <h2>Subject</h2>
-<th:block th:fragment="subject">Placement confirmation: 12 weeks to go</th:block>
+<th:block th:fragment="subject">Placement confirmation</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -164,6 +164,31 @@ class PlacementServiceTest {
   }
 
   @Test
+  void shouldNotAddNotificationsIfNoStartDate() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+
+    service.addNotifications(placement);
+
+    verify(notificationService, never()).scheduleNotification(any(), any(), any());
+  }
+
+  @Test
+  void shouldNotAddNotificationsIfPastStartDate() throws SchedulerException {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+    placement.setOwner(OWNER);
+    placement.setPlacementType(IN_POST);
+    placement.setStartDate(LocalDate.MIN);
+
+    service.addNotifications(placement);
+
+    verify(notificationService, never()).scheduleNotification(any(), any(), any());
+  }
+
+  @Test
   void shouldAddNotificationsIfNotExcluded() throws SchedulerException {
     Placement placement = new Placement();
     placement.setTisId(TIS_ID);


### PR DESCRIPTION
For some reason, there are a lot of past placements being edited, which are triggering issues with AWS too-many-requests since they are all scheduled very close together.

Ignore these, and a few other minor tweaks

NO-TICKET