### PR TITLE
fix: default empty-string for undefined subjectText

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.12.3"
+version = "1.12.4"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
@@ -103,11 +103,11 @@ public interface HistoryMapper {
    */
   default String getSubjectText(NotificationType notificationType, MessageType messageType) {
     if (messageType != MessageType.IN_APP) {
-      return null; //these are ignored
+      return ""; //these are ignored
     }
     return switch (notificationType) {
       case WELCOME -> WELCOME_SUBJECT_TEXT;
-      default -> null;
+      default -> "";
     };
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapperTest.java
@@ -94,24 +94,24 @@ class HistoryMapperTest {
   }
 
   @Test
-  void shouldHaveNoSubjectTextWhenNotInAppNotification() {
+  void shouldHaveBlankSubjectTextWhenNotInAppNotification() {
     ObjectId id = new ObjectId();
     RecipientInfo recipient = new RecipientInfo(null, MessageType.EMAIL, null);
     History entity = new History(id, null, NotificationType.WELCOME, recipient, null,
         null, null, null, null);
 
     HistoryDto dto = mapper.toDto(entity);
-    assertThat("Unexpected subject text.", dto.subjectText(), is(nullValue()));
+    assertThat("Unexpected subject text.", dto.subjectText(), is(""));
   }
 
   @Test
-  void shouldHaveNoSubjectTextWhenUnmappedInAppNotification() {
+  void shouldHaveBlankSubjectTextWhenUnmappedInAppNotification() {
     ObjectId id = new ObjectId();
     RecipientInfo recipient = new RecipientInfo(null, MessageType.IN_APP, null);
     History entity = new History(id, null, NotificationType.COJ_CONFIRMATION, recipient, null,
         null, null, null, null);
 
     HistoryDto dto = mapper.toDto(entity);
-    assertThat("Unexpected subject text.", dto.subjectText(), is(nullValue()));
+    assertThat("Unexpected subject text.", dto.subjectText(), is(""));
   }
 }


### PR DESCRIPTION
The front-end _should_ only use the IN_APP notifications, for which the `subjectText` will always be defined, but there is a discussion needed when the FE specialists are back in the office to clarify how they would like the API to support this usage 😁.

At the moment the FE is pulling the whole notification history and then falling-over as the `subjectText` for other types of notification is (currently) null.

To be honest, the way we provide subject text currently is an acknowledged hack - so even though null is probably more technically correct, being picky about the difference is probably not so important right now. The whole area of functionality will probably be refactored soon to better integrate it with the thymeleaf template content.

NO-TICKET