### PR TITLE
chore: upgrade sentry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,8 +65,8 @@ dependencies {
   implementation("io.mongock:mongodb-springdata-v4-driver:${mongockVersion}")
 
   // Sentry reporting
-  val sentryVersion = "7.4.0"
-  implementation("io.sentry:sentry-spring-boot-starter:${sentryVersion}")
+  val sentryVersion = "7.6.0"
+  implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
   implementation("io.sentry:sentry-logback:${sentryVersion}")
 
   testImplementation("org.springframework.cloud:spring-cloud-starter-bootstrap")


### PR DESCRIPTION
Sentry should use a different dependency for Spring Boot 3 compatibility.

TIS21-SHED