### PR TITLE
fix: eportfolio subject text population

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.13.0"
+version = "1.13.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
@@ -30,17 +30,13 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
 import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.model.History;
-import uk.nhs.tis.trainee.notifications.model.MessageType;
 import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
-import uk.nhs.tis.trainee.notifications.model.NotificationType;
 
 /**
  * A mapper to convert between notification history data types.
  */
 @Mapper(componentModel = ComponentModel.SPRING)
 public interface HistoryMapper {
-
-  String WELCOME_SUBJECT_TEXT = "Welcome to TIS Self-Service";
 
   /**
    * Convert history entities to history DTOs.
@@ -60,14 +56,32 @@ public interface HistoryMapper {
   @Mapping(target = "type", source = "recipient.type")
   @Mapping(target = "tisReference")
   @Mapping(target = "subject", source = "type")
-  @Mapping(target = "subjectText",
-      expression = "java(getSubjectText(entity.type(), entity.recipient().type()))")
+  @Mapping(target = "subjectText", ignore = true)
   @Mapping(target = "contact", source = "recipient.contact")
   @Mapping(target = "sentAt")
   @Mapping(target = "readAt")
   @Mapping(target = "status")
   @Mapping(target = "statusDetail")
   HistoryDto toDto(History entity);
+
+  /**
+   * Convert a history entity to a history DTO.
+   *
+   * @param entity      The history entity to convert.
+   * @param subjectText A pre-generated subject text.
+   * @return The converted history DTOs.
+   */
+  @Mapping(target = "id", expression = "java(entity.id().toString())")
+  @Mapping(target = "type", source = "entity.recipient.type")
+  @Mapping(target = "tisReference", source = "entity.tisReference")
+  @Mapping(target = "subject", source = "entity.type")
+  @Mapping(target = "subjectText", source = "subjectText")
+  @Mapping(target = "contact", source = "entity.recipient.contact")
+  @Mapping(target = "sentAt", source = "entity.sentAt")
+  @Mapping(target = "readAt", source = "entity.readAt")
+  @Mapping(target = "status", source = "entity.status")
+  @Mapping(target = "statusDetail", source = "entity.statusDetail")
+  HistoryDto toDto(History entity, String subjectText);
 
   /**
    * Update the status of the given history entity.
@@ -91,23 +105,5 @@ public interface HistoryMapper {
    */
   default Instant calculateReadAt(History entity, NotificationStatus status) {
     return entity.readAt() == null && status.equals(READ) ? Instant.now() : entity.readAt();
-  }
-
-  /**
-   * Get the subject text from the NotificationType for in-app messages. Note this is hardcoded, not
-   * extracted from the applicable template subject fragment.
-   *
-   * @param notificationType The notification type.
-   * @param messageType      The message type.
-   * @return The corresponding subject text.
-   */
-  default String getSubjectText(NotificationType notificationType, MessageType messageType) {
-    if (messageType != MessageType.IN_APP) {
-      return ""; //these are ignored
-    }
-    return switch (notificationType) {
-      case WELCOME -> WELCOME_SUBJECT_TEXT;
-      default -> "";
-    };
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -160,7 +160,22 @@ public class HistoryService {
    */
   public List<HistoryDto> findAllForTrainee(String traineeId) {
     List<History> history = repository.findAllByRecipient_IdOrderBySentAtDesc(traineeId);
-    return mapper.toDtos(history);
+
+    return history.stream()
+        .map(h -> {
+          String subject = null;
+
+          if (h.recipient().type() == IN_APP) {
+            subject = rebuildMessage(h, Set.of("subject")).orElse("");
+          }
+
+          if (subject == null || subject.isEmpty()) {
+            return mapper.toDto(h);
+          } else {
+            return mapper.toDto(h, subject);
+          }
+        })
+        .toList();
   }
 
   /**
@@ -204,7 +219,7 @@ public class HistoryService {
   /**
    * Rebuild the message for a given notification history.
    *
-   * @param history The historical notification.
+   * @param history   The historical notification.
    * @param selectors The template selectors to use.
    * @return The rebuilt message, or empty if the notification was not found.
    */

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapperTest.java
@@ -26,22 +26,16 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
-import static uk.nhs.tis.trainee.notifications.mapper.HistoryMapper.WELCOME_SUBJECT_TEXT;
 
 import java.time.Duration;
 import java.time.Instant;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.model.History;
-import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
-import uk.nhs.tis.trainee.notifications.model.MessageType;
 import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
-import uk.nhs.tis.trainee.notifications.model.NotificationType;
 
 class HistoryMapperTest {
 
@@ -80,38 +74,5 @@ class HistoryMapperTest {
 
     long diffSeconds = Instant.now().getEpochSecond() - readAt.getEpochSecond();
     assertThat("Unexpected readAt timestamp drift.", diffSeconds, lessThan(10L));
-  }
-
-  @Test
-  void shouldGenerateSubjectTextWhenWelcomeInAppNotification() {
-    ObjectId id = new ObjectId();
-    RecipientInfo recipient = new RecipientInfo(null, MessageType.IN_APP, null);
-    History entity = new History(id, null, NotificationType.WELCOME, recipient, null,
-        null, null, null, null);
-
-    HistoryDto dto = mapper.toDto(entity);
-    assertThat("Unexpected subject text.", dto.subjectText(), is(WELCOME_SUBJECT_TEXT));
-  }
-
-  @Test
-  void shouldHaveBlankSubjectTextWhenNotInAppNotification() {
-    ObjectId id = new ObjectId();
-    RecipientInfo recipient = new RecipientInfo(null, MessageType.EMAIL, null);
-    History entity = new History(id, null, NotificationType.WELCOME, recipient, null,
-        null, null, null, null);
-
-    HistoryDto dto = mapper.toDto(entity);
-    assertThat("Unexpected subject text.", dto.subjectText(), is(""));
-  }
-
-  @Test
-  void shouldHaveBlankSubjectTextWhenUnmappedInAppNotification() {
-    ObjectId id = new ObjectId();
-    RecipientInfo recipient = new RecipientInfo(null, MessageType.IN_APP, null);
-    History entity = new History(id, null, NotificationType.COJ_CONFIRMATION, recipient, null,
-        null, null, null, null);
-
-    HistoryDto dto = mapper.toDto(entity);
-    assertThat("Unexpected subject text.", dto.subjectText(), is(""));
   }
 }


### PR DESCRIPTION
The subject text is not populated on the eportfolio in-app notification DTO because the behaviour is hardcoded. Refactor to retrieve the subject line from the associated template's subject.

TIS21-5615