### PR TITLE
feat: create indemnity insurance notification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.14.0"
+version = "1.15.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/Curriculum.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/Curriculum.java
@@ -32,7 +32,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Curriculum(
     String curriculumSubType,
-    String curriculumSpecialty
+    String curriculumSpecialty,
+    boolean curriculumSpecialtyBlockIndemnity
 ) {
 
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
@@ -37,6 +37,7 @@ public enum NotificationType {
   CREDENTIAL_REVOKED("credential-revoked"),
   E_PORTFOLIO("e-portfolio"),
   FORM_UPDATED("form-updated"),
+  INDEMNITY_INSURANCE("indemnity-insurance"),
   PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
   PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
   PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,8 @@ application:
       in-app: v1.0.0
     form-updated:
       email: v1.0.0
+    indemnity-insurance:
+      in-app: v1.0.0
     welcome:
       in-app: v1.0.0
   timezone: Europe/London

--- a/src/main/resources/templates/in-app/indemnity-insurance/v1.0.0.html
+++ b/src/main/resources/templates/in-app/indemnity-insurance/v1.0.0.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Indemnity Insurance for Speciality</title>
+  </head>
+  <body>
+    <h1>In-App Notification</h1>
+    <h2>Subject</h2>
+    <th:block th:fragment="subject">Indemnity Insurance for Speciality</th:block>
+    <h2>Content</h2>
+    <th:block th:fragment="content">Indemnity Insurance for Speciality
+
+This notification pertains to the following programme <th:block th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : _">(programme name missing)</th:block> starting on <th:block th:text="${startDate} ? |${#temporals.format(startDate, 'dd MMMM yyyy')}| : _">(start date missing)</th:block>.
+
+Please note that although indemnity cover is provided to postgraduate doctors by your host Trust this does not cover any work outside your agreed training programme. For any work undertaken outside your training programme you must ensure that you purchase additional cover.
+<th:block th:if="${hasBlockIndemnity}">
+The specialty you are training in is covered by a Block indemnity scheme.  You will be contacted separately about this ahead of your programme start date. Please look out for this email and respond as appropriate.</th:block></th:block>
+  </body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -58,7 +58,7 @@ class ProgrammeMembershipMapperTest {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(TIS_ID);
     programmeMembership.setStartDate(START_DATE);
-    Curriculum curriculum = new Curriculum(CURRICULUM_SUB_TYPE, CURRICULUM_SPECIALTY);
+    Curriculum curriculum = new Curriculum(CURRICULUM_SUB_TYPE, CURRICULUM_SPECIALTY, false);
     programmeMembership.setCurricula(List.of(curriculum));
 
     ProgrammeMembership returnedPm = mapper.toEntity(event.recrd().getData());


### PR DESCRIPTION
The indemnity insurance notification should be sent to all new starters taking part in the notification pilot.
There is a conditional section that should be shown dependant on the specialty being in a block indemnity scheme.

Update the Curriculum to include `curriculumSpecialtyBlockIndemnity`. When a qualifying PM is detected, check all associated curricula for any in a block indemnity scheme. When found then show the conditional notification section.

TIS21-5617
TIS21-5837