### PR TITLE
fix: disable programme membership update notifications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.15.0"
+version = "1.15.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
@@ -43,6 +43,7 @@ public enum NotificationType {
   PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),
   PROGRAMME_UPDATED_WEEK_1("programme-updated-week-1"),
   PROGRAMME_UPDATED_WEEK_0("programme-updated-week-0"),
+  PROGRAMME_CREATED("programme-created"),
   WELCOME("welcome");
 
   /**
@@ -53,7 +54,8 @@ public enum NotificationType {
       PROGRAMME_UPDATED_WEEK_8,
       PROGRAMME_UPDATED_WEEK_4,
       PROGRAMME_UPDATED_WEEK_1,
-      PROGRAMME_UPDATED_WEEK_0);
+      PROGRAMME_UPDATED_WEEK_0,
+      PROGRAMME_CREATED);
 
   private final String templateName;
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.quartz.JobBuilder.newJob;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
-import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_UPDATED_WEEK_8;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PAST_MILESTONE_SCHEDULE_DELAY_HOURS;
 import static uk.nhs.tis.trainee.notifications.service.PlacementService.PLACEMENT_OWNER_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.PlacementService.PLACEMENT_SPECIALTY_FIELD;
@@ -91,7 +91,7 @@ class NotificationServiceTest {
   private static final String PERSON_ID = "person-id";
   private static final String PROGRAMME_NAME = "the programme";
   private static final LocalDate START_DATE = LocalDate.now();
-  private static final NotificationType PM_NOTIFICATION_TYPE = PROGRAMME_UPDATED_WEEK_8;
+  private static final NotificationType PM_NOTIFICATION_TYPE = PROGRAMME_CREATED;
 
   private static final String LOCAL_OFFICE = "local office";
   private static final String PLACEMENT_SPECIALTY = "specialty";
@@ -281,8 +281,7 @@ class NotificationServiceTest {
 
   @ParameterizedTest
   @EnumSource(value = NotificationType.class, mode = Mode.EXCLUDE,
-      names = {"PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_UPDATED_WEEK_8", "PROGRAMME_UPDATED_WEEK_4",
-          "PROGRAMME_UPDATED_WEEK_1", "PROGRAMME_UPDATED_WEEK_0"})
+      names = {"PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED"})
   void shouldIgnoreNonProgrammeOrPlacementJobs(NotificationType notificationType)
       throws MessagingException {
     UserDetails userAccountDetails =
@@ -304,7 +303,7 @@ class NotificationServiceTest {
 
   @Test
   void shouldScheduleProgrammeMembershipNotification() throws SchedulerException {
-    NotificationType milestone = NotificationType.PROGRAMME_UPDATED_WEEK_0;
+    NotificationType milestone = PROGRAMME_CREATED;
     String jobId = milestone + "-" + TIS_ID;
 
     LocalDate expectedDate = START_DATE
@@ -379,7 +378,7 @@ class NotificationServiceTest {
 
   @Test
   void shouldRemoveNotification() throws SchedulerException {
-    String jobId = NotificationType.PROGRAMME_UPDATED_WEEK_0 + "-" + TIS_ID;
+    String jobId = NotificationType.PROGRAMME_CREATED + "-" + TIS_ID;
 
     service.removeNotification(jobId);
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.INDEMNITY_INSURANCE;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.BLOCK_INDEMNITY_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.COJ_SYNCED_FIELD;
@@ -48,7 +49,6 @@ import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipServic
 
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
@@ -363,7 +363,6 @@ class ProgrammeMembershipServiceTest {
     programmeMembership.setCurricula(List.of(theCurriculum));
     programmeMembership.setConditionsOfJoining(new ConditionsOfJoining(Instant.MIN));
 
-    NotificationType milestone = NotificationType.PROGRAMME_CREATED;
     Date expectedWhen = Date.from(Instant.now().plus(1, ChronoUnit.HOURS));
 
     when(notificationService.getScheduleDate(LocalDate.now(), 1))
@@ -379,9 +378,9 @@ class ProgrammeMembershipServiceTest {
         dateCaptor.capture()
     );
 
-    //verify the details of the last notification added
+    //verify the details of the notification added
     String jobId = stringCaptor.getValue();
-    String expectedJobId = milestone + "-" + TIS_ID;
+    String expectedJobId = PROGRAMME_CREATED + "-" + TIS_ID;
     assertThat("Unexpected job id.", jobId, is(expectedJobId));
 
     JobDataMap jobDataMap = jobDataMapCaptor.getValue();
@@ -411,7 +410,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new HistoryDto("id",
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         MessageType.EMAIL,
-        NotificationType.PROGRAMME_CREATED, null,
+        PROGRAMME_CREATED, null,
         "email address",
         Instant.MIN, Instant.MAX, SENT, null));
 
@@ -427,9 +426,9 @@ class ProgrammeMembershipServiceTest {
   }
 
   @ParameterizedTest
-  @MethodSource(
-      "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getNonProgrammeUpdateNotificationTypes")
-  void shouldIgnoreNonPmUpdateSentNotifications(NotificationType notificationType)
+  @EnumSource(value = NotificationType.class, mode = Mode.EXCLUDE,
+      names = {"PROGRAMME_CREATED", "PLACEMENT_UPDATED_WEEK_12"})
+  void shouldIgnoreNonPmCreatedSentNotifications(NotificationType notificationType)
       throws SchedulerException {
     Curriculum theCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "any specialty", false);
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
@@ -468,7 +467,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new HistoryDto("id",
         new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_ID), //note: placement type
         MessageType.EMAIL,
-        NotificationType.PROGRAMME_CREATED, null, //to avoid masking the test condition
+        PROGRAMME_CREATED, null, //to avoid masking the test condition
         "email address",
         Instant.MIN, Instant.MAX, SENT, null));
 
@@ -493,7 +492,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new HistoryDto("id",
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, "another id"),
         MessageType.EMAIL,
-        NotificationType.PROGRAMME_CREATED, null,
+        PROGRAMME_CREATED, null,
         "email address",
         Instant.MIN, Instant.MAX, SENT, null));
 
@@ -505,7 +504,7 @@ class ProgrammeMembershipServiceTest {
   }
 
   @Test
-  void shouldScheduleMostRecentMissedNotification() throws SchedulerException {
+  void shouldScheduleMissedNotification() throws SchedulerException {
     LocalDate dateToday = LocalDate.now();
 
     Curriculum theCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "any specialty", false);
@@ -547,7 +546,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new HistoryDto("id",
         null,
         MessageType.EMAIL,
-        NotificationType.PROGRAMME_CREATED, null,
+        PROGRAMME_CREATED, null,
         "email address",
         Instant.MIN, Instant.MAX, SENT, null));
 
@@ -573,7 +572,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new HistoryDto("id",
         null,
         MessageType.EMAIL,
-        NotificationType.PROGRAMME_CREATED, null,
+        PROGRAMME_CREATED, null,
         "email address",
         Instant.MIN, Instant.MAX, SENT, null));
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -60,7 +60,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -426,8 +425,7 @@ class ProgrammeMembershipServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationType.class, mode = Mode.EXCLUDE,
-      names = {"PROGRAMME_CREATED", "PLACEMENT_UPDATED_WEEK_12"})
+  @EnumSource(value = NotificationType.class, mode = Mode.EXCLUDE, names = "PROGRAMME_CREATED")
   void shouldIgnoreNonPmCreatedSentNotifications(NotificationType notificationType)
       throws SchedulerException {
     Curriculum theCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "any specialty", false);


### PR DESCRIPTION
They are not ever sent, they clutter up the schedule and the logs, and removing them will simplify the PM creation email.

The first in a series of PRs to implement the programme creation email.

TIS21-5038