### PR TITLE
Refactor/in app message html

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.15.1"
+version = "1.15.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -149,7 +149,7 @@ public class HistoryService {
 
     history = mapper.updateStatus(history, status, detail);
     history = repository.save(history);
-    return Optional.of(mapper.toDto(history));
+    return Optional.of(toDto(history));
   }
 
   /**
@@ -162,20 +162,28 @@ public class HistoryService {
     List<History> history = repository.findAllByRecipient_IdOrderBySentAtDesc(traineeId);
 
     return history.stream()
-        .map(h -> {
-          String subject = null;
-
-          if (h.recipient().type() == IN_APP) {
-            subject = rebuildMessage(h, Set.of("subject")).orElse("");
-          }
-
-          if (subject == null || subject.isEmpty()) {
-            return mapper.toDto(h);
-          } else {
-            return mapper.toDto(h, subject);
-          }
-        })
+        .map(this::toDto)
         .toList();
+  }
+
+  /**
+   * Convert a history entity to an equivalent DTO, handles in-app subject text.
+   *
+   * @param history The history entity to map.
+   * @return The mapped HistoryDto.
+   */
+  private HistoryDto toDto(History history) {
+    String subject = null;
+
+    if (history.recipient().type() == IN_APP) {
+      subject = rebuildMessage(history, Set.of("subject")).orElse("");
+    }
+
+    if (subject == null || subject.isEmpty()) {
+      return mapper.toDto(history);
+    } else {
+      return mapper.toDto(history, subject);
+    }
   }
 
   /**

--- a/src/main/resources/templates/in-app/e-portfolio/v1.0.0.html
+++ b/src/main/resources/templates/in-app/e-portfolio/v1.0.0.html
@@ -9,10 +9,25 @@
     <h2>Subject</h2>
     <th:block th:fragment="subject">ePortfolio</th:block>
     <h2>Content</h2>
-    <th:block th:fragment="content">ePortfolio
-
-This notification pertains to the following programme <th:block th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : _">(programme name missing)</th:block> starting on <th:block th:text="${startDate} ? |${#temporals.format(startDate, 'dd MMMM yyyy')}| : _">(start date missing)</th:block>.
-
-Please remember to register with your Royal College or Faculty as appropriate, and they will set up your e-portfolio account. https://tis-support.hee.nhs.uk/trainees/royal-college-faculties-contact-information</th:block>
+    <th:block th:fragment="content">
+      <p>
+        This notification pertains to the following programme
+        <th:block th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : _"
+          >(programme name missing)</th:block
+        >
+        starting on
+        <th:block th:text="${startDate} ? |${#temporals.format(startDate, 'dd MMMM yyyy')}| : _"
+          >(start date missing)</th:block
+        >.
+      </p>
+      <p>
+        Please remember to register with your Royal College or Faculty as appropriate, and they will
+        set up your e-portfolio account.
+        <a
+          href="https://tis-support.hee.nhs.uk/trainees/royal-college-faculties-contact-information"
+          >See contact information.</a
+        >
+      </p>
+    </th:block>
   </body>
 </html>

--- a/src/main/resources/templates/in-app/indemnity-insurance/v1.0.0.html
+++ b/src/main/resources/templates/in-app/indemnity-insurance/v1.0.0.html
@@ -9,12 +9,28 @@
     <h2>Subject</h2>
     <th:block th:fragment="subject">Indemnity Insurance for Speciality</th:block>
     <h2>Content</h2>
-    <th:block th:fragment="content">Indemnity Insurance for Speciality
-
-This notification pertains to the following programme <th:block th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : _">(programme name missing)</th:block> starting on <th:block th:text="${startDate} ? |${#temporals.format(startDate, 'dd MMMM yyyy')}| : _">(start date missing)</th:block>.
-
-Please note that although indemnity cover is provided to postgraduate doctors by your host Trust this does not cover any work outside your agreed training programme. For any work undertaken outside your training programme you must ensure that you purchase additional cover.
-<th:block th:if="${hasBlockIndemnity}">
-The specialty you are training in is covered by a Block indemnity scheme.  You will be contacted separately about this ahead of your programme start date. Please look out for this email and respond as appropriate.</th:block></th:block>
+    <th:block th:fragment="content">
+      <p>
+        This notification pertains to the following programme
+        <th:block th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : _"
+          >(programme name missing)</th:block
+        >
+        starting on
+        <th:block th:text="${startDate} ? |${#temporals.format(startDate, 'dd MMMM yyyy')}| : _"
+          >(start date missing)</th:block
+        >.
+      </p>
+      <p>
+        Please note that although indemnity cover is provided to postgraduate doctors by your host
+        Trust this does not cover any work outside your agreed training programme. For any work
+        undertaken outside your training programme you must ensure that you purchase additional
+        cover.
+      </p>
+      <p th:if="${hasBlockIndemnity}">
+        The specialty you are training in is covered by a Block indemnity scheme. You will be
+        contacted separately about this ahead of your programme start date. Please look out for this
+        email and respond as appropriate.
+      </p>
+    </th:block>
   </body>
 </html>

--- a/src/main/resources/templates/in-app/welcome/v1.0.0.html
+++ b/src/main/resources/templates/in-app/welcome/v1.0.0.html
@@ -9,10 +9,12 @@
     <h2>Subject</h2>
     <th:block th:fragment="subject">Welcome to TIS Self-Service</th:block>
     <h2>Content</h2>
-    <th:block th:fragment="content">Welcome to TIS Self-Service
-
-Our goal is to improve your training experience by making TIS Self-Service a one-stop-shop for your training-related admin tasks.
-
-We are in the Private Beta phase of delivery so expect more features soon.</th:block>
+    <th:block th:fragment="content">
+      <p>
+        Our goal is to improve your training experience by making TIS Self-Service a one-stop-shop
+        for your training-related admin tasks.
+      </p>
+      <p>We are in the Private Beta phase of delivery so expect more features soon.</p>
+    </th:block>
   </body>
 </html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/MethodArgumentUtil.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/MethodArgumentUtil.java
@@ -80,12 +80,12 @@ public class MethodArgumentUtil {
    * @throws IOException If the template files could not be traversed.
    */
   public static Stream<Arguments> getInAppTemplateTypeAndVersions() throws IOException {
-    File emailRoot = ResourceUtils.getFile(CLASSPATH_URL_PREFIX + "templates/in-app/");
+    File inAppRoot = ResourceUtils.getFile(CLASSPATH_URL_PREFIX + "templates/in-app/");
     List<Arguments> arguments = new ArrayList<>();
 
     for (NotificationType type : NotificationType.values()) {
       String name = type.getTemplateName();
-      Path templateRoot = emailRoot.toPath().resolve(name);
+      Path templateRoot = inAppRoot.toPath().resolve(name);
 
       try (Stream<Path> paths = Files.walk(templateRoot)) {
         int parentNameCount = templateRoot.getNameCount();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -24,10 +24,12 @@ package uk.nhs.tis.trainee.notifications.service;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
 
 import java.time.Duration;
@@ -41,8 +43,6 @@ import org.bson.types.ObjectId;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
-import org.jsoup.nodes.TextNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -319,7 +319,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null);
+        recipientInfo, templateInfo, Instant.now(), Instant.now(), UNREAD, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID.toString());
@@ -329,9 +329,9 @@ class HistoryServiceIntegrationTest {
     Document content = Jsoup.parse(message.get());
     Element body = content.body();
 
-    assertThat("Unexpected child count.", body.childNodeSize(), is(1));
+    assertThat("Unexpected child count.", body.childNodeSize(), greaterThanOrEqualTo(1));
 
-    Node contentNode = body.childNode(0);
-    assertThat("Unexpected node type.", contentNode, instanceOf(TextNode.class));
+    body.children().forEach(
+        contentNode -> assertThat("Unexpected node type.", contentNode.tagName(), is("p")));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -179,6 +179,7 @@ class HistoryServiceTest {
     assertThat("Unexpected TIS reference.", history.tisReference(), is(tisReferenceInfo));
     assertThat("Unexpected type.", history.type(), is(EMAIL));
     assertThat("Unexpected subject.", history.subject(), is(COJ_CONFIRMATION));
+    assertThat("Unexpected subject.", history.subjectText(), nullValue());
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));
@@ -212,6 +213,12 @@ class HistoryServiceTest {
     History foundHistory = new History(notificationId, tisReferenceInfo, COJ_CONFIRMATION,
         recipientInfo, templateInfo, Instant.MIN, Instant.MAX, null, null);
 
+    String templatePath = "in-app/test/template/v1.2.3";
+    when(templateService.getTemplatePath(IN_APP, TEMPLATE_NAME, TEMPLATE_VERSION)).thenReturn(
+        templatePath);
+    when(templateService.process(templatePath, Set.of("subject"), TEMPLATE_VARIABLES)).thenReturn(
+        "Test Subject");
+
     when(repository.findById(notificationId)).thenReturn(Optional.of(foundHistory));
     when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -229,6 +236,7 @@ class HistoryServiceTest {
     assertThat("Unexpected TIS reference.", history.tisReference(), is(tisReferenceInfo));
     assertThat("Unexpected type.", history.type(), is(IN_APP));
     assertThat("Unexpected subject.", history.subject(), is(COJ_CONFIRMATION));
+    assertThat("Unexpected subject text.", history.subjectText(), is("Test Subject"));
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));
@@ -291,6 +299,7 @@ class HistoryServiceTest {
     assertThat("Unexpected TIS reference.", history.tisReference(), is(tisReferenceInfo));
     assertThat("Unexpected type.", history.type(), is(EMAIL));
     assertThat("Unexpected subject.", history.subject(), is(COJ_CONFIRMATION));
+    assertThat("Unexpected subject text.", history.subjectText(), nullValue());
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));
@@ -326,6 +335,12 @@ class HistoryServiceTest {
     History foundHistory = new History(notificationId, tisReferenceInfo, COJ_CONFIRMATION,
         recipientInfo, templateInfo, Instant.MIN, Instant.MAX, null, null);
 
+    String templatePath = "in-app/test/template/v1.2.3";
+    when(templateService.getTemplatePath(IN_APP, TEMPLATE_NAME, TEMPLATE_VERSION)).thenReturn(
+        templatePath);
+    when(templateService.process(templatePath, Set.of("subject"), TEMPLATE_VARIABLES)).thenReturn(
+        "Test Subject");
+
     when(repository.findByIdAndRecipient_Id(notificationId, TRAINEE_ID)).thenReturn(
         Optional.of(foundHistory));
     when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -343,6 +358,7 @@ class HistoryServiceTest {
     assertThat("Unexpected TIS reference.", history.tisReference(), is(tisReferenceInfo));
     assertThat("Unexpected type.", history.type(), is(IN_APP));
     assertThat("Unexpected subject.", history.subject(), is(COJ_CONFIRMATION));
+    assertThat("Unexpected subject text.", history.subjectText(), is("Test Subject"));
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));


### PR DESCRIPTION
When a notification's status is updated the new state is returned to the
caller, however the subject text is missing.

Update the HistoryService to re-populate the DTOs subject text after the
entity has been updated.

---

The in-app notification contents are currently plain text, but should be
changed to HTML fragments so that they can be displayed and formatted
correctly by the client.

---

TIS21-5898
TIS21-5899
TIS21-5900