### PR TITLE
fix: refine placement confirm notification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.16.0"
+version = "1.16.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/PlacementMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/PlacementMapper.java
@@ -45,6 +45,7 @@ public interface PlacementMapper {
   @Mapping(target = "startDate", source = "recordData.dateFrom")
   @Mapping(target = "placementType", source = "recordData.placementType")
   @Mapping(target = "owner", source = "recordData.owner")
+  @Mapping(target = "site", source = "recordData.site")
   Placement toEntity(Map<String, String> recordData);
 }
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/Placement.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/Placement.java
@@ -36,4 +36,5 @@ public class Placement {
   private String placementType;
   private String owner;
   private String specialty;
+  private String site;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -313,7 +313,7 @@ public class NotificationService implements Job {
           userTraineeDetails.title(),
           userCognitoAccountDetails.familyName(),
           userCognitoAccountDetails.givenName(),
-          userTraineeDetails.gmcNumber());
+          userTraineeDetails.gmcNumber().trim());
     } else if (userTraineeDetails != null) {
       //no TSS account or duplicate accounts in Cognito
       return new UserDetails(false,
@@ -321,7 +321,7 @@ public class NotificationService implements Job {
           userTraineeDetails.title(),
           userTraineeDetails.familyName(),
           userTraineeDetails.givenName(),
-          userTraineeDetails.gmcNumber());
+          userTraineeDetails.gmcNumber().trim());
     } else {
       return null;
     }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -201,6 +202,13 @@ public class NotificationService implements Job {
 
     if (isActionableJob) {
       if (userAccountDetails != null) {
+        jobDetails.putIfAbsent("isRegistered", userAccountDetails.isRegistered());
+        jobDetails.putIfAbsent("title", userAccountDetails.title());
+        jobDetails.putIfAbsent("familyName", userAccountDetails.familyName());
+        jobDetails.putIfAbsent("givenName", userAccountDetails.givenName());
+        jobDetails.putIfAbsent("email", userAccountDetails.email());
+        jobDetails.putIfAbsent("gmcNumber", userAccountDetails.gmcNumber());
+        jobDetails.putIfAbsent("isValidGmc", isValidGmc(userAccountDetails.gmcNumber()));
 
         try {
           emailService.sendMessage(personId, userAccountDetails.email(), notificationType,
@@ -400,6 +408,19 @@ public class NotificationService implements Job {
       MessageType messageType) {
     String traineeId = programmeMembership.getPersonId();
     return messagingControllerService.isValidRecipient(traineeId, messageType);
+  }
+
+  /**
+   * Validate the stored GMC number of the trainee.
+   *
+   * @param gmcNumber The GMC number to validate.
+   * @return true if it is 7 consecutive numerical digits string, otherwise false.
+   */
+  public boolean isValidGmc(String gmcNumber) {
+    if (gmcNumber == null) {
+      return false;
+    }
+    return (gmcNumber.length() == 7 && StringUtils.isNumeric(gmcNumber));
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -58,6 +58,7 @@ public class PlacementService {
   public static final String START_DATE_FIELD = "startDate";
   public static final String PLACEMENT_TYPE_FIELD = "placementType";
   public static final String PLACEMENT_SPECIALTY_FIELD = "specialty";
+  public static final String PLACEMENT_SITE_FIELD = "site";
 
   public static final List<String> PLACEMENT_TYPES_TO_ACT_ON
       = List.of("In post", "In post - Acting up", "In Post - Extension");
@@ -156,6 +157,7 @@ public class PlacementService {
         jobDataMap.put(START_DATE_FIELD, placement.getStartDate());
         jobDataMap.put(PLACEMENT_TYPE_FIELD, placement.getPlacementType());
         jobDataMap.put(PLACEMENT_SPECIALTY_FIELD, placement.getSpecialty());
+        jobDataMap.put(PLACEMENT_SITE_FIELD, placement.getSite());
         jobDataMap.put(TEMPLATE_OWNER_FIELD, placement.getOwner());
         jobDataMap.put(TEMPLATE_NOTIFICATION_TYPE_FIELD, PLACEMENT_UPDATED_WEEK_12);
 

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
@@ -6,35 +6,37 @@
 <body>
 <h1>Email Message</h1>
 <h2>Subject</h2>
-<th:block th:fragment="subject">Placement confirmation</th:block>
+<th:block th:fragment="subject">NHS England - <th:block th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : _"></th:block> - Notification of Placement</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
   <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span>,</p>
-  <p th:if="${not #strings.isEmpty(gmcNumber)}">GMC <span th:text="${gmcNumber}"></span></p>
+  <p>GMC <th:block th:text="${not #strings.isEmpty(gmcNumber)} ? ${gmcNumber} : _">UNKNOWN</th:block><th:block th:if="${#strings.isEmpty(isValidGmc) OR not isValidGmc}"> - We don't have a confirmed GMC no. please contact your local office to update this.</th:block></p>
+  <p>
+    This notification pertains to your placement in <b><th:block th:text="${not #strings.isEmpty(specialty)} ? ${specialty} : _">(speciality name missing)</th:block></b> at <b><th:block th:text="${not #strings.isEmpty(site)} ? ${site} : _">(site name missing)</th:block></b> starting on <b><th:block th:text="${startDate} ? |${#temporals.format(startDate, 'dd MMMM yyyy')}| : _">(start date missing)</th:block></b>.
+  </p>
   <p>
     We appreciate this must be a busy time for you but please set some time aside to read this letter as it contains some vital information regarding your training placement.
   </p>
   <p>
-    The NHS England team can now confirm your placement within a <b><span th:text="${localOfficeName}"></span></b> programme.
+    The NHS England team can now confirm your placement within a <b><span th:text="${localOfficeName}"></span></b> programme. {Please note Healthcare Education England is now part of NHS England. Our systems will be updated in due course}
   </p>
   <p>
     Please note your allocation and grade progression if appropriate will be subject to you receiving a satisfactory ARCP outcome, and your continued registration/licence to practise with the GMC for the duration of your training.
   </p>
+  <p><b>Accessing TIS Self Service (TSS)</b></p>
   <th:block th:switch="${isRegistered}"
   ><p th:case="true">
-    We have a registered account for you on TIS Self Service against the email address <b><span th:text="${email}"></span></b>. To access your upcoming placement details please log in to TIS Self Service: <a href="https://trainee.tis.nhs.uk/home">https://trainee.tis.nhs.uk/home</a>
+    We have a registered account for you on TIS Self Service against the email address <b><span th:text="${email}"></span></b>. To access your upcoming placement details please log in to <a href="https://trainee.tis.nhs.uk/home">TIS Self Service</a>
   </p>
   <p th:case="false">
-    We have no TIS Self Service account associated to your record. Please create one by clicking the link below.
-    <br/>
-    Please ensure you use the email address we have against our records <b><span th:text="${email}"></span></b>
-    <br/>
-    <a href="https://trainee.tis.nhs.uk/">https://trainee.tis.nhs.uk/</a>.
+    We have no TIS Self Service account associated with your records. Please create one by clicking the link below.
+    Please ensure you use the email address we have against our records, which is: <b><span th:text="${email}"></span></b>
+    <p><a href="https://trainee.tis.nhs.uk/">TIS Self Service</a></p>
   </p>
   </th:block>
   <p>
-    If your email address is likely to change, then please ensure that you update our team via <th:block th:switch="${contactHref}"
+    If your email address is likely to change, or you need support signing up on TIS Self Service then please ensure that you contact via <th:block th:switch="${contactHref}"
   ><span th:case="url"><a th:href="${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
   ><span th:case="email"><a th:href="'mailto:' + ${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
   ><span th:case="*"><span th:text="${localOfficeContact}"></span></span
@@ -47,8 +49,9 @@
     Further details on the specialist area of your placement will be confirmed by your employing organisation. This is because we are only able to confirm details that relate specifically to your college recognised curriculum.
   </p>
   <p>
-    An example of this would be If you have preference a specific post with your Training Programme Director but does not relate to sub-specialty training. This may be a job in a specific location or department
+    An example of this would be if you have a preference for a specific post within your Training Programme that does not relate to sub-specialty training. This may be a job in a specific location or department. Please confirm this with your Training Programme Director.
   </p>
+  <p><b>We are currently piloting the Placement confirmation service. You may come across a series of questions about this within the TIS Self Service app. We appreciate your feedback to help us improve the process and make it easy for you to access the necessary information.</b></p>
   <p>
     Kind Regards,
   </p>

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
@@ -6,7 +6,7 @@
 <body>
 <h1>Email Message</h1>
 <h2>Subject</h2>
-<th:block th:fragment="subject">NHS England - <th:block th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : _"></th:block> - Notification of Placement</th:block>
+<th:block th:fragment="subject">NHS England - <th:block th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local deanery office'"></th:block> - Notification of Placement</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
@@ -19,24 +19,24 @@
     We appreciate this must be a busy time for you but please set some time aside to read this letter as it contains some vital information regarding your training placement.
   </p>
   <p>
-    The NHS England team can now confirm your placement within a <b><span th:text="${localOfficeName}"></span></b> programme. {Please note Healthcare Education England is now part of NHS England. Our systems will be updated in due course}
+    The NHS England team can now confirm your placement within a <b><span th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local deanery office'"></span></b> programme. Please note Healthcare Education England is now part of NHS England. Our systems will be updated in due course.
   </p>
   <p>
     Please note your allocation and grade progression if appropriate will be subject to you receiving a satisfactory ARCP outcome, and your continued registration/licence to practise with the GMC for the duration of your training.
   </p>
-  <p><b>Accessing TIS Self Service (TSS)</b></p>
+  <p><b>Accessing TIS Self-Service (TSS)</b></p>
   <th:block th:switch="${isRegistered}"
   ><p th:case="true">
-    We have a registered account for you on TIS Self Service against the email address <b><span th:text="${email}"></span></b>. To access your upcoming placement details please log in to <a href="https://trainee.tis.nhs.uk/home">TIS Self Service</a>
+    We have a registered account for you on TIS Self-Service against the email address <b><span th:text="${email}"></span></b>. To access your upcoming placement details please log in to <a href="https://trainee.tis.nhs.uk/">TIS Self-Service</a>
   </p>
   <p th:case="false">
-    We have no TIS Self Service account associated with your records. Please create one by clicking the link below.
-    Please ensure you use the email address we have against our records, which is: <b><span th:text="${email}"></span></b>
-    <p><a href="https://trainee.tis.nhs.uk/">TIS Self Service</a></p>
+    We have no TIS Self-Service account associated with your records. Please create one by clicking the link below.
+    Please ensure you use the email address we have against our records, which is: <b><span th:text="${email}"></span></b>.
+    <p><a href="https://trainee.tis.nhs.uk/">TIS Self-Service</a></p>
   </p>
   </th:block>
   <p>
-    If your email address is likely to change, or you need support signing up on TIS Self Service then please ensure that you contact via <th:block th:switch="${contactHref}"
+    If your email address is likely to change, or you need support signing up on TIS Self-Service then please ensure that you contact via <th:block th:switch="${contactHref}"
   ><span th:case="url"><a th:href="${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
   ><span th:case="email"><a th:href="'mailto:' + ${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
   ><span th:case="*"><span th:text="${localOfficeContact}"></span></span
@@ -51,7 +51,7 @@
   <p>
     An example of this would be if you have a preference for a specific post within your Training Programme that does not relate to sub-specialty training. This may be a job in a specific location or department. Please confirm this with your Training Programme Director.
   </p>
-  <p><b>We are currently piloting the Placement confirmation service. You may come across a series of questions about this within the TIS Self Service app. We appreciate your feedback to help us improve the process and make it easy for you to access the necessary information.</b></p>
+  <p><b>We are currently piloting the Placement confirmation service. You may come across a series of questions about this within the TIS Self-Service app. We appreciate your feedback to help us improve the process and make it easy for you to access the necessary information.</b></p>
   <p>
     Kind Regards,
   </p>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -74,7 +74,8 @@ class HistoryServiceIntegrationTest {
   private static final String TEMPLATE_VERSION = "v1.2.3";
   private static final Map<String, Object> TEMPLATE_VARIABLES = Map.of(
       "key1", "value1",
-      "key2", "value2");
+      "key2", "value2",
+      "isValidGmc", true);
   private static final TisReferenceType TIS_REFERENCE_TYPE = TisReferenceType.PLACEMENT;
   private static final String TIS_REFERENCE_ID = UUID.randomUUID().toString();
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -811,4 +811,30 @@ class NotificationServiceTest {
 
     assertThat("Unexpected owner contact.", contactList.size(), is(0));
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"1234567", "0000000"})
+  void shouldValidateGmcReturnTrueFor7ConsecutiveNumerical(String gmcNumber) {
+
+    boolean isValidGmc = service.isValidGmc(gmcNumber);
+
+    assertThat("Unexpected validate GMC result.", isValidGmc, is(true));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abcdefg", "0000g00", "12345678", ""})
+  void shouldValidateGmcReturnFalseForNot7ConsecutiveNumerical(String gmcNumber) {
+
+    boolean isValidGmc = service.isValidGmc(gmcNumber);
+
+    assertThat("Unexpected validate GMC result.", isValidGmc, is(false));
+  }
+
+  @Test
+  void shouldValidateGmcReturnFalseWhenGmcNull() {
+
+    boolean isValidGmc = service.isValidGmc(null);
+
+    assertThat("Unexpected validate GMC result.", isValidGmc, is(false));
+  }
 }


### PR DESCRIPTION
Sample email:
![placementEmail](https://github.com/Health-Education-England/tis-trainee-notifications/assets/56677534/c4dd6397-ce07-4006-93bc-e614f110623f)

TIS21-5857