### PR TITLE
feat: in-app ltft notification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.16.0"
+version = "1.17.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
@@ -38,6 +38,7 @@ public enum NotificationType {
   E_PORTFOLIO("e-portfolio"),
   FORM_UPDATED("form-updated"),
   INDEMNITY_INSURANCE("indemnity-insurance"),
+  LTFT("less-than-full-time"),
   PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
   PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
   PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -435,6 +435,23 @@ public class NotificationService implements Job {
    */
   protected String getOwnerContact(List<Map<String, String>> ownerContactList,
       LocalOfficeContactType contactType, LocalOfficeContactType fallbackContactType) {
+    return getOwnerContact(ownerContactList, contactType, fallbackContactType,
+        DEFAULT_NO_CONTACT_MESSAGE);
+  }
+
+  /**
+   * Get specified owner contact from a list of contacts.
+   *
+   * @param ownerContactList    The owner contact list to search.
+   * @param contactType         The contact type to return.
+   * @param fallbackContactType if the contactType is not available, return this contactType
+   *                            instead.
+   * @param defaultMessage      The default message if the contact was not found.
+   * @return The specific contact of the owner, or the default message if not found.
+   */
+  protected String getOwnerContact(List<Map<String, String>> ownerContactList,
+      LocalOfficeContactType contactType, LocalOfficeContactType fallbackContactType,
+      String defaultMessage) {
 
     Optional<Map<String, String>> ownerContact = ownerContactList.stream()
         .filter(c ->
@@ -448,7 +465,7 @@ public class NotificationService implements Job {
           .findFirst();
     }
     return ownerContact.map(oc -> oc.get(CONTACT_FIELD))
-        .orElse(DEFAULT_NO_CONTACT_MESSAGE);
+        .orElse(defaultMessage);
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,8 @@ application:
       email: v1.0.0
     indemnity-insurance:
       in-app: v1.0.0
+    less-than-full-time:
+      in-app: v1.0.0
     welcome:
       in-app: v1.0.0
   timezone: Europe/London

--- a/src/main/resources/templates/in-app/less-than-full-time/v1.0.0.html
+++ b/src/main/resources/templates/in-app/less-than-full-time/v1.0.0.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Less Than Full Time</title>
+  </head>
+  <body>
+    <h1>In-App Notification</h1>
+    <h2>Subject</h2>
+    <th:block th:fragment="subject">Less Than Full Time</th:block>
+    <h2>Content</h2>
+    <th:block th:fragment="content">
+      <p>
+        This notification pertains to the following programme
+        <th:block th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : _"
+          >(programme name missing)</th:block
+        >
+        starting on
+        <th:block th:text="${startDate} ? |${#temporals.format(startDate, 'dd MMMM yyyy')}| : _"
+          >(start date missing)</th:block
+        >.
+      </p>
+      <p>
+        If you already know the programme that you have been allocated to and wish to apply to work
+        LTFT (Less than Full Time), then please submit your application as soon as possible to
+        ensure that there is no delay in notifying your employer.
+      </p>
+      <p>
+        If you are currently awaiting final allocation, then we advise that you submit your
+        application as soon as your programme is confirmed. Please follow your local office process.
+        <th:block: th:switch="${localOfficeContactType}">
+          <a th:case="url" th:href="${localOfficeContact}" th:text="${localOfficeContact}"></a>
+          <a
+            th:case="email"
+            th:href="|mailto:${localOfficeContact}|"
+            th:text="${localOfficeContact}"
+          ></a>
+          <th:block th:case="*"
+            >Contact your local deanery office for information on LTFT.</th:block
+          >
+        </th:block:>
+      </p>
+    </th:block>
+  </body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -796,6 +796,34 @@ class NotificationServiceTest {
   }
 
   @Test
+  void shouldUseCustomDefaultNoContactWhenContactAndFallbackMissing() {
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, LocalOfficeContactType.TSS_SUPPORT.getContactTypeName());
+    contact1.put(CONTACT_FIELD, "one@email.com, another@email.com");
+    contacts.add(contact1);
+
+    String ownerContact = service.getOwnerContact(contacts,
+        LocalOfficeContactType.ONBOARDING_SUPPORT, LocalOfficeContactType.DEFERRAL, "testDefault");
+
+    assertThat("Unexpected owner contact.", ownerContact, is("testDefault"));
+  }
+
+  @Test
+  void shouldUseCustomDefaultNoContactWhenContactMissingAndFallbackNull() {
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, LocalOfficeContactType.TSS_SUPPORT.getContactTypeName());
+    contact1.put(CONTACT_FIELD, "one@email.com, another@email.com");
+    contacts.add(contact1);
+
+    String ownerContact = service.getOwnerContact(contacts,
+        LocalOfficeContactType.ONBOARDING_SUPPORT, null, "testDefault");
+
+    assertThat("Unexpected owner contact.", ownerContact, is("testDefault"));
+  }
+
+  @Test
   void shouldGetEmptyContactListIfReferenceServiceFailure() {
     doThrow(new RestClientException("error"))
         .when(restTemplate).getForObject(any(), any(), anyMap());


### PR DESCRIPTION
Create an in-app notification for LFTF when a PM is created. The target user must be both a new starter and be part of the notifications pilot.

The contact details should be added to the standard template variables.

TIS21-5613
TIS21-5765