### PR TITLE
Fix/trim gmc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.17.1"
+version = "1.17.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerService.java
@@ -48,7 +48,6 @@ public class MessagingControllerService {
   protected static final String API_PROGRAMME_MEMBERSHIP_NEW_STARTER
       = "/api/programme-membership/isnewstarter/{traineeTisId}/{programmeMembershipId}";
 
-  private final List<String> notificationsWhitelist;
   private final boolean inAppNotificationsEnabled;
   private final boolean emailNotificationsEnabled;
   private final RestTemplate restTemplate;
@@ -63,12 +62,10 @@ public class MessagingControllerService {
    * @param emailNotificationsEnabled Whether email notification messages should be sent.
    */
   public MessagingControllerService(RestTemplate restTemplate,
-      @Value("${application.notifications-whitelist}") List<String> notificationsWhitelist,
       @Value("${application.in-app.enabled}") boolean inAppNotificationsEnabled,
       @Value("${application.email.enabled}") boolean emailNotificationsEnabled,
       @Value("${service.trainee.url}") String serviceUrl) {
     this.restTemplate = restTemplate;
-    this.notificationsWhitelist = notificationsWhitelist;
     this.inAppNotificationsEnabled = inAppNotificationsEnabled;
     this.emailNotificationsEnabled = emailNotificationsEnabled;
     this.serviceUrl = serviceUrl;
@@ -84,17 +81,10 @@ public class MessagingControllerService {
    * @return true if the trainee could be sent the message, otherwise false.
    */
   public boolean isValidRecipient(String traineeTisId, MessageType messageType) {
-
-    boolean inWhitelist = notificationsWhitelist.contains(traineeTisId);
-
-    if (inWhitelist) {
-      return true;
-    } else {
-      return switch (messageType) {
-        case EMAIL -> emailNotificationsEnabled;
-        case IN_APP -> inAppNotificationsEnabled;
-      };
-    }
+    return switch (messageType) {
+      case EMAIL -> emailNotificationsEnabled;
+      case IN_APP -> inAppNotificationsEnabled;
+    };
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerService.java
@@ -57,7 +57,6 @@ public class MessagingControllerService {
    * Initialise the service with the environmental variables that control message dispatch.
    *
    * @param restTemplate              The REST template.
-   * @param notificationsWhitelist    The whitelist of (tester) trainee TIS IDs.
    * @param inAppNotificationsEnabled Whether in-app notification messages should be sent.
    * @param emailNotificationsEnabled Whether email notification messages should be sent.
    */

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -192,8 +192,8 @@ public class NotificationService implements Job {
       minimalPm.setPersonId(personId);
       minimalPm.setTisId(tisReferenceInfo.id());
       actuallySendEmail
-          = inWhitelist ||
-          (messagingControllerService.isValidRecipient(personId, MessageType.EMAIL)
+          = inWhitelist
+          || (messagingControllerService.isValidRecipient(personId, MessageType.EMAIL)
           && meetsCriteria(minimalPm, true, true));
 
     } else if (notificationType == NotificationType.PLACEMENT_UPDATED_WEEK_12) {
@@ -204,8 +204,8 @@ public class NotificationService implements Job {
       tisReferenceInfo = new TisReferenceInfo(PLACEMENT,
           jobDetails.get(PlacementService.TIS_ID_FIELD).toString());
 
-      actuallySendEmail = inWhitelist ||
-          (messagingControllerService.isValidRecipient(personId, MessageType.EMAIL)
+      actuallySendEmail = inWhitelist
+          || (messagingControllerService.isValidRecipient(personId, MessageType.EMAIL)
           && messagingControllerService.isPlacementInPilot2024(personId, tisReferenceInfo.id()));
     }
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -163,8 +163,9 @@ public class NotificationService implements Job {
 
     String owner = jobDetails.getString(TEMPLATE_OWNER_FIELD);
     List<Map<String, String>> ownerContactList = getOwnerContactList(owner);
-    String contact = getOwnerContact(ownerContactList, LocalOfficeContactType.ONBOARDING_SUPPORT,
-        LocalOfficeContactType.TSS_SUPPORT);
+//    String contact = getOwnerContact(ownerContactList, LocalOfficeContactType.ONBOARDING_SUPPORT,
+//        LocalOfficeContactType.TSS_SUPPORT);
+    String contact = "local.office@nhs.uk";
     jobDetails.putIfAbsent(TEMPLATE_OWNER_CONTACT_FIELD, contact);
     jobDetails.putIfAbsent(TEMPLATE_CONTACT_HREF_FIELD, getHrefTypeForContact(contact));
     String website = getOwnerContact(ownerContactList, LocalOfficeContactType.LOCAL_OFFICE_WEBSITE,
@@ -283,18 +284,21 @@ public class NotificationService implements Job {
   public Date getScheduleDate(LocalDate startDate, int daysBeforeStart) {
     Date milestone;
     LocalDate milestoneDate = startDate.minusDays(daysBeforeStart);
-    if (!milestoneDate.isAfter(LocalDate.now())) {
-      // 'Missed' milestones: schedule to be sent soon, but not immediately
-      // in case of human editing 'jitter'.
-      milestone = Date.from(Instant.now()
-          .plus(immediateNotificationDelayMinutes, ChronoUnit.MINUTES));
-    } else {
-      // Future milestone.
-      milestone = Date.from(milestoneDate
-          .atStartOfDay()
-          .atZone(ZoneId.systemDefault())
-          .toInstant());
-    }
+//    if (!milestoneDate.isAfter(LocalDate.now())) {
+//      // 'Missed' milestones: schedule to be sent soon, but not immediately
+//      // in case of human editing 'jitter'.
+//      milestone = Date.from(Instant.now()
+//          .plus(immediateNotificationDelayMinutes, ChronoUnit.MINUTES));
+//    } else {
+//      // Future milestone.
+//      milestone = Date.from(milestoneDate
+//          .atStartOfDay()
+//          .atZone(ZoneId.systemDefault())
+//          .toInstant());
+//    }
+
+    milestone = Date.from(Instant.now()
+        .plus(immediateNotificationDelayMinutes, ChronoUnit.SECONDS));
     return milestone;
   }
 
@@ -315,7 +319,7 @@ public class NotificationService implements Job {
           userTraineeDetails.title(),
           userCognitoAccountDetails.familyName(),
           userCognitoAccountDetails.givenName(),
-          userTraineeDetails.gmcNumber().trim());
+          (userTraineeDetails.gmcNumber() != null? userTraineeDetails.gmcNumber().trim() : null));
     } else if (userTraineeDetails != null) {
       //no TSS account or duplicate accounts in Cognito
       return new UserDetails(false,
@@ -323,7 +327,7 @@ public class NotificationService implements Job {
           userTraineeDetails.title(),
           userTraineeDetails.familyName(),
           userTraineeDetails.givenName(),
-          userTraineeDetails.gmcNumber().trim());
+          (userTraineeDetails.gmcNumber() != null? userTraineeDetails.gmcNumber().trim() : null));
     } else {
       return null;
     }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerServiceTest.java
@@ -40,9 +40,6 @@ import uk.nhs.tis.trainee.notifications.model.MessageType;
 class MessagingControllerServiceTest {
 
   private static final String SERVICE_URL = "the-url";
-  private static final String WHITELIST_1 = "123";
-  private static final String WHITELIST_2 = "456";
-  private static final List<String> WHITELISTED = List.of(WHITELIST_1, WHITELIST_2);
 
   private RestTemplate restTemplate;
   private MessagingControllerService service;
@@ -50,14 +47,7 @@ class MessagingControllerServiceTest {
   @BeforeEach
   void setUp() {
     restTemplate = mock(RestTemplate.class);
-    service = new MessagingControllerService(restTemplate, WHITELISTED, false, false, SERVICE_URL);
-  }
-
-  @ParameterizedTest
-  @EnumSource(MessageType.class)
-  void whitelistedShouldBeValidRecipients(MessageType messageType) {
-    assertThat("Unexpected isValidRecipient().",
-        service.isValidRecipient(WHITELIST_1, messageType), is(true));
+    service = new MessagingControllerService(restTemplate, false, false, SERVICE_URL);
   }
 
   @ParameterizedTest
@@ -69,11 +59,11 @@ class MessagingControllerServiceTest {
 
   @Test
   void nonWhitelistedShouldBeValidRecipientsIfNotificationsEnabled() {
-    service = new MessagingControllerService(restTemplate, WHITELISTED, true, false, SERVICE_URL);
+    service = new MessagingControllerService(restTemplate, true, false, SERVICE_URL);
     assertThat("Unexpected isValidRecipient().",
         service.isValidRecipient("some other id", MessageType.IN_APP), is(true));
 
-    service = new MessagingControllerService(restTemplate, WHITELISTED, false, true, SERVICE_URL);
+    service = new MessagingControllerService(restTemplate, false, true, SERVICE_URL);
     assertThat("Unexpected isValidRecipient().",
         service.isValidRecipient("some other id", MessageType.EMAIL), is(true));
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -70,6 +70,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -88,6 +90,7 @@ import org.quartz.TriggerKey;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.shaded.org.apache.commons.lang3.time.DateUtils;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
@@ -534,6 +537,23 @@ class NotificationServiceTest {
     UserDetails expectedResult = service.mapUserDetails(null, null);
 
     assertThat("Unexpected user details", expectedResult, is(nullValue()));
+  }
+
+  @Test
+  void shouldNotFailToMapUserDetailsWhenGmcNumberIsNull() {
+    UserDetails traineeProfileDetails =
+        new UserDetails(
+            null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, null);
+
+    UserDetails expectedResult = service.mapUserDetails(null, traineeProfileDetails);
+    assertDoesNotThrow(() -> service.mapUserDetails(null, traineeProfileDetails));
+
+    assertThat("Unexpected isRegister", expectedResult.isRegistered(), is(false));
+    assertThat("Unexpected email", expectedResult.email(), is(USER_EMAIL));
+    assertThat("Unexpected title", expectedResult.title(), is(USER_TITLE));
+    assertThat("Unexpected family name", expectedResult.familyName(), is(USER_FAMILY_NAME));
+    assertThat("Unexpected given name", expectedResult.givenName(), is(USER_GIVEN_NAME));
+    assertThat("Unexpected gmc number", expectedResult.gmcNumber(), is(nullValue()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -70,7 +70,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -556,6 +555,27 @@ class NotificationServiceTest {
   }
 
   @Test
+  void shouldMapUserDetailsWhenCognitoAndTssAccountsExistAndGmcNumberIsNull() {
+    UserDetails cognitoAccountDetails =
+        new UserDetails(
+            true, COGNITO_EMAIL, null, COGNITO_FAMILY_NAME, COGNITO_GIVEN_NAME, null);
+    UserDetails traineeProfileDetails =
+        new UserDetails(
+            null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, null);
+
+    UserDetails expectedResult =
+        service.mapUserDetails(cognitoAccountDetails, traineeProfileDetails);
+    assertDoesNotThrow(() -> service.mapUserDetails(cognitoAccountDetails, traineeProfileDetails));
+
+    assertThat("Unexpected isRegister", expectedResult.isRegistered(), is(true));
+    assertThat("Unexpected email", expectedResult.email(), is(COGNITO_EMAIL));
+    assertThat("Unexpected title", expectedResult.title(), is(USER_TITLE));
+    assertThat("Unexpected family name", expectedResult.familyName(), is(COGNITO_FAMILY_NAME));
+    assertThat("Unexpected given name", expectedResult.givenName(), is(COGNITO_GIVEN_NAME));
+    assertThat("Unexpected gmc number", expectedResult.gmcNumber(), is(nullValue()));
+  }
+
+  @Test
   void shouldMapUserDetailsWhenCognitoAccountNotExist() {
     UserDetails traineeProfileDetails =
         new UserDetails(
@@ -569,6 +589,23 @@ class NotificationServiceTest {
     assertThat("Unexpected family name", expectedResult.familyName(), is(USER_FAMILY_NAME));
     assertThat("Unexpected given name", expectedResult.givenName(), is(USER_GIVEN_NAME));
     assertThat("Unexpected gmc number", expectedResult.gmcNumber(), is(USER_GMC));
+  }
+
+  @Test
+  void shouldNotFailToMapUserDetailsWhenCognitoAccountNotExistAndGmcNumberIsNull() {
+    UserDetails traineeProfileDetails =
+        new UserDetails(
+            null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, null);
+
+    UserDetails expectedResult = service.mapUserDetails(null, traineeProfileDetails);
+    assertDoesNotThrow(() -> service.mapUserDetails(null, traineeProfileDetails));
+
+    assertThat("Unexpected isRegister", expectedResult.isRegistered(), is(false));
+    assertThat("Unexpected email", expectedResult.email(), is(USER_EMAIL));
+    assertThat("Unexpected title", expectedResult.title(), is(USER_TITLE));
+    assertThat("Unexpected family name", expectedResult.familyName(), is(USER_FAMILY_NAME));
+    assertThat("Unexpected given name", expectedResult.givenName(), is(USER_GIVEN_NAME));
+    assertThat("Unexpected gmc number", expectedResult.gmcNumber(), is(nullValue()));
   }
 
   @Test
@@ -587,23 +624,6 @@ class NotificationServiceTest {
     UserDetails expectedResult = service.mapUserDetails(null, null);
 
     assertThat("Unexpected user details", expectedResult, is(nullValue()));
-  }
-
-  @Test
-  void shouldNotFailToMapUserDetailsWhenGmcNumberIsNull() {
-    UserDetails traineeProfileDetails =
-        new UserDetails(
-            null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, null);
-
-    UserDetails expectedResult = service.mapUserDetails(null, traineeProfileDetails);
-    assertDoesNotThrow(() -> service.mapUserDetails(null, traineeProfileDetails));
-
-    assertThat("Unexpected isRegister", expectedResult.isRegistered(), is(false));
-    assertThat("Unexpected email", expectedResult.email(), is(USER_EMAIL));
-    assertThat("Unexpected title", expectedResult.title(), is(USER_TITLE));
-    assertThat("Unexpected family name", expectedResult.familyName(), is(USER_FAMILY_NAME));
-    assertThat("Unexpected given name", expectedResult.givenName(), is(USER_GIVEN_NAME));
-    assertThat("Unexpected gmc number", expectedResult.gmcNumber(), is(nullValue()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -556,7 +556,8 @@ class NotificationServiceTest {
     assertThat("Unexpected given name", expectedResult.givenName(), is(COGNITO_GIVEN_NAME));
     if (gmcNumber == null) {
       assertThat("Unexpected gmc number.", expectedResult.gmcNumber(), is(nullValue()));
-      assertDoesNotThrow(() -> service.mapUserDetails(cognitoAccountDetails, traineeProfileDetails));
+      assertDoesNotThrow(() ->
+          service.mapUserDetails(cognitoAccountDetails, traineeProfileDetails));
     } else {
       assertThat("Unexpected gmc number.", expectedResult.gmcNumber(), is(USER_GMC));
     }


### PR DESCRIPTION
Fixing Sentry exception for trimming GMC number when GMC is null

Further to the suggestion from @ReubenRobertsHEE, this PR is tweaking the whitelist logic, if the traineeId is in the whitelist, it will send notification email anyway without requiring to meet the criteria