### PR TITLE
fix: LTFT contact link wording

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.17.1"
+version = "1.17.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/templates/in-app/less-than-full-time/v1.0.0.html
+++ b/src/main/resources/templates/in-app/less-than-full-time/v1.0.0.html
@@ -27,17 +27,18 @@
       </p>
       <p>
         If you are currently awaiting final allocation, then we advise that you submit your
-        application as soon as your programme is confirmed. Please follow your local office process.
+        application as soon as your programme is confirmed.
         <th:block: th:switch="${localOfficeContactType}">
-          <a th:case="url" th:href="${localOfficeContact}" th:text="${localOfficeContact}"></a>
-          <a
-            th:case="email"
-            th:href="|mailto:${localOfficeContact}|"
-            th:text="${localOfficeContact}"
-          ></a>
-          <th:block th:case="*"
+          <th:block th:case="NON_HREF"
             >Contact your local deanery office for information on LTFT.</th:block
           >
+          <th:block th:case="*"
+            >Please click on the following link for details on application process.
+            <a
+              th:href="${localOfficeContactType} == 'email' ? |mailto:${localOfficeContact}| : ${localOfficeContact}"
+              th:text="${localOfficeContact}"
+            ></a
+          ></th:block>
         </th:block:>
       </p>
     </th:block>


### PR DESCRIPTION
The wording just prior to the contact link in the LTFT notification is awkwardly worded and doesn't read well when the contact is not available.

Fix the template the better handle each scenario.

TIS21-5613
TIS21-5765