### PR TITLE
fix: handle null email addresses in hashing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.20.2"
+version = "1.20.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -252,16 +252,18 @@ public class EmailService {
    * Create an MD5 hash of a given string.
    *
    * @param input The string to hash.
-   * @return The MD5 hash, or a fixed default if MD5 is not available.
+   * @return The MD5 hash, or a fixed default if MD5 is not available or the input is null.
    */
   public String createMD5Hash(final String input) {
-    try {
-      MessageDigest md = MessageDigest.getInstance("MD5");
-      byte[] messageDigest = md.digest(input.getBytes());
-      return convertToHex(messageDigest);
-    } catch (NoSuchAlgorithmException e) {
-      return "0".repeat(32); //default hash
+    if (input != null) {
+      try {
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        byte[] messageDigest = md.digest(input.getBytes());
+        return convertToHex(messageDigest);
+      } catch (NoSuchAlgorithmException ignored) {
+      }
     }
+    return "0".repeat(32); //default hash
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -92,6 +91,7 @@ class EmailServiceTest {
   private static final URI APP_DOMAIN = URI.create("local.notifications.com");
   private static final TisReferenceType REFERENCE_TABLE = PLACEMENT;
   private static final String REFERENCE_KEY = "the-key";
+  private static final String DEFAULT_EMAIL_HASH = "00000000000000000000000000000000";
 
   private EmailService service;
   private UserAccountService userAccountService;
@@ -562,7 +562,13 @@ class EmailServiceTest {
        .thenThrow(new NoSuchAlgorithmException("error"));
 
    String hash = service.createMD5Hash("some input");
-   assertThat("Unexpected default hash.", hash, is("00000000000000000000000000000000"));
+   assertThat("Unexpected default hash.", hash, is(DEFAULT_EMAIL_HASH));
    mockedMessageDigest.close();
+  }
+
+  @Test
+  void shouldUseDefaultHashIfInputIsNull() {
+    String hash = service.createMD5Hash(null);
+    assertThat("Unexpected default hash.", hash, is(DEFAULT_EMAIL_HASH));
   }
 }


### PR DESCRIPTION
To avoid cluttering-up Sentry with unneeded exceptions, e.g. https://hee-nhs-tis.slack.com/archives/GQ03M1PKN/p1713953281565079 which was triggered by this trainee https://build.tis.nhs.uk/metabase/question#eyJuYW1lIjpudWxsLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjozNiwidHlwZSI6InF1ZXJ5IiwicXVlcnkiOnsic291cmNlLXRhYmxlIjoxNzQyLCJmaWx0ZXIiOlsiYW5kIixbIj0iLFsiZmllbGQiLDI2NDI1LG51bGxdLCIzMjY4NTEiXV19fSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319

Trainees with null email addresses can't receive emails anyway, but better to handle the exception more gracefully.

NO-TICKET