### PR TITLE
fix: repeated caching of missing users

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.20.3"
+version = "1.20.4"
 
 configurations {
   compileOnly {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
@@ -42,6 +42,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
@@ -56,6 +58,7 @@ import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
 @ActiveProfiles({"redis", "test"})
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(MockitoExtension.class)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 class UserAccountServiceIntegrationTest {
 
   private static final String PERSON_ID = "40";

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -182,6 +183,21 @@ class UserAccountServiceTest {
     Set<String> userAccountIds = service.getUserAccountIds(PERSON_ID_1);
 
     assertThat("Unexpected user IDs count.", userAccountIds.size(), is(0));
+  }
+
+  @Test
+  void shouldNotImmediatelyRepeatBuildingUserIdCache() {
+    // The response is mocked instead of constructed due to embedded pagination handling.
+    ListUsersIterable responses = mock(ListUsersIterable.class);
+    when(cognitoClient.listUsersPaginator(any(ListUsersRequest.class))).thenReturn(responses);
+
+    SdkIterable<UserType> users = mock(SdkIterable.class);
+    when(responses.users()).thenReturn(users);
+
+    service.getUserAccountIds(PERSON_ID_1);
+    service.getUserAccountIds(PERSON_ID_2);
+
+    verify(cognitoClient, times(1)).listUsersPaginator(any(ListUsersRequest.class));
   }
 
   @Test


### PR DESCRIPTION
When a trainee ID is not found in the existing cache, a lookup is performed on the Cognito user pool and all users are re-cached. As there can be a large number of person records without Cognito accounts it can lead to attempts to constant re-cache the user pool over and over.

A fifteen minute window should be added after each full cache operation, during which no re-caching will occur. This will help reduce demand on the Cognito API when processing large numbers of contact detail changes. The fifteen minutes is fairly arbitrary and may need tweaking, until a longer term solution can be put in place.

TIS21-5904