### PR TITLE
fix: ignore non-future PMs and Placements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.20.5"
+version = "1.20.6"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -34,6 +34,7 @@ import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPL
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -80,6 +81,8 @@ public class ProgrammeMembershipService {
   private final InAppService inAppService;
   private final NotificationService notificationService;
 
+  private final ZoneId timezone;
+
   private final String deferralVersion;
   private final String eportfolioVersion;
   private final String indemnityInsuranceVersion;
@@ -99,7 +102,7 @@ public class ProgrammeMembershipService {
    * @param sponsorshipVersion        The sponsorship version.
    */
   public ProgrammeMembershipService(HistoryService historyService, InAppService inAppService,
-      NotificationService notificationService,
+      NotificationService notificationService, @Value("${application.timezone}") ZoneId timezone,
       @Value("${application.template-versions.deferral.in-app}") String deferralVersion,
       @Value("${application.template-versions.e-portfolio.in-app}") String eportfolioVersion,
       @Value("${application.template-versions.indemnity-insurance.in-app}")
@@ -109,6 +112,7 @@ public class ProgrammeMembershipService {
     this.historyService = historyService;
     this.inAppService = inAppService;
     this.notificationService = notificationService;
+    this.timezone = timezone;
     this.deferralVersion = deferralVersion;
     this.eportfolioVersion = eportfolioVersion;
     this.indemnityInsuranceVersion = indemnityInsuranceVersion;
@@ -130,6 +134,11 @@ public class ProgrammeMembershipService {
    * @return true if the programme membership is excluded.
    */
   public boolean isExcluded(ProgrammeMembership programmeMembership) {
+    LocalDate startDate = programmeMembership.getStartDate();
+    if (startDate == null || startDate.isBefore(LocalDate.now(timezone))) {
+      return true;
+    }
+
     List<Curriculum> curricula = programmeMembership.getCurricula();
     if (curricula == null) {
       return true;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -88,7 +88,7 @@ class PlacementServiceTest {
     historyService = mock(HistoryService.class);
     notificationService = mock(NotificationService.class);
     restTemplate = mock(RestTemplate.class);
-    service = new PlacementService(historyService, notificationService);
+    service = new PlacementService(historyService, notificationService, ZoneId.of("Europe/London"));
   }
 
   @ParameterizedTest
@@ -96,6 +96,7 @@ class PlacementServiceTest {
   void shouldNotExcludePlacementWithInPostPlacementType(String placementType) {
     Placement placement = new Placement();
     placement.setPlacementType(placementType);
+    placement.setStartDate(START_DATE);
 
     boolean isExcluded = service.isExcluded(placement);
 
@@ -103,9 +104,31 @@ class PlacementServiceTest {
   }
 
   @Test
+  void shouldExcludePlacementWithNoStartDate() {
+    Placement placement = new Placement();
+    placement.setPlacementType(IN_POST);
+
+    boolean isExcluded = service.isExcluded(placement);
+
+    assertThat("Unexpected excluded value.", isExcluded, is(true));
+  }
+
+  @Test
+  void shouldExcludePlacementThatIsNotFuture() {
+    Placement placement = new Placement();
+    placement.setPlacementType(IN_POST);
+    placement.setStartDate(LocalDate.now().minusYears(1));
+
+    boolean isExcluded = service.isExcluded(placement);
+
+    assertThat("Unexpected excluded value.", isExcluded, is(true));
+  }
+
+  @Test
   void shouldExcludePlacementNotWithInPostPlacementType() {
     Placement placement = new Placement();
     placement.setPlacementType(EXCLUDED_PLACEMENT_TYPE);
+    placement.setStartDate(START_DATE);
 
     boolean isExcluded = service.isExcluded(placement);
 
@@ -114,7 +137,10 @@ class PlacementServiceTest {
 
   @Test
   void shouldExcludePlacementWithoutPlacementType() {
-    boolean isExcluded = service.isExcluded(new Placement());
+    Placement placement = new Placement();
+    placement.setStartDate(START_DATE);
+
+    boolean isExcluded = service.isExcluded(placement);
 
     assertThat("Unexpected excluded value.", isExcluded, is(true));
   }


### PR DESCRIPTION
We only need to send notifications for future PMs and Placements, so exclude any with a past start date (Current and Past).

TIS21-5967
TIS21-5970