### PR TITLE
fix: ignore PMs that have already ended.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.20.5"
+version = "1.20.6"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
@@ -51,6 +51,7 @@ public interface ProgrammeMembershipMapper {
   @Mapping(target = "curricula", source = "recordData.curricula")
   @Mapping(target = "tisId", source = "recordData.tisId")
   @Mapping(target = "startDate", source = "recordData.startDate")
+  @Mapping(target = "endDate", source = "recordData.endDate")
   ProgrammeMembership toEntity(Map<String, String> recordData);
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
@@ -38,6 +38,7 @@ public class ProgrammeMembership {
   private String programmeName;
   private String managingDeanery;
   private LocalDate startDate;
+  private LocalDate endDate;
   private List<Curriculum> curricula = new ArrayList<>();
   private ConditionsOfJoining conditionsOfJoining;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -62,6 +62,7 @@ import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.MessageType;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.model.Placement;
 import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
 
 /**
@@ -112,7 +113,7 @@ public class NotificationService implements Job {
    *                                   profile information.
    * @param referenceUrl               The URL for the tis-trainee-reference service to use for
    *                                   local office information.
-   * @param notificationsWhitelist    The whitelist of (tester) trainee TIS IDs.
+   * @param notificationsWhitelist     The whitelist of (tester) trainee TIS IDs.
    */
   public NotificationService(EmailService emailService, RestTemplate restTemplate,
       Scheduler scheduler, MessagingControllerService messagingControllerService,
@@ -430,6 +431,39 @@ public class NotificationService implements Job {
       return false;
     }
     return (gmcNumber.length() == 7 && StringUtils.isNumeric(gmcNumber));
+  }
+
+  /**
+   * Get a quartz jobId for a given programme membership and notification type.
+   *
+   * @param notificationType    The notification type.
+   * @param programmeMembership The programme membership.
+   * @return The jobId string, or null if the parameters contain a null value.
+   */
+  public String getQuartzJobId(NotificationType notificationType,
+      ProgrammeMembership programmeMembership) {
+    if (notificationType != null && programmeMembership != null
+        && programmeMembership.getTisId() != null) {
+      return notificationType + "-" + programmeMembership.getTisId();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Get a quartz jobId for a given placement and notification type.
+   *
+   * @param notificationType The notification type.
+   * @param placement        The placement.
+   * @return The jobId string, or null if the parameters contain a null value.
+   */
+  public String getQuartzJobId(NotificationType notificationType, Placement placement) {
+    if (notificationType != null && placement != null
+        && placement.getTisId() != null) {
+      return notificationType + "-" + placement.getTisId();
+    } else {
+      return null;
+    }
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -36,12 +36,8 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobDataMap;
 import org.quartz.SchedulerException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
-import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
 import uk.nhs.tis.trainee.notifications.model.Placement;
 import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
@@ -164,7 +160,7 @@ public class PlacementService {
         // Note the status of the trainee will be retrieved when the job is executed, as will
         // their name and email address, and the contact details of the owner LO, not now.
 
-        String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + placement.getTisId();
+        String jobId = notificationService.getQuartzJobId(PLACEMENT_UPDATED_WEEK_12, placement);
         try {
           notificationService.scheduleNotification(jobId, jobDataMap, when);
         } catch (SchedulerException e) {
@@ -183,7 +179,7 @@ public class PlacementService {
    */
   public void deleteNotifications(Placement placement)
       throws SchedulerException {
-    String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + placement.getTisId();
+    String jobId = notificationService.getQuartzJobId(PLACEMENT_UPDATED_WEEK_12, placement);
     notificationService.removeNotification(jobId); //remove existing notification if it exists
   }
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -41,6 +41,7 @@ class ProgrammeMembershipMapperTest {
 
   private static final String TIS_ID = "123";
   private static final LocalDate START_DATE = LocalDate.now();
+  private static final LocalDate END_DATE = LocalDate.MAX;
   private static final String CURRICULUM_SUB_TYPE = "sub-type";
   private static final String CURRICULUM_SPECIALTY = "specialty";
   private static final Instant COJ_SYNCED_AT = Instant.now();
@@ -58,6 +59,7 @@ class ProgrammeMembershipMapperTest {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(TIS_ID);
     programmeMembership.setStartDate(START_DATE);
+    programmeMembership.setEndDate(END_DATE);
     Curriculum curriculum = new Curriculum(CURRICULUM_SUB_TYPE, CURRICULUM_SPECIALTY, false);
     programmeMembership.setCurricula(List.of(curriculum));
 
@@ -65,6 +67,7 @@ class ProgrammeMembershipMapperTest {
 
     assertThat("Unexpected Tis Id.", returnedPm.getTisId(), is(TIS_ID));
     assertThat("Unexpected start date.", returnedPm.getStartDate(), is(START_DATE));
+    assertThat("Unexpected end date.", returnedPm.getEndDate(), is(END_DATE));
     assertThat("Unexpected curricula.", returnedPm.getCurricula(), is(List.of(curriculum)));
     assertThat("Unexpected Conditions of joining.", returnedPm.getConditionsOfJoining(),
         is(new ConditionsOfJoining(COJ_SYNCED_AT)));
@@ -79,6 +82,7 @@ class ProgrammeMembershipMapperTest {
     Map<String, String> dataMap = new HashMap<>();
     dataMap.put("tisId", TIS_ID);
     dataMap.put("startDate", START_DATE.toString());
+    dataMap.put("endDate", END_DATE.toString());
     dataMap.put("another-pm-property", "some value");
     dataMap.put("curricula",
         "[{\"curriculumSubType\": \"" + CURRICULUM_SUB_TYPE + "\", "

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -94,6 +94,7 @@ import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.MessageType;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.model.Placement;
 import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
 
 class NotificationServiceTest {
@@ -932,5 +933,42 @@ class NotificationServiceTest {
     boolean isValidGmc = service.isValidGmc(null);
 
     assertThat("Unexpected validate GMC result.", isValidGmc, is(false));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EnumSource(value = NotificationType.class, mode = Mode.INCLUDE,
+      names = {"PLACEMENT_UPDATED_WEEK_12"})
+  void shouldReturnExpectedPlacementQuartzJobId(NotificationType notificationType) {
+    Placement placement = new Placement();
+    placement.setTisId(TIS_ID);
+
+    String jobId = service.getQuartzJobId(notificationType, placement);
+    String jobId2 = service.getQuartzJobId(notificationType, (Placement) null);
+
+    if (notificationType == null) {
+      assertThat("Unexpected quartz job id", jobId, is(nullValue()));
+    } else {
+      assertThat("Unexpected quartz job id", jobId, is(notificationType + "-" + TIS_ID));
+    }
+    assertThat("Unexpected quartz job id", jobId2, is(nullValue()));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @EnumSource(value = NotificationType.class, mode = Mode.INCLUDE, names = {"PROGRAMME_CREATED"})
+  void shouldReturnExpectedProgrammeMembershipQuartzJobId(NotificationType notificationType) {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(TIS_ID);
+
+    String jobId = service.getQuartzJobId(notificationType, programmeMembership);
+    String jobId2 = service.getQuartzJobId(notificationType, (ProgrammeMembership) null);
+
+    if (notificationType == null) {
+      assertThat("Unexpected quartz job id", jobId, is(nullValue()));
+    } else {
+      assertThat("Unexpected quartz job id", jobId, is(notificationType + "-" + TIS_ID));
+    }
+    assertThat("Unexpected quartz job id", jobId2, is(nullValue()));
   }
 }


### PR DESCRIPTION
Also some refactoring to ensure jobIds are only constructed in one place.

TIS21-TODO