### PR TITLE
fix: handle nulls when determining excluded PMs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.20.6"
+version = "1.20.7"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -145,14 +145,21 @@ public class ProgrammeMembershipService {
     }
 
     boolean hasMedicalSubType = curricula.stream()
+        .filter(c -> c.curriculumSubType() != null)
         .map(c -> c.curriculumSubType().toUpperCase())
         .anyMatch(INCLUDE_CURRICULUM_SUBTYPES::contains);
 
     boolean hasExcludedSpecialty = curricula.stream()
+        .filter(c -> c.curriculumSpecialty() != null)
         .map(c -> c.curriculumSpecialty().toUpperCase())
         .anyMatch(EXCLUDE_CURRICULUM_SPECIALTIES::contains);
 
-    return !hasMedicalSubType || hasExcludedSpecialty;
+    boolean hasSomeNonNullSpecialties = curricula.stream()
+        .anyMatch(c -> c.curriculumSpecialty() != null);
+
+    boolean excludedSpecialty = hasExcludedSpecialty || !hasSomeNonNullSpecialties;
+
+    return !hasMedicalSubType || excludedSpecialty;
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -150,16 +150,10 @@ public class ProgrammeMembershipService {
         .anyMatch(INCLUDE_CURRICULUM_SUBTYPES::contains);
 
     boolean hasExcludedSpecialty = curricula.stream()
-        .filter(c -> c.curriculumSpecialty() != null)
         .map(c -> c.curriculumSpecialty().toUpperCase())
         .anyMatch(EXCLUDE_CURRICULUM_SPECIALTIES::contains);
 
-    boolean hasSomeNonNullSpecialties = curricula.stream()
-        .anyMatch(c -> c.curriculumSpecialty() != null);
-
-    boolean excludedSpecialty = hasExcludedSpecialty || !hasSomeNonNullSpecialties;
-
-    return !hasMedicalSubType || excludedSpecialty;
+    return !hasMedicalSubType || hasExcludedSpecialty;
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -169,6 +169,18 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected excluded value.", isExcluded, is(true));
   }
 
+  @Test
+  void shouldExcludePmWithNullSubtype() {
+    Curriculum theCurriculum = new Curriculum(null, "some-specialty", false);
+    List<Curriculum> curricula = List.of(theCurriculum);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setStartDate(START_DATE);
+    programmeMembership.setCurricula(curricula);
+
+    boolean isExcluded = service.isExcluded(programmeMembership);
+    assertThat("Unexpected excluded value.", isExcluded, is(true));
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   void shouldExcludePmWithNoCurricula(List<Curriculum> curricula) {
@@ -193,6 +205,18 @@ class ProgrammeMembershipServiceTest {
     boolean isExcluded = service.isExcluded(programmeMembership);
 
     assertThat("Unexpected excluded value.", isExcluded, is(true));
+  }
+
+  @Test
+  void shouldNotExcludePmWithMedicalSubtypeAndSomeNonNullSpecialty() {
+    Curriculum nullCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, null, false);
+    Curriculum notNullCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "some specialty", false);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setStartDate(START_DATE);
+    programmeMembership.setCurricula(List.of(nullCurriculum, notNullCurriculum));
+
+    boolean isExcluded = service.isExcluded(programmeMembership);
+    assertThat("Unexpected excluded value.", isExcluded, is(false));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -207,16 +207,14 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected excluded value.", isExcluded, is(true));
   }
 
-  @Test
-  void shouldNotExcludePmWithMedicalSubtypeAndSomeNonNullSpecialty() {
+  @Test()
+  void shouldThrowExceptionIfPmHasNullSpecialty() {
     Curriculum nullCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, null, false);
-    Curriculum notNullCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "some specialty", false);
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setStartDate(START_DATE);
-    programmeMembership.setCurricula(List.of(nullCurriculum, notNullCurriculum));
+    programmeMembership.setCurricula(List.of(nullCurriculum, nullCurriculum));
 
-    boolean isExcluded = service.isExcluded(programmeMembership);
-    assertThat("Unexpected excluded value.", isExcluded, is(false));
+    assertThrows(NullPointerException.class, () -> service.isExcluded(programmeMembership));
   }
 
   @Test


### PR DESCRIPTION
TIS21-5971