### PR TITLE
feat: send to profile email address

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.20.7"
+version = "1.21.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -232,6 +232,16 @@ public class EmailService {
   }
 
   /**
+   * Get the user account for the given trainee email.
+   *
+   * @param email The trainee email to get the account for.
+   * @return The found account.
+   */
+  public UserDetails getRecipientAccountByEmail(String email) {
+    return userAccountService.getUserDetails(email);
+  }
+
+  /**
    * Get the user account for the given trainee ID.
    *
    * @param traineeId The trainee ID to get the account for.

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -194,7 +194,7 @@ class NotificationServiceTest {
         new UserDetails(
             true, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(PERSON_ID, MessageType.EMAIL))
@@ -214,7 +214,7 @@ class NotificationServiceTest {
             true, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
 
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(PERSON_ID, MessageType.EMAIL))
@@ -228,35 +228,46 @@ class NotificationServiceTest {
   }
 
   @Test
-  void shouldNotSetResultWhenUserDetailsCannotBeFound() {
+  void shouldThrowExceptionWhenUserDetailsCannotBeFound() {
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
 
-    when(emailService.getRecipientAccount(any())).thenReturn(null);
+    when(emailService.getRecipientAccountByEmail(any())).thenReturn(null);
     when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(null);
 
-    service.execute(jobExecutionContext);
+    assertThrows(IllegalArgumentException.class, () -> service.execute(jobExecutionContext));
 
     verify(jobExecutionContext, never()).setResult(any());
   }
 
   @Test
-  void shouldHandleRestClientExceptions() {
+  void shouldThrowExceptionWhenRestClientExceptions() {
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
 
-    when(emailService.getRecipientAccount(any())).thenThrow(new IllegalArgumentException("error"));
+    when(emailService.getRecipientAccountByEmail(any())).thenThrow(
+        new IllegalArgumentException("error"));
     when(restTemplate.getForObject(any(), any(), anyMap()))
         .thenThrow(new RestClientException("error"));
 
-    assertDoesNotThrow(() -> service.execute(jobExecutionContext));
+    assertThrows(IllegalArgumentException.class, () -> service.execute(jobExecutionContext));
+
+    verify(jobExecutionContext, never()).setResult(any());
   }
 
   @Test
   void shouldHandleCognitoExceptions() {
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
 
-    when(emailService.getRecipientAccount(any())).thenThrow(new IllegalArgumentException("error"));
+    UserDetails userAccountDetails = new UserDetails(false, USER_EMAIL, USER_TITLE,
+        USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
+    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
+        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+
+    when(emailService.getRecipientAccountByEmail(any())).thenThrow(
+        new IllegalArgumentException("error"));
 
     assertDoesNotThrow(() -> service.execute(jobExecutionContext));
+
+    verify(jobExecutionContext).setResult(any());
   }
 
   @Test
@@ -267,7 +278,7 @@ class NotificationServiceTest {
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(PERSON_ID, MessageType.EMAIL))
         .thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(PERSON_ID, TIS_ID))
@@ -287,7 +298,7 @@ class NotificationServiceTest {
         new UserDetails(
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
@@ -308,7 +319,7 @@ class NotificationServiceTest {
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
@@ -331,7 +342,7 @@ class NotificationServiceTest {
         new UserDetails(
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
@@ -352,7 +363,7 @@ class NotificationServiceTest {
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
@@ -374,7 +385,7 @@ class NotificationServiceTest {
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
 
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
@@ -393,7 +404,7 @@ class NotificationServiceTest {
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
@@ -418,7 +429,7 @@ class NotificationServiceTest {
 
     programmeJobDetails.getJobDataMap().put(TEMPLATE_NOTIFICATION_TYPE_FIELD, notificationType);
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
 
@@ -480,7 +491,7 @@ class NotificationServiceTest {
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
-    when(emailService.getRecipientAccount(PERSON_ID)).thenReturn(userAccountDetails);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
@@ -536,7 +547,7 @@ class NotificationServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {USER_GMC, "  " + USER_GMC,  USER_GMC + "  ",  "  " + USER_GMC + "  "})
+  @ValueSource(strings = {USER_GMC, "  " + USER_GMC, USER_GMC + "  ", "  " + USER_GMC + "  "})
   @NullSource
   void shouldMapUserDetailsWhenCognitoAndTssAccountsExist(String gmcNumber) {
     UserDetails cognitoAccountDetails =
@@ -564,7 +575,7 @@ class NotificationServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {USER_GMC, "  " + USER_GMC,  USER_GMC + "  ",  "  " + USER_GMC + "  "})
+  @ValueSource(strings = {USER_GMC, "  " + USER_GMC, USER_GMC + "  ", "  " + USER_GMC + "  "})
   @NullSource
   void shouldMapUserDetailsWhenCognitoAccountNotExist(String gmcNumber) {
     UserDetails traineeProfileDetails =


### PR DESCRIPTION
The trainee profile was not explicitly trusted and is only used when no Cognito account was found based on the trainee ID. The Cognito looking is done using an expensive caching operation as there is no direct way to query based on tranine ID.

Now that the Cognito account and trainee profile emails are kept in sync it is preferred to lookup the Cognito account based on the email from the trainee profile.

Update the NotificationService to retrieve the trainee profile first, then perform a single Cognito query to find an existing account for the email address.
There is a small edge case where the Cognito account could not be updated in time either due to either race conditions or issues like multiple accounts (in which case the UM service errors), in those cases the email will be sent based on the profile email instead of erroring out - and may be flagged as "not registered" incorrectly.

TIS21-5967
TIS21-5969