### PR TITLE
fix: catch UserNotFoundException

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.21.1"
-
+version = "1.21.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -43,6 +43,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
@@ -236,8 +237,9 @@ public class EmailService {
    *
    * @param email The trainee email to get the account for.
    * @return The found account.
+   * @throws UserNotFoundException if the user account could not be found.
    */
-  public UserDetails getRecipientAccountByEmail(String email) {
+  public UserDetails getRecipientAccountByEmail(String email) throws UserNotFoundException {
     return userAccountService.getUserDetails(email);
   }
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -57,6 +57,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
@@ -366,8 +367,7 @@ public class NotificationService implements Job {
   private UserDetails getCognitoAccountDetails(String email) {
     try {
       return emailService.getRecipientAccountByEmail(email);
-    } catch (IllegalArgumentException e) {
-      //no TSS account or duplicate accounts
+    } catch (UserNotFoundException e) {
       return null;
     }
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -89,6 +89,7 @@ import org.quartz.TriggerKey;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.shaded.org.apache.commons.lang3.time.DateUtils;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
@@ -262,8 +263,7 @@ class NotificationServiceTest {
     when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
         UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
 
-    when(emailService.getRecipientAccountByEmail(any())).thenThrow(
-        new IllegalArgumentException("error"));
+    when(emailService.getRecipientAccountByEmail(any())).thenThrow(UserNotFoundException.class);
 
     assertDoesNotThrow(() -> service.execute(jobExecutionContext));
 


### PR DESCRIPTION
As the user account is looked up by email/username there are no longer multiple failure scenarios (e.g. duplicate accounts) that need be wrapped in a generic IllegalArgumentException.
The UserNotFoundException is passed through, so catch it and return `null` back to the NotificationService so it can continue to merge the user details.

TIS21-5967