### PR TITLE
feat: store failure when email missing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.21.3"
+version = "1.22.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/UserDetails.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/UserDetails.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.tis.trainee.notifications.dto;
 
+import lombok.Builder;
+
 /**
  * User details for an individual user.
  *
@@ -31,6 +33,7 @@ package uk.nhs.tis.trainee.notifications.dto;
  * @param givenName     The user's given name.
  * @param gmcNumber     The user's GMC number.
  */
+@Builder
 public record UserDetails(
     Boolean isRegistered,
     String email,

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -347,8 +347,9 @@ public class NotificationService implements Job {
           (userTraineeDetails.gmcNumber() != null ? userTraineeDetails.gmcNumber().trim() : null));
     } else if (userTraineeDetails != null) {
       //no TSS account or duplicate accounts in Cognito
+      String email = userTraineeDetails.email();
       return new UserDetails(false,
-          userTraineeDetails.email(),
+          email == null || email.isBlank() ? null : email,
           userTraineeDetails.title(),
           userTraineeDetails.familyName(),
           userTraineeDetails.givenName(),
@@ -366,7 +367,8 @@ public class NotificationService implements Job {
    */
   private UserDetails getCognitoAccountDetails(String email) {
     try {
-      return emailService.getRecipientAccountByEmail(email);
+      return email == null || email.isBlank() ? null
+          : emailService.getRecipientAccountByEmail(email);
     } catch (UserNotFoundException e) {
       return null;
     }
@@ -525,7 +527,7 @@ public class NotificationService implements Job {
    *
    * @param contact The contact string, expected to be either an email address or a URL.
    * @return "email" if it looks like an email address, "url" if it looks like a URL, and "NOT_HREF"
-   * otherwise.
+   *     otherwise.
    */
   protected String getHrefTypeForContact(String contact) {
     try {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -197,7 +197,7 @@ public class PlacementService {
    *
    * @param notificationType The notification type.
    * @return The number of days before the placement start for the notification, or null if not a
-   * placement update notification type.
+   *     placement update notification type.
    */
   public Integer getNotificationDaysBeforeStart(NotificationType notificationType) {
     if (notificationType.equals(PLACEMENT_UPDATED_WEEK_12)) {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
@@ -58,7 +58,7 @@ class MongoConfigurationTest {
 
     configuration.initIndexes();
 
-    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
+    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.captor();
     verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
 
     List<IndexDefinition> indexes = indexCaptor.getAllValues();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -136,7 +136,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
         templateVersion);
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -172,7 +172,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -212,7 +212,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -248,7 +248,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -286,7 +286,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -324,7 +324,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -360,7 +360,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerTest.java
@@ -106,7 +106,7 @@ class ConditionsOfJoiningListenerTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 
@@ -121,7 +121,7 @@ class ConditionsOfJoiningListenerTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 
@@ -136,7 +136,7 @@ class ConditionsOfJoiningListenerTest {
 
     listener.handleConditionsOfJoiningReceived(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
@@ -140,7 +140,7 @@ class CredentialListenerIntegrationTest {
     CredentialListener listener = new CredentialListener(emailService, templateVersion);
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -176,7 +176,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -217,7 +217,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -255,7 +255,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -295,7 +295,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -333,7 +333,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -369,7 +369,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -397,7 +397,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -425,7 +425,7 @@ class CredentialListenerIntegrationTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerTest.java
@@ -121,7 +121,7 @@ class CredentialListenerTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 
@@ -138,7 +138,7 @@ class CredentialListenerTest {
 
     listener.handleCredentialRevoked(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
@@ -142,7 +142,7 @@ class FormListenerIntegrationTest {
     FormListener listener = new FormListener(emailService, templateVersion);
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -180,7 +180,7 @@ class FormListenerIntegrationTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -224,7 +224,7 @@ class FormListenerIntegrationTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -268,7 +268,7 @@ class FormListenerIntegrationTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -309,7 +309,7 @@ class FormListenerIntegrationTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerTest.java
@@ -110,7 +110,7 @@ class FormListenerTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 
@@ -125,7 +125,7 @@ class FormListenerTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 
@@ -141,7 +141,7 @@ class FormListenerTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 
@@ -156,7 +156,7 @@ class FormListenerTest {
 
     listener.handleFormUpdate(event);
 
-    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> templateVarsCaptor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(),
         templateVarsCaptor.capture(), any());
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/PlacementListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/PlacementListenerTest.java
@@ -93,7 +93,7 @@ class PlacementListenerTest {
 
     when(mapper.toEntity(any())).thenReturn(placementToDelete);
 
-    ArgumentCaptor<Placement> placementCaptor = ArgumentCaptor.forClass(Placement.class);
+    ArgumentCaptor<Placement> placementCaptor = ArgumentCaptor.captor();
 
     listener.handlePlacementDelete(event);
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/DeleteUnusedPlacementUpdateHistoryTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/DeleteUnusedPlacementUpdateHistoryTest.java
@@ -63,7 +63,7 @@ class DeleteUnusedPlacementUpdateHistoryTest {
     when(template.remove(any(), eq(History.class))).thenReturn(DeleteResult.acknowledged(1L));
     migration.migrate();
 
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
     verify(template, times(expectedDeletes)).remove(queryCaptor.capture(), eq(History.class));
 
     List<Query> queries = queryCaptor.getAllValues();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/DeleteUnusedPmUpdateHistoryTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/DeleteUnusedPmUpdateHistoryTest.java
@@ -62,7 +62,7 @@ class DeleteUnusedPmUpdateHistoryTest {
     when(template.remove(any(), eq(History.class))).thenReturn(DeleteResult.acknowledged(1L));
     migration.migrate();
 
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
     verify(template, times(expectedDeletes)).remove(queryCaptor.capture(), eq(History.class));
 
     List<Query> queries = queryCaptor.getAllValues();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -91,7 +91,7 @@ class EmailServiceIntegrationTest {
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -108,7 +108,7 @@ class EmailServiceIntegrationTest {
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -125,7 +125,7 @@ class EmailServiceIntegrationTest {
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -147,7 +147,7 @@ class EmailServiceIntegrationTest {
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -176,7 +176,7 @@ class EmailServiceIntegrationTest {
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion,
         Map.of("familyName", "Maillig"), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -185,7 +185,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "", Map.of(),
         null);
 
-    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.captor();
     verify(templateService, atLeastOnce()).process(any(), any(), contextCaptor.capture());
 
     Context context = contextCaptor.getValue();
@@ -201,7 +201,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of("familyName", "Maillig"), null);
 
-    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.captor();
     verify(templateService, atLeastOnce()).process(any(), any(), contextCaptor.capture());
 
     Context context = contextCaptor.getValue();
@@ -214,7 +214,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.captor();
     verify(templateService, atLeastOnce()).process(any(), any(), contextCaptor.capture());
 
     Context context = contextCaptor.getValue();
@@ -229,7 +229,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of("domain", domain), null);
 
-    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.captor();
     verify(templateService, atLeastOnce()).process(any(), any(), contextCaptor.capture());
 
     Context context = contextCaptor.getValue();
@@ -241,10 +241,10 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.captor();
     verify(templateService, atLeastOnce()).process(any(), any(), contextCaptor.capture());
 
-    String expectedHashedEmail = service.createMD5Hash(RECIPIENT);
+    String expectedHashedEmail = service.createMd5Hash(RECIPIENT);
 
     Context context = contextCaptor.getValue();
     assertThat("Unexpected hashed email.", context.getVariable("hashedEmail"),
@@ -260,7 +260,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -277,7 +277,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -295,7 +295,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -311,7 +311,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -331,7 +331,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
@@ -354,8 +354,8 @@ class EmailServiceTest {
     verify(templateService, times(2)).process(eq("template/path"),
         any(), (Context) any());
 
-    ArgumentCaptor<Set<String>> selectorCaptor = ArgumentCaptor.forClass(Set.class);
-    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    ArgumentCaptor<Set<String>> selectorCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.captor();
     verify(templateService, times(2)).process(any(), selectorCaptor.capture(),
         contextCaptor.capture());
 
@@ -386,7 +386,7 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, notificationType, templateVersion,
         Map.of("key1", "value1"), tisReferenceInfo);
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -440,7 +440,7 @@ class EmailServiceTest {
         templateInfo, sentAt, null, FAILED, "bounced", null);
     service.resendMessage(toResend, "newemailaddress");
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -504,13 +504,13 @@ class EmailServiceTest {
     service.sendMessageToExistingUser(TRAINEE_ID, NOTIFICATION_TYPE, "",
         Map.of(), null);
 
-    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
 
     MimeMessage message = messageCaptor.getValue();
     String headerId = message.getHeader("NotificationId", "");
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -524,11 +524,32 @@ class EmailServiceTest {
     when(templateService.process(any(), eq(Set.of("content")), (Context) any())).thenReturn(
         template);
 
-    service.sendMessage(TRAINEE_ID, RECIPIENT, NOTIFICATION_TYPE, "", new HashMap<>(),
-        null, true);
+    service.sendMessage(TRAINEE_ID, RECIPIENT, NOTIFICATION_TYPE, "", Map.of("key1", "val1"), null,
+        true);
 
     verify(mailSender, never()).send((MimeMessage) any());
     verify(historyService, never()).save(any());
+  }
+
+  @Test
+  void shouldNotActuallySendMessageIfNoRecipient() throws MessagingException {
+    String template = "<div>Test message body</div>";
+    when(templateService.process(any(), eq(Set.of("content")), (Context) any())).thenReturn(
+        template);
+
+    service.sendMessage(TRAINEE_ID, null, NOTIFICATION_TYPE, "", new HashMap<>(),
+        null, false);
+
+    verify(mailSender, never()).send((MimeMessage) any());
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected recipient contact.", history.recipient().contact(), nullValue());
+    assertThat("Unexpected status.", history.status(), is(FAILED));
+    assertThat("Unexpected status detail.", history.statusDetail(),
+        is("No email address available."));
   }
 
   @Test
@@ -557,18 +578,18 @@ class EmailServiceTest {
 
   @Test
   void shouldUseDefaultHashIfMd5NotAvailable() {
-   MockedStatic<MessageDigest> mockedMessageDigest = Mockito.mockStatic(MessageDigest.class);
-   mockedMessageDigest.when(() -> MessageDigest.getInstance(any()))
-       .thenThrow(new NoSuchAlgorithmException("error"));
+    MockedStatic<MessageDigest> mockedMessageDigest = Mockito.mockStatic(MessageDigest.class);
+    mockedMessageDigest.when(() -> MessageDigest.getInstance(any()))
+        .thenThrow(new NoSuchAlgorithmException("error"));
 
-   String hash = service.createMD5Hash("some input");
-   assertThat("Unexpected default hash.", hash, is(DEFAULT_EMAIL_HASH));
-   mockedMessageDigest.close();
+    String hash = service.createMd5Hash("some input");
+    assertThat("Unexpected default hash.", hash, is(DEFAULT_EMAIL_HASH));
+    mockedMessageDigest.close();
   }
 
   @Test
   void shouldUseDefaultHashIfInputIsNull() {
-    String hash = service.createMD5Hash(null);
+    String hash = service.createMd5Hash(null);
     assertThat("Unexpected default hash.", hash, is(DEFAULT_EMAIL_HASH));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
@@ -85,7 +85,7 @@ class InAppServiceTest {
   void shouldNotSetIdWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -99,7 +99,7 @@ class InAppServiceTest {
     TisReferenceInfo referenceInfo = new TisReferenceInfo(PLACEMENT, referenceId);
     service.createNotifications(TRAINEE_ID, referenceInfo, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -113,7 +113,7 @@ class InAppServiceTest {
   void shouldSetNotificationTypeWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -125,7 +125,7 @@ class InAppServiceTest {
   void shouldSetRecipientInfoWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -145,7 +145,7 @@ class InAppServiceTest {
     );
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, variables);
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -166,7 +166,7 @@ class InAppServiceTest {
   void shouldSetSentAtWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -179,7 +179,7 @@ class InAppServiceTest {
   void shouldNotSetReadAtWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -191,7 +191,7 @@ class InAppServiceTest {
   void shouldSetStatusWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();
@@ -203,7 +203,7 @@ class InAppServiceTest {
   void shouldSetStatusDetailWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 
-    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());
 
     History history = historyCaptor.getValue();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -75,6 +76,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -102,6 +104,8 @@ class NotificationServiceTest {
   private static final String TEMPLATE_VERSION = "template-version";
   private static final String SERVICE_URL = "the-url";
   private static final String REFERENCE_URL = "reference-url";
+  private static final String ACCOUNT_DETAILS_URL =
+      SERVICE_URL + "/api/trainee-profile/account-details/{tisId}";
   private static final String JOB_KEY_STRING = "job-key";
   private static final JobKey JOB_KEY = new JobKey(JOB_KEY_STRING);
   private static final String TIS_ID = "tis-id";
@@ -196,8 +200,8 @@ class NotificationServiceTest {
             true, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(PERSON_ID, MessageType.EMAIL))
         .thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(PERSON_ID, TIS_ID))
@@ -216,8 +220,8 @@ class NotificationServiceTest {
 
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(PERSON_ID, MessageType.EMAIL))
         .thenReturn(true);
     when(messagingControllerService.isPlacementInPilot2024(PERSON_ID, TIS_ID))
@@ -260,8 +264,8 @@ class NotificationServiceTest {
 
     UserDetails userAccountDetails = new UserDetails(false, USER_EMAIL, USER_TITLE,
         USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
 
     when(emailService.getRecipientAccountByEmail(any())).thenThrow(UserNotFoundException.class);
 
@@ -275,8 +279,8 @@ class NotificationServiceTest {
     UserDetails userAccountDetails =
         new UserDetails(
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(PERSON_ID, MessageType.EMAIL))
@@ -299,8 +303,8 @@ class NotificationServiceTest {
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
     when(messagingControllerService.isPlacementInPilot2024(any(), any())).thenReturn(!apiResult);
 
@@ -320,8 +324,8 @@ class NotificationServiceTest {
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
         .thenReturn(!apiResult);
@@ -343,8 +347,8 @@ class NotificationServiceTest {
             false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
     when(messagingControllerService.isPlacementInPilot2024(any(), any())).thenReturn(!apiResult);
 
@@ -364,8 +368,8 @@ class NotificationServiceTest {
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
         .thenReturn(!apiResult);
@@ -386,8 +390,8 @@ class NotificationServiceTest {
 
     when(jobExecutionContext.getJobDetail()).thenReturn(placementJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isPlacementInPilot2024(any(), any())).thenReturn(true);
 
@@ -405,8 +409,8 @@ class NotificationServiceTest {
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
@@ -430,14 +434,73 @@ class NotificationServiceTest {
     programmeJobDetails.getJobDataMap().put(TEMPLATE_NOTIFICATION_TYPE_FIELD, notificationType);
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
 
     service.execute(jobExecutionContext);
 
     verify(emailService, never())
         .sendMessage(any(), any(), any(), any(), any(), any(), anyBoolean());
     verify(jobExecutionContext, never()).setResult(any());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" "})
+  void shouldExecuteNowWithNullEmailWhenNoEmail(String email) throws MessagingException {
+    UserDetails userAccountDetails = UserDetails.builder()
+        .isRegistered(false)
+        .email(email)
+        .build();
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+
+    when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
+    when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any())).thenReturn(true);
+    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any())).thenReturn(
+        true);
+
+    JobDataMap jobData = new JobDataMap(Map.of(
+        PERSON_ID_FIELD, PERSON_ID,
+        TIS_ID_FIELD, TIS_ID,
+        TEMPLATE_NOTIFICATION_TYPE_FIELD, PROGRAMME_CREATED
+    ));
+
+    service.executeNow(JOB_KEY_STRING, jobData);
+
+    verify(emailService, never()).getRecipientAccountByEmail(any());
+    verify(emailService).sendMessage(eq(PERSON_ID), isNull(), any(), any(), anyMap(), any(),
+        eq(false));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldExecuteNowWithNullEmailWhenEmailNoLongerAvailable(String email)
+      throws MessagingException {
+    UserDetails userAccountDetails = UserDetails.builder()
+        .isRegistered(false)
+        .email(email)
+        .build();
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+
+    when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
+    when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any())).thenReturn(true);
+    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any())).thenReturn(
+        true);
+
+    JobDataMap jobData = new JobDataMap(Map.of(
+        PERSON_ID_FIELD, PERSON_ID,
+        TIS_ID_FIELD, TIS_ID,
+        TEMPLATE_NOTIFICATION_TYPE_FIELD, PROGRAMME_CREATED,
+        "email", "existing@example.com"
+    ));
+
+    service.executeNow(JOB_KEY_STRING, jobData);
+
+    verify(emailService, never()).getRecipientAccountByEmail(any());
+    verify(emailService).sendMessage(eq(PERSON_ID), isNull(), any(), any(), anyMap(), any(),
+        eq(false));
   }
 
   @Test
@@ -452,8 +515,8 @@ class NotificationServiceTest {
 
     service.scheduleNotification(jobId, programmeJobDataMap, when);
 
-    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass(JobDetail.class);
-    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
+    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.captor();
     verify(scheduler).scheduleJob(jobDetailCaptor.capture(), triggerCaptor.capture());
 
     Trigger trigger = triggerCaptor.getValue();
@@ -474,8 +537,8 @@ class NotificationServiceTest {
 
     service.scheduleNotification(jobId, placementJobDataMap, when);
 
-    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass(JobDetail.class);
-    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
+    ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.captor();
     verify(scheduler).scheduleJob(jobDetailCaptor.capture(), triggerCaptor.capture());
 
     Trigger trigger = triggerCaptor.getValue();
@@ -492,8 +555,8 @@ class NotificationServiceTest {
 
     when(jobExecutionContext.getJobDetail()).thenReturn(programmeJobDetails);
     when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject("the-url/api/trainee-profile/account-details/{tisId}",
-        UserDetails.class, Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
         .thenReturn(true);
@@ -512,9 +575,8 @@ class NotificationServiceTest {
 
     service.execute(jobExecutionContext);
 
-    ArgumentCaptor<Map<String, Object>> jobDetailsCaptor = ArgumentCaptor.forClass(Map.class);
-    ArgumentCaptor<TisReferenceInfo> tisReferenceInfoCaptor
-        = ArgumentCaptor.forClass(TisReferenceInfo.class);
+    ArgumentCaptor<Map<String, Object>> jobDetailsCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<TisReferenceInfo> tisReferenceInfoCaptor = ArgumentCaptor.captor();
 
     verify(emailService).sendMessage(eq(PERSON_ID), eq(USER_EMAIL), eq(PROGRAMME_CREATED),
         eq(TEMPLATE_VERSION), jobDetailsCaptor.capture(), tisReferenceInfoCaptor.capture(),
@@ -566,7 +628,7 @@ class NotificationServiceTest {
     assertThat("Unexpected family name", expectedResult.familyName(), is(COGNITO_FAMILY_NAME));
     assertThat("Unexpected given name", expectedResult.givenName(), is(COGNITO_GIVEN_NAME));
     if (gmcNumber == null) {
-      assertThat("Unexpected gmc number.", expectedResult.gmcNumber(), is(nullValue()));
+      assertThat("Unexpected gmc number.", expectedResult.gmcNumber(), nullValue());
       assertDoesNotThrow(() ->
           service.mapUserDetails(cognitoAccountDetails, traineeProfileDetails));
     } else {
@@ -590,11 +652,23 @@ class NotificationServiceTest {
     assertThat("Unexpected family name", expectedResult.familyName(), is(USER_FAMILY_NAME));
     assertThat("Unexpected given name", expectedResult.givenName(), is(USER_GIVEN_NAME));
     if (gmcNumber == null) {
-      assertThat("Unexpected gmc number.", expectedResult.gmcNumber(), is(nullValue()));
+      assertThat("Unexpected gmc number.", expectedResult.gmcNumber(), nullValue());
       assertDoesNotThrow(() -> service.mapUserDetails(null, traineeProfileDetails));
     } else {
       assertThat("Unexpected gmc number.", expectedResult.gmcNumber(), is(USER_GMC));
     }
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void shouldMapUserDetailsWithNullEmailWhenEmailMissing(String email) {
+    UserDetails traineeDetails = UserDetails.builder()
+        .email(email)
+        .build();
+
+    UserDetails userDetails = service.mapUserDetails(null, traineeDetails);
+
+    assertThat("Unexpected email.", userDetails.email(), nullValue());
   }
 
   @Test
@@ -605,14 +679,14 @@ class NotificationServiceTest {
 
     UserDetails expectedResult = service.mapUserDetails(cognitoAccountDetails, null);
 
-    assertThat("Unexpected user details", expectedResult, is(nullValue()));
+    assertThat("Unexpected user details", expectedResult, nullValue());
   }
 
   @Test
   void shouldMapUserDetailsWhenBothCognitoAccountAndTraineeProfileNotExist() {
     UserDetails expectedResult = service.mapUserDetails(null, null);
 
-    assertThat("Unexpected user details", expectedResult, is(nullValue()));
+    assertThat("Unexpected user details", expectedResult, nullValue());
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -224,9 +224,9 @@ class PlacementServiceTest {
         .thenReturn(expectedWhen);
     service.addNotifications(placement);
 
-    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
-    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.captor();
     verify(notificationService).scheduleNotification(
         stringCaptor.capture(),
         jobDataMapCaptor.capture(),
@@ -366,7 +366,7 @@ class PlacementServiceTest {
     service.addNotifications(placement);
 
     //the zero-day notification should be scheduled, but no other missed notifications
-    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.captor();
     verify(notificationService).scheduleNotification(
         any(),
         any(),

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -281,8 +281,8 @@ class ProgrammeMembershipServiceTest {
 
     ArgumentCaptor<TisReferenceInfo> referenceInfoCaptor = ArgumentCaptor.forClass(
         TisReferenceInfo.class);
-    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.forClass(Map.class);
-    ArgumentCaptor<Boolean> doNotStoreJustLogCaptor = ArgumentCaptor.forClass(Boolean.class);
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Boolean> doNotStoreJustLogCaptor = ArgumentCaptor.captor();
     verify(inAppService).createNotifications(eq(PERSON_ID), referenceInfoCaptor.capture(),
         eq(notificationType), eq(notificationVersion), variablesCaptor.capture(),
         doNotStoreJustLogCaptor.capture());
@@ -317,7 +317,7 @@ class ProgrammeMembershipServiceTest {
 
     service.addNotifications(programmeMembership);
 
-    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
     verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(INDEMNITY_INSURANCE),
         eq(INDEMNITY_INSURANCE_VERSION), variablesCaptor.capture(), anyBoolean());
 
@@ -347,7 +347,7 @@ class ProgrammeMembershipServiceTest {
 
     service.addNotifications(programmeMembership);
 
-    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
     verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(INDEMNITY_INSURANCE),
         eq(INDEMNITY_INSURANCE_VERSION), variablesCaptor.capture(), anyBoolean());
 
@@ -373,7 +373,7 @@ class ProgrammeMembershipServiceTest {
 
     service.addNotifications(programmeMembership);
 
-    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
     verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(INDEMNITY_INSURANCE),
         eq(INDEMNITY_INSURANCE_VERSION), variablesCaptor.capture(), anyBoolean());
 
@@ -414,7 +414,7 @@ class ProgrammeMembershipServiceTest {
 
     service.addNotifications(programmeMembership);
 
-    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
     verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(LTFT),
         eq(LTFT_VERSION), variablesCaptor.capture(), anyBoolean());
     verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(DEFERRAL),
@@ -501,9 +501,9 @@ class ProgrammeMembershipServiceTest {
         .thenReturn(expectedWhen);
     service.addNotifications(programmeMembership);
 
-    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
-    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    ArgumentCaptor<String> stringCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.captor();
     verify(notificationService).executeNow(
         stringCaptor.capture(),
         jobDataMapCaptor.capture());
@@ -723,7 +723,7 @@ class ProgrammeMembershipServiceTest {
 
     service.addNotifications(programmeMembership);
 
-    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.forClass(JobDataMap.class);
+    ArgumentCaptor<JobDataMap> jobDataMapCaptor = ArgumentCaptor.captor();
     verify(notificationService).executeNow(any(), jobDataMapCaptor.capture());
 
     //verify the details of the job scheduled

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/TemplateServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/TemplateServiceTest.java
@@ -173,7 +173,7 @@ class TemplateServiceTest {
     Set<String> selectors = Set.of("selector1", "selector2");
     Map<String, Object> templateVariables = Map.of("key1", "value1");
 
-    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.captor();
     when(templateEngine.process(eq(template), eq(selectors), contextCaptor.capture())).thenReturn(
         "processedTemplate");
 


### PR DESCRIPTION
Currently when an email is missing the sending causes an error and the
triggering message ends up on the DLQ. This means that Local Offices are
unable to report on these particular types of failure easily.

Update the NotificationService and EmailService to handle `null` or
empty values for the email field on the trainee record.
If the email is `null` or empty then no attempt should be made to find
the associated user account.

TIS21-5984
TIS21-5985