### PR TITLE
fix: resending failures when previous contact null

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.22.0"
+version = "1.22.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsService.java
@@ -54,7 +54,8 @@ public class ContactDetailsService {
         = historyService.findAllFailedForTrainee(contactDetails.getTisId());
     List<History> onesToResend = failedMessages.stream()
         .filter(h -> h.recipient().type() == MessageType.EMAIL)
-        .filter(h -> !h.recipient().contact().equalsIgnoreCase(contactDetails.getEmail()))
+        .filter(h -> h.recipient().contact() == null || !h.recipient().contact()
+            .equalsIgnoreCase(contactDetails.getEmail()))
         .toList();
     log.info("There are {} failed emails to retry for trainee {} with updated email address",
         onesToResend.size(), contactDetails.getTisId());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
@@ -80,11 +80,14 @@ class ContactDetailsServiceTest {
   void shouldResendFailedEmailTypeMessagesWithDifferentEmailOnly() throws MessagingException {
     History historySameEmail = buildHistory(TRAINEE_CONTACT, EMAIL);
     History historyOtherEmail = buildHistory("different email", EMAIL);
+    History historyNullEmail = buildHistory(null, EMAIL);
     History historySameInApp = buildHistory(TRAINEE_CONTACT, IN_APP);
     History historyOtherInApp = buildHistory("different email", IN_APP);
+    History historyNullInApp = buildHistory(null, IN_APP);
 
     when(historyService.findAllFailedForTrainee(TRAINEE_ID)).thenReturn(
-        List.of(historySameEmail, historyOtherEmail, historySameInApp, historyOtherInApp));
+        List.of(historySameEmail, historyOtherEmail, historyNullEmail, historySameInApp,
+            historyOtherInApp, historyNullInApp));
 
     ContactDetails updatedContactDetails = new ContactDetails();
     updatedContactDetails.setEmail(TRAINEE_CONTACT);
@@ -93,6 +96,7 @@ class ContactDetailsServiceTest {
     service.updateContactDetails(updatedContactDetails);
 
     verify(emailService).resendMessage(historyOtherEmail, TRAINEE_CONTACT);
+    verify(emailService).resendMessage(historyNullEmail, TRAINEE_CONTACT);
     verifyNoMoreInteractions(emailService);
   }
 
@@ -122,7 +126,7 @@ class ContactDetailsServiceTest {
    * Helper function to build a standard history object with variable contact email and message
    * type.
    *
-   * @param contact The contact email to use.
+   * @param contact     The contact email to use.
    * @param messageType The message type to use.
    * @return The history object.
    */


### PR DESCRIPTION
When an email address is not available during sending, the failure is recorded with no email address.
Upon receiving an updating set of contact details the previously failed message should be resent.

Update the ContactDetailsService to properly handle the `null` value is when determining whether to resend the message or not.

TIS21-5984