### PR TITLE
fix: handle resending template with null vars

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.22.2"
+version = "1.22.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -179,8 +179,7 @@ public class EmailService {
           toResend.template().version());
       log.info("Sending template {} to {}.", templateName, updatedEmailAddress);
       ObjectId notificationId = toResend.id();
-      Map<String, Object> resendVariables = new HashMap<>(
-          Map.copyOf(toResend.template().variables()));
+      Map<String, Object> resendVariables = new HashMap<>(toResend.template().variables());
       resendVariables.putIfAbsent("originallySentOn", toResend.sentAt());
 
       MimeMessageHelper helper = buildMessageHelper(updatedEmailAddress, templateName,

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -428,6 +428,7 @@ class EmailServiceTest {
     String templateVersion = "v1.2.3";
     Map<String, Object> variables = new HashMap<>();
     variables.put("key1", "value1");
+    variables.put("key2", null);
     TemplateInfo templateInfo = new TemplateInfo(notificationType.getTemplateName(),
         templateVersion, variables);
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(REFERENCE_TABLE, REFERENCE_KEY);
@@ -466,8 +467,9 @@ class EmailServiceTest {
     assertThat("Unexpected template version.", savedTemplateInfo.version(), is(templateVersion));
 
     Map<String, Object> storedVariables = templateInfo.variables();
-    assertThat("Unexpected template variable count.", storedVariables.size(), is(1));
+    assertThat("Unexpected template variable count.", storedVariables.size(), is(2));
     assertThat("Unexpected template variable.", storedVariables.get("key1"), is("value1"));
+    assertThat("Unexpected template variable.", storedVariables.get("key2"), nullValue());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
When a template variable value is null the resending will fail due to `Map.copyOf()` not supporting null values.

Update the EmailService to create a new instance of the map without using that function call.

NO-TICKET