### PR TITLE
fix: do not resend when email still null

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.22.3"
+version = "1.22.4"
 
 configurations {
   compileOnly {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
@@ -74,6 +75,15 @@ class ContactDetailsServiceTest {
     emailService = mock(EmailService.class);
     notificationService = mock(NotificationService.class);
     service = new ContactDetailsService(historyService, emailService);
+  }
+
+  @Test
+  void shouldNotResendFailedEmailsWhenLatestEmailIsNull() {
+    ContactDetails updatedContactDetails = new ContactDetails();
+    updatedContactDetails.setTisId(TRAINEE_ID);
+    service.updateContactDetails(updatedContactDetails);
+
+    verifyNoInteractions(emailService);
   }
 
   @Test


### PR DESCRIPTION
Attempting to resend emails when the contact details are updated, but the email address is still null, results in an exception being thrown by the email service.

Update ContactDetailsService to fail fast and log the null email address instead of trying to have it re-sent anyway.

NO-TICKET