### PR TITLE
feat: notify trainees of email changes

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -9,6 +9,10 @@
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/account/confirmed"
         },
         {
+          "name": "ACCOUNT_UPDATED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/user-account/updated"
+        },
+        {
           "name": "APP_DOMAIN",
           "valueFrom": "/tis/trainee/${environment}/app-domain"
         },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.23.0"
+version = "1.24.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/AccountUpdatedEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/AccountUpdatedEvent.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.dto;
+
+import java.util.UUID;
+
+/**
+ * An event published when a user account is updated.
+ *
+ * @param userId        The user account ID.
+ * @param traineeId     The linked trainee ID.
+ * @param previousEmail The user account's previous email address.
+ * @param newEmail      The user account's new email address.
+ */
+public record AccountUpdatedEvent(UUID userId, String traineeId, String previousEmail,
+                                  String newEmail) {
+
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
@@ -37,6 +37,8 @@ public enum NotificationType {
   CREDENTIAL_REVOKED("credential-revoked"),
   DEFERRAL("deferral"),
   E_PORTFOLIO("e-portfolio"),
+  EMAIL_UPDATED_NEW("email-updated-new"),
+  EMAIL_UPDATED_OLD("email-updated-old"),
   FORM_UPDATED("form-updated"),
   INDEMNITY_INSURANCE("indemnity-insurance"),
   LTFT("less-than-full-time"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,7 @@ application:
   immediate-notifications-delay-minutes: ${IMMEDIATE_NOTIFICATIONS_DELAY:60}
   queues:
     account-confirmed: ${ACCOUNT_CONFIRMED_QUEUE}
+    account-updated: ${ACCOUNT_UPDATED_QUEUE}
     coj-received: ${COJ_RECEIVED_QUEUE}
     credential-revoked: ${CREDENTIAL_REVOKED_QUEUE}
     contact-details-updated: ${CONTACT_DETAILS_UPDATED_QUEUE}
@@ -38,6 +39,10 @@ application:
       in-app: v1.0.0
     e-portfolio:
       in-app: v1.0.0
+    email-updated-new:
+      email: v1.0.0
+    email-updated-old:
+      email: v1.0.0
     form-updated:
       email: v1.0.0
     indemnity-insurance:

--- a/src/main/resources/templates/email/email-updated-new/v1.0.0.html
+++ b/src/main/resources/templates/email/email-updated-new/v1.0.0.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>TIS Self-Service Email Updated (New)</title>
+  </head>
+  <body>
+    <h1>Email Message</h1>
+    <h2>Subject</h2>
+    <th:block th:fragment="subject">TIS Self-Service Email Updated</th:block>
+    <h2>Content</h2>
+    <th:block th:fragment="content">
+      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div style="text-align: right">
+        <img
+          style="margin-right: 25px"
+          src="https://trainee.tis.nhs.uk/nhse-logo.png"
+          alt="NHS England logo"
+        />
+      </div>
+      <p th:replace="fragments/greeting/v1.0.0 :: p"></p>
+
+      <p>
+        Your contact details have been updated by your NHS England local office, as a result
+        <strong th:text="${newEmail}"></strong> is now what you should use to sign in to
+        <a th:href="${not #strings.isEmpty(domain)} ? @{{domain}/(domain=${domain})} : _"
+          >TIS Self-Service</a
+        >. Your previous email will no longer allow you to sign in.
+      </p>
+      <p>
+        If the new email address is incorrect, or you did not request a change to your contact
+        details, please contact your local office as soon as possible.
+      </p>
+
+      <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+    </th:block>
+  </body>
+</html>

--- a/src/main/resources/templates/email/email-updated-old/v1.0.0.html
+++ b/src/main/resources/templates/email/email-updated-old/v1.0.0.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>TIS Self-Service Email Updated (Old)</title>
+  </head>
+  <body>
+    <h1>Email Message</h1>
+    <h2>Subject</h2>
+    <th:block th:fragment="subject">TIS Self-Service Email Updated</th:block>
+    <h2>Content</h2>
+    <th:block th:fragment="content">
+      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div style="text-align: right">
+        <img
+          style="margin-right: 25px"
+          src="https://trainee.tis.nhs.uk/nhse-logo.png"
+          alt="NHS England logo"
+        />
+      </div>
+      <p th:replace="fragments/greeting/v1.0.0 :: p"></p>
+
+      <p>
+        Your contact details have been updated by your NHS England local office, as a result
+        <strong th:text="${previousEmail}"></strong> can no longer be used to sign in to
+        <a th:href="${not #strings.isEmpty(domain)} ? @{{domain}/(domain=${domain})} : _"
+          >TIS Self-Service</a
+        >. You should use <strong th:text="${newEmail}"></strong> next time you sign in, we will
+        send a separate confirmation to that address.
+      </p>
+      <p>
+        If the new email address is incorrect, or you did not request a change to your contact
+        details, please contact your local office as soon as possible.
+      </p>
+
+      <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+    </th:block>
+  </body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -244,11 +244,9 @@ class EmailServiceIntegrationTest {
   }
 
   int getGreetingElementIndex(NotificationType notificationType) {
-    int greetingElement = 0;
-    if (notificationType.equals(NotificationType.PLACEMENT_UPDATED_WEEK_12)
-        || notificationType.equals(NotificationType.PROGRAMME_CREATED)) {
-      greetingElement = 1; //because of logo above it
-    }
-    return greetingElement;
+    return switch (notificationType) {
+      case PLACEMENT_UPDATED_WEEK_12, PROGRAMME_CREATED, EMAIL_UPDATED_NEW, EMAIL_UPDATED_OLD -> 1;
+      default -> 0;
+    };
   }
 }


### PR DESCRIPTION
When a user account email is changed, the trainee should receive an email to both the new and old email addresses to inform them of the change to their contact and sign-in details.

Update the UserAccountListener to receive account update events and use the EmailService to send both emails.

TIS21-6006
TIS21-6009
TIS21-6010