### PR TITLE
refactor: shorten template name to fit formatting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.25.0"
+version = "1.25.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
@@ -44,7 +44,7 @@ public enum NotificationType {
   LTFT("less-than-full-time"),
   NON_EMPLOYMENT("non-employment"),
   PLACEMENT_INFORMATION("placement-information"),
-  PLACEMENT_USEFUL_INFORMATION("placement-useful-information"),
+  USEFUL_INFORMATION("placement-useful-information"),
   PLACEMENT_UPDATED_WEEK_12("placement-updated-week-12"),
   PROGRAMME_UPDATED_WEEK_8("programme-updated-week-8"),
   PROGRAMME_UPDATED_WEEK_4("programme-updated-week-4"),

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -25,7 +25,7 @@ import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.NON_EMPLOYMENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_INFORMATION;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
-import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_USEFUL_INFORMATION;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.USEFUL_INFORMATION;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_NOTIFICATION_TYPE_FIELD;
@@ -148,7 +148,7 @@ public class PlacementService {
     Set<NotificationType> notificationTypes = new HashSet<>();
     notificationTypes.add(PLACEMENT_UPDATED_WEEK_12);
     notificationTypes.add(PLACEMENT_INFORMATION);
-    notificationTypes.add(PLACEMENT_USEFUL_INFORMATION);
+    notificationTypes.add(USEFUL_INFORMATION);
     notificationTypes.add(NON_EMPLOYMENT);
 
     for (NotificationType milestone : notificationTypes) {
@@ -212,7 +212,7 @@ public class PlacementService {
   public Integer getNotificationDaysBeforeStart(NotificationType notificationType) {
     if (notificationType.equals(PLACEMENT_UPDATED_WEEK_12)
         || notificationType.equals(PLACEMENT_INFORMATION)
-        || notificationType.equals(PLACEMENT_USEFUL_INFORMATION)
+        || notificationType.equals(USEFUL_INFORMATION)
         || notificationType.equals(NON_EMPLOYMENT)) {
       return 84;
     } else {
@@ -304,7 +304,7 @@ public class PlacementService {
 
       // PLACEMENT_USEFUL_INFORMATION
       createUniqueInAppNotification(placement, notificationsAlreadySent,
-          PLACEMENT_USEFUL_INFORMATION, placementUsefulInfoVersion, Map.of(
+          USEFUL_INFORMATION, placementUsefulInfoVersion, Map.of(
               LOCAL_OFFICE_CONTACT_FIELD, localOfficeContact,
               LOCAL_OFFICE_CONTACT_TYPE_FIELD, localOfficeContactType));
 

--- a/src/main/resources/templates/in-app/placement-useful-information/v1.0.0.html
+++ b/src/main/resources/templates/in-app/placement-useful-information/v1.0.0.html
@@ -43,7 +43,8 @@
     <li>Taking time out of programme (OOP)</li>
     <li>Working less than full time (LTFT)</li>
     <li><a
-      href="https://www.hee.nhs.uk/our-work/supporting-doctors-returning-training-after-time-out">
+      href="https://www.hee.nhs.uk/our-work/supporting-doctors-returning-training-after-time-out"
+      target="_blank">
       Supported Return to Training (SuppoRTT)</a></li>
     <li>Concerns or complaints</li>
     <li>Specialty specific guidance</li>

--- a/src/main/resources/templates/in-app/placement-useful-information/v1.0.0.html
+++ b/src/main/resources/templates/in-app/placement-useful-information/v1.0.0.html
@@ -2,12 +2,12 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-  <title>Useful information</title>
+  <title>Placement Useful information</title>
 </head>
 <body>
 <h1>In-App Notification</h1>
 <h2>Subject</h2>
-<th:block th:fragment="subject">Useful Information</th:block>
+<th:block th:fragment="subject">Placement Useful Information</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
   <p>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -41,7 +41,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.NON_EMPLOYMENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_INFORMATION;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
-import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_USEFUL_INFORMATION;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.USEFUL_INFORMATION;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTACT_TYPE_FIELD;
@@ -504,8 +504,8 @@ class PlacementServiceTest {
       PLACEMENT_INFORMATION | v1.2.3 | false
       NON_EMPLOYMENT | v2.3.4 | true
       NON_EMPLOYMENT | v2.3.4 | false
-      PLACEMENT_USEFUL_INFORMATION | v3.4.5 | true
-      PLACEMENT_USEFUL_INFORMATION | v3.4.5 | false""")
+      USEFUL_INFORMATION | v3.4.5 | true
+      USEFUL_INFORMATION | v3.4.5 | false""")
   void shouldAddInAppNotificationsWhenNotExcludedAndMeetsCriteria(NotificationType notificationType,
       String notificationVersion, boolean notifiable) throws SchedulerException {
     Placement placement = new Placement();
@@ -589,7 +589,7 @@ class PlacementServiceTest {
         eq(PLACEMENT_INFO_VERSION), variablesCaptor.capture(), anyBoolean(), any());
     verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(NON_EMPLOYMENT),
         eq(NON_EMPLOYMENT_VERSION), variablesCaptor.capture(), anyBoolean(), any());
-    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(PLACEMENT_USEFUL_INFORMATION),
+    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(USEFUL_INFORMATION),
         eq(PLACEMENT_USEFUL_INFO_VERSION), variablesCaptor.capture(), anyBoolean(), any());
 
     Map<String, Object> variables = variablesCaptor.getValue();
@@ -625,7 +625,7 @@ class PlacementServiceTest {
 
   @ParameterizedTest
   @EnumSource(value = NotificationType.class, mode = EnumSource.Mode.INCLUDE,
-      names = {"PLACEMENT_INFORMATION", "PLACEMENT_USEFUL_INFORMATION", "NON_EMPLOYMENT"})
+      names = {"PLACEMENT_INFORMATION", "USEFUL_INFORMATION", "NON_EMPLOYMENT"})
   void shouldNotAddInAppNotificationsWhenPastSentHistoryExist(NotificationType notificationType)
       throws SchedulerException {
     Placement placement = new Placement();
@@ -656,7 +656,7 @@ class PlacementServiceTest {
 
   @ParameterizedTest
   @EnumSource(value = NotificationType.class, mode = EnumSource.Mode.INCLUDE,
-      names = {"PLACEMENT_INFORMATION", "PLACEMENT_USEFUL_INFORMATION", "NON_EMPLOYMENT"})
+      names = {"PLACEMENT_INFORMATION", "USEFUL_INFORMATION", "NON_EMPLOYMENT"})
   void shouldAddInAppNotificationsWhenNoPastSentHistoryWithSameRefType(
       NotificationType notificationType)
       throws SchedulerException {


### PR DESCRIPTION
the template name was too long to fit within the bounds of the notification when displayed on the FE, name has been shortened from PLACEMENT_USEFUL_INFORMATION to USEFUL_INFORMATION & update a link in the template to open in a new tab instead of navigating away from TSS

NOT_TICKET