### PR TITLE
fix: quartz clustering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.25.3"
+version = "1.25.4"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/PlacementListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/PlacementListener.java
@@ -22,8 +22,6 @@
 package uk.nhs.tis.trainee.notifications.event;
 
 import io.awspring.cloud.sqs.annotation.SqsListener;
-import java.time.LocalDate;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
 import org.springframework.stereotype.Component;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -114,6 +114,12 @@ spring:
       initialize-schema: never
     jobStore:
       useProperties: true
+    properties:
+      org.quartz:
+        scheduler:
+          instanceId: AUTO
+        jobStore:
+          isClustered: true
 
 service:
   trainee:


### PR DESCRIPTION
Configure quartz for clusting, setting `instanceId=AUTO` allows Quartz to generate unique instance IDs.

NO-TICKET