### PR TITLE
fix: meaningful subject for mailto link

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.25.5"
+version = "1.25.6"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/UserAccountListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/UserAccountListener.java
@@ -56,6 +56,12 @@ public class UserAccountListener {
   private final String emailUpdatedOldVersion;
   private final String welcomeVersion;
 
+  /**
+   * Construct a listener for user account events.
+   *
+   * @param emailService The email service.
+   * @param inAppService The in-app service.
+   */
   public UserAccountListener(EmailService emailService, InAppService inAppService,
       UserAccountService userAccountService, @Value("${application.domain}") URI appDomain,
       @Value("${application.template-versions.email-updated-new.email}")

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/ProgrammeMembership.java
@@ -36,6 +36,7 @@ public class ProgrammeMembership {
   private String tisId;
   private String personId;
   private String programmeName;
+  private String programmeNumber;
   private String managingDeanery;
   private LocalDate startDate;
   private List<Curriculum> curricula = new ArrayList<>();

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -405,7 +405,7 @@ public class NotificationService implements Job {
    * @param personId The person ID to search for.
    * @return The user trainee profile details, or null if not found.
    */
-  private UserDetails getTraineeDetails(String personId) {
+  public UserDetails getTraineeDetails(String personId) {
     try {
       return restTemplate.getForObject(serviceUrl + API_TRAINEE_DETAILS, UserDetails.class,
           Map.of(TIS_ID_FIELD, personId));

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -48,6 +48,7 @@ import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
@@ -68,6 +69,7 @@ public class PlacementService {
   public static final String PLACEMENT_SITE_FIELD = "site";
   public static final String LOCAL_OFFICE_CONTACT_FIELD = "localOfficeContact";
   public static final String LOCAL_OFFICE_CONTACT_TYPE_FIELD = "localOfficeContactType";
+  public static final String GMC_NUMBER_FIELD = "gmcNumber";
 
   public static final List<String> PLACEMENT_TYPES_TO_ACT_ON
       = List.of("In post", "In post - Acting up", "In Post - Extension");
@@ -290,29 +292,36 @@ public class PlacementService {
     if (meetsCriteria) {
       String owner = placement.getOwner();
       List<Map<String, String>> contactList = notificationService.getOwnerContactList(owner);
-
       String localOfficeContact = notificationService.getOwnerContact(contactList,
           LocalOfficeContactType.TSS_SUPPORT, null);
       String localOfficeContactType =
           notificationService.getHrefTypeForContact(localOfficeContact);
 
+      UserDetails userTraineeDetails = notificationService.getTraineeDetails(
+          placement.getPersonId());
+      String gmcNumber = (userTraineeDetails != null && userTraineeDetails.gmcNumber() != null)
+          ? userTraineeDetails.gmcNumber().trim() : "unknown";
+
       // PLACEMENT_INFORMATION
       createUniqueInAppNotification(placement, notificationsAlreadySent, PLACEMENT_INFORMATION,
           placementInfoVersion, Map.of(
               LOCAL_OFFICE_CONTACT_FIELD, localOfficeContact,
-              LOCAL_OFFICE_CONTACT_TYPE_FIELD, localOfficeContactType));
+              LOCAL_OFFICE_CONTACT_TYPE_FIELD, localOfficeContactType,
+              GMC_NUMBER_FIELD, gmcNumber));
 
       // PLACEMENT_USEFUL_INFORMATION
       createUniqueInAppNotification(placement, notificationsAlreadySent,
           USEFUL_INFORMATION, placementUsefulInfoVersion, Map.of(
               LOCAL_OFFICE_CONTACT_FIELD, localOfficeContact,
-              LOCAL_OFFICE_CONTACT_TYPE_FIELD, localOfficeContactType));
+              LOCAL_OFFICE_CONTACT_TYPE_FIELD, localOfficeContactType,
+              GMC_NUMBER_FIELD, gmcNumber));
 
       // NON_EMPLOYMENT
       createUniqueInAppNotification(placement, notificationsAlreadySent, NON_EMPLOYMENT,
           nonEmploymentVersion, Map.of(
               LOCAL_OFFICE_CONTACT_FIELD, localOfficeContact,
-              LOCAL_OFFICE_CONTACT_TYPE_FIELD, localOfficeContactType));
+              LOCAL_OFFICE_CONTACT_TYPE_FIELD, localOfficeContactType,
+              GMC_NUMBER_FIELD, gmcNumber));
     }
   }
 

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
@@ -44,7 +44,7 @@
   <p>
     If your email address is likely to change, or you need support creating an account on TIS Self-Service then please contact us via <th:block th:switch="${contactHref}"
     ><span th:case="url"><a th:href="${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
-    ><span th:case="email"><a th:href="|mailto:${localOfficeContact}?subject=Notification of Placement - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Start Date: ${#temporals.format(startDate, 'dd/MM/yyyy')}|"><span th:text="${localOfficeContact}"></span></a></span
+    ><span th:case="email"><a id="loMail" th:href="|mailto:${localOfficeContact}?subject=Notification of Placement - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Start Date: ${#temporals.format(startDate, 'dd/MM/yyyy')}|"><span th:text="${localOfficeContact}"></span></a></span
     ><span th:case="*"><span th:text="${localOfficeContact}"></span></span
     ></th:block> or see our <a href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/">FAQ</a> for details.
   </p>

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
@@ -44,7 +44,7 @@
   <p>
     If your email address is likely to change, or you need support creating an account on TIS Self-Service then please contact us via <th:block th:switch="${contactHref}"
     ><span th:case="url"><a th:href="${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
-    ><span th:case="email"><a th:href="'mailto:' + ${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
+    ><span th:case="email"><a th:href="|mailto:${localOfficeContact}?subject=Notification of Placement - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Start Date: ${#temporals.format(startDate, 'dd/MM/yyyy')}|"><span th:text="${localOfficeContact}"></span></a></span
     ><span th:case="*"><span th:text="${localOfficeContact}"></span></span
     ></th:block> or see our <a href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/">FAQ</a> for details.
   </p>

--- a/src/main/resources/templates/email/programme-created/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-created/v1.0.0.html
@@ -59,7 +59,7 @@
       <li th:case="false">According to our records, you do not currently have a TIS Self-Service account. Please create one by visiting <a href="https://trainee.tis.nhs.uk/">TIS Self-Service</a>. Please ensure you create an account using the email address we have against our records: <b><span th:text="${email}"></span></b>.</li></th:block>
     <li>If your email address is likely to change, or you need support signing up on TIS Self-Service, then contact us via <th:block th:switch="${contactHref}"
     ><span th:case="url"><a th:href="${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
-    ><span th:case="email"><a th:href="|mailto:${localOfficeContact}?subject=Onboarding to Programme - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Prog No: ${not #strings.isEmpty(programmeNumber) ? programmeNumber : 'unknown'}|"><span th:text="${localOfficeContact}"></span></a></span
+    ><span th:case="email"><a id="loMail" th:href="|mailto:${localOfficeContact}?subject=Onboarding to Programme - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Prog No: ${not #strings.isEmpty(programmeNumber) ? programmeNumber : 'unknown'}|"><span th:text="${localOfficeContact}"></span></a></span
     ><span th:case="*"><span th:text="${localOfficeContact}"></span></span
     ></th:block> or see our <a href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/">FAQ</a> for details.</li>
     <li>Once you access TIS Self-Service, you will be presented with a set of actions and notifications to read relating to your training programme. Please complete the actions and read the notification as requested.</li>

--- a/src/main/resources/templates/email/programme-created/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-created/v1.0.0.html
@@ -59,7 +59,7 @@
       <li th:case="false">According to our records, you do not currently have a TIS Self-Service account. Please create one by visiting <a href="https://trainee.tis.nhs.uk/">TIS Self-Service</a>. Please ensure you create an account using the email address we have against our records: <b><span th:text="${email}"></span></b>.</li></th:block>
     <li>If your email address is likely to change, or you need support signing up on TIS Self-Service, then contact us via <th:block th:switch="${contactHref}"
     ><span th:case="url"><a th:href="${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
-    ><span th:case="email"><a th:href="'mailto:' + ${localOfficeContact}"><span th:text="${localOfficeContact}"></span></a></span
+    ><span th:case="email"><a th:href="|mailto:${localOfficeContact}?subject=Onboarding to Programme - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Prog No: ${not #strings.isEmpty(programmeNumber) ? programmeNumber : 'unknown'}|"><span th:text="${localOfficeContact}"></span></a></span
     ><span th:case="*"><span th:text="${localOfficeContact}"></span></span
     ></th:block> or see our <a href="https://tis-support.hee.nhs.uk/trainees/changes-to-account/">FAQ</a> for details.</li>
     <li>Once you access TIS Self-Service, you will be presented with a set of actions and notifications to read relating to your training programme. Please complete the actions and read the notification as requested.</li>

--- a/src/main/resources/templates/in-app/deferral/v1.0.0.html
+++ b/src/main/resources/templates/in-app/deferral/v1.0.0.html
@@ -36,7 +36,9 @@
            <th:block th:case="*"
              >Please click on the following link for details on the Deferral process.
              <a
-               th:href="${localOfficeContactType} == 'email' ? |mailto:${localOfficeContact}| : ${localOfficeContact}"
+               th:href="${localOfficeContactType} == 'email' ?
+               |mailto:${localOfficeContact}?subject=Deferral - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Prog No: ${not #strings.isEmpty(programmeNumber) ? programmeNumber : 'unknown'}|
+               : ${localOfficeContact}"
                th:text="${localOfficeContact}"
                th:target="_blank"
              ></a

--- a/src/main/resources/templates/in-app/less-than-full-time/v1.0.0.html
+++ b/src/main/resources/templates/in-app/less-than-full-time/v1.0.0.html
@@ -35,7 +35,9 @@
           <th:block th:case="*"
             >Please click on the following link for details on application process.
             <a
-              th:href="${localOfficeContactType} == 'email' ? |mailto:${localOfficeContact}| : ${localOfficeContact}"
+              th:href="${localOfficeContactType} == 'email' ?
+              |mailto:${localOfficeContact}?subject=Less Than Full Time - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Prog No: ${not #strings.isEmpty(programmeNumber) ? programmeNumber : 'unknown'}|
+              : ${localOfficeContact}"
               th:text="${localOfficeContact}"
               th:target="_blank"
             ></a

--- a/src/main/resources/templates/in-app/non-employment/v1.0.0.html
+++ b/src/main/resources/templates/in-app/non-employment/v1.0.0.html
@@ -97,7 +97,9 @@
           <th:block th:case="*"
           > please contact your
             <a
-              th:href="${localOfficeContactType} == 'email' ? |mailto:${localOfficeContact}| : ${localOfficeContact}"
+              th:href="${localOfficeContactType} == 'email' ?
+              |mailto:${localOfficeContact}?subject=Placement Confirmation Does Not Constitute An Offer Of Employment - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Start Date: ${#temporals.format(startDate, 'dd/MM/yyyy')}|
+              : ${localOfficeContact}"
               th:target="_blank"
             >NHS England local office</a
             >.</th:block>

--- a/src/main/resources/templates/in-app/placement-information/v1.0.0.html
+++ b/src/main/resources/templates/in-app/placement-information/v1.0.0.html
@@ -41,7 +41,9 @@
           <th:block th:case="*"
           > please contact your
             <a
-              th:href="${localOfficeContactType} == 'email' ? |mailto:${localOfficeContact}| : ${localOfficeContact}"
+              th:href="${localOfficeContactType} == 'email' ?
+              |mailto:${localOfficeContact}?subject=Placement Information - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Start Date: ${#temporals.format(startDate, 'dd/MM/yyyy')}|
+              : ${localOfficeContact}"
               th:target="_blank"
             >NHS England local office</a
             >.</th:block>

--- a/src/main/resources/templates/in-app/placement-useful-information/v1.0.0.html
+++ b/src/main/resources/templates/in-app/placement-useful-information/v1.0.0.html
@@ -33,7 +33,9 @@
     >
     <th:block th:case="*"
     ><a
-      th:href="${localOfficeContactType} == 'email' ? |mailto:${localOfficeContact}| : ${localOfficeContact}"
+      th:href="${localOfficeContactType} == 'email' ?
+      |mailto:${localOfficeContact}?subject=Placement Useful Information - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Start Date: ${#temporals.format(startDate, 'dd/MM/yyyy')}|
+      : ${localOfficeContact}"
       th:target="_blank"
     >NHS England local office</a
     >.</th:block>

--- a/src/main/resources/templates/in-app/sponsorship/v1.0.0.html
+++ b/src/main/resources/templates/in-app/sponsorship/v1.0.0.html
@@ -34,7 +34,9 @@
           <th:block th:case="*"
           > please click on the following link for information on Sponsorship.
             <a
-              th:href="${localOfficeContactType} == 'email' ? |mailto:${localOfficeContact}| : ${localOfficeContact}"
+              th:href="${localOfficeContactType} == 'email' ?
+              |mailto:${localOfficeContact}?subject=Sponsorship - GMC: ${not #strings.isEmpty(gmcNumber) ? gmcNumber : 'unknown'}, Prog No: ${not #strings.isEmpty(programmeNumber) ? programmeNumber : 'unknown'}|
+              : ${localOfficeContact}"
               th:text="${localOfficeContact}"
               th:target="_blank"
             ></a

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -27,9 +27,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_CONTACT_HREF_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.START_DATE_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.GMC_NUMBER_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NUMBER_FIELD;
 
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -37,6 +45,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -59,7 +68,10 @@ class EmailServiceIntegrationTest {
   private static final String USER_ID = UUID.randomUUID().toString();
   private static final String RECIPIENT = "test@tis.nhs.uk";
   private static final String GMC = "111111";
-  private static final String API = "the-url/api/trainee-profile/account-details/{tisId}";
+  private static final String TEMPLATE_VERSION = "v1.0.0";
+  private static final String PROGRAM_NO = "SW111";
+  private static final LocalDate PLACEMENT_START_DATE = LocalDate.now();
+
 
   @MockBean
   private JavaMailSender mailSender;
@@ -155,7 +167,7 @@ class EmailServiceIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
     Element body = content.body();
 
-    if (notificationType.equals(NotificationType.PLACEMENT_UPDATED_WEEK_12)) {
+    if (notificationType.equals(PLACEMENT_UPDATED_WEEK_12)) {
       Element greeting = body.children().get(getGreetingElementIndex(notificationType));
       assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
       assertThat("Unexpected greeting.", greeting.text(), is("Dear Dr Anthony Gilliam,"));
@@ -184,7 +196,7 @@ class EmailServiceIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
     Element body = content.body();
 
-    if (notificationType.equals(NotificationType.PLACEMENT_UPDATED_WEEK_12)) {
+    if (notificationType.equals(PLACEMENT_UPDATED_WEEK_12)) {
       Element greeting = body.children().get(getGreetingElementIndex(notificationType));
       assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
       assertThat("Unexpected greeting.", greeting.text(), is("Dear Dr Anthony Maillig,"));
@@ -204,7 +216,7 @@ class EmailServiceIntegrationTest {
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, "Gilliam", "Anthony", null));
 
-    service.sendMessageToExistingUser(PERSON_ID, NotificationType.PLACEMENT_UPDATED_WEEK_12,
+    service.sendMessageToExistingUser(PERSON_ID, PLACEMENT_UPDATED_WEEK_12,
         templateVersion, Map.of("familyName", "Maillig", "gmcNumber", gmc), null);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
@@ -228,7 +240,7 @@ class EmailServiceIntegrationTest {
     when(userAccountService.getUserDetails(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, "Gilliam", "Anthony", null));
 
-    service.sendMessageToExistingUser(PERSON_ID, NotificationType.PLACEMENT_UPDATED_WEEK_12,
+    service.sendMessageToExistingUser(PERSON_ID, PLACEMENT_UPDATED_WEEK_12,
         templateVersion, Map.of("familyName", "Maillig", "gmcNumber", gmc), null);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
@@ -241,6 +253,109 @@ class EmailServiceIntegrationTest {
     Element survey = body.children().get(19);
     assertThat("Unexpected survey segment.",
         survey.text().contains("Did you find this email useful?"), is(false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED"})
+  void shouldIncludeGmcInMailtoSubjectWhenGmcAvailable(NotificationType notificationType)
+      throws Exception {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, GMC));
+
+    service.sendMessageToExistingUser(PERSON_ID, notificationType, TEMPLATE_VERSION,
+        Map.of(TEMPLATE_CONTACT_HREF_FIELD, "email", GMC_NUMBER_FIELD, GMC), null);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    String mailTo = body.getElementById("loMail").attributes().get("href");
+    assertThat("Unexpected gmc.", mailTo.contains("GMC: " + GMC), is(true));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED"})
+  void shouldIncludeUnknownGmcInMailtoSubjectWhenGmcIsMissing(NotificationType notificationType)
+      throws Exception {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, null));
+
+    service.sendMessageToExistingUser(PERSON_ID, notificationType, TEMPLATE_VERSION,
+        Map.of(TEMPLATE_CONTACT_HREF_FIELD, "email"), null);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    String mailTo = body.getElementById("loMail").attributes().get("href");
+    assertThat("Unexpected gmc.", mailTo.contains("GMC: unknown"), is(true));
+  }
+
+  @Test
+  void shouldIncludeProgNoInMailtoSubjectWhenProgNoAvailable() throws Exception {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, GMC));
+
+    service.sendMessageToExistingUser(PERSON_ID, PROGRAMME_CREATED, TEMPLATE_VERSION,
+        Map.of(TEMPLATE_CONTACT_HREF_FIELD, "email", PROGRAMME_NUMBER_FIELD, PROGRAM_NO), null);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    String mailTo = body.getElementById("loMail").attributes().get("href");
+    assertThat("Unexpected programme number.", mailTo.contains("Prog No: " + PROGRAM_NO), is(true));
+  }
+
+  @Test
+  void shouldIncludeUnknownProgNoInMailtoSubjectWhenProgNoIsMissing() throws Exception {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, GMC));
+
+    service.sendMessageToExistingUser(PERSON_ID, PROGRAMME_CREATED, TEMPLATE_VERSION,
+        Map.of(TEMPLATE_CONTACT_HREF_FIELD, "email"), null);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    String mailTo = body.getElementById("loMail").attributes().get("href");
+    assertThat("Unexpected programme number.", mailTo.contains("Prog No: unknown"), is(true));
+  }
+
+  @Test
+  void shouldIncludeStartDateInMailtoSubjectWhenStartDateAvailable() throws Exception {
+    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, GMC));
+
+    service.sendMessageToExistingUser(PERSON_ID, PLACEMENT_UPDATED_WEEK_12, TEMPLATE_VERSION,
+        Map.of(TEMPLATE_CONTACT_HREF_FIELD, "email", START_DATE_FIELD, PLACEMENT_START_DATE), null);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    String expectedStartDate = PLACEMENT_START_DATE.format(formatter);
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    String mailTo = body.getElementById("loMail").attributes().get("href");
+    assertThat("Unexpected start date.", mailTo.contains("Start Date: " + expectedStartDate),
+        is(true));
   }
 
   int getGreetingElementIndex(NotificationType notificationType) {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -1116,4 +1116,34 @@ class NotificationServiceTest {
 
     assertThat("Unexpected validate GMC result.", isValidGmc, is(false));
   }
+
+  @Test
+  void shouldGetTraineeDetails() {
+    UserDetails userAccountDetails =
+        new UserDetails(
+            null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
+
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+
+    UserDetails result = service.getTraineeDetails(PERSON_ID);
+
+    assertThat("Unexpected email.", result.email(), is(userAccountDetails.email()));
+    assertThat("Unexpected title.", result.title(), is(userAccountDetails.title()));
+    assertThat("Unexpected family name.", result.familyName(),
+        is(userAccountDetails.familyName()));
+    assertThat("Unexpected given name.", result.givenName(),
+        is(userAccountDetails.givenName()));
+    assertThat("Unexpected gmc.", result.gmcNumber(), is(userAccountDetails.gmcNumber()));
+  }
+
+  @Test
+  void shouldReturnNullWhenRestClientExceptionsInGetTraineeDetails() {
+    when(restTemplate.getForObject(any(), any(), anyMap()))
+        .thenThrow(new RestClientException("error"));
+
+    UserDetails result = service.getTraineeDetails(PERSON_ID);
+
+    assertThat("Unexpected result.", result, is(nullValue()));
+  }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -75,7 +75,6 @@ import org.mockito.ArgumentCaptor;
 import org.quartz.JobDataMap;
 import org.quartz.SchedulerException;
 import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
-import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
 import uk.nhs.tis.trainee.notifications.model.History;
@@ -752,6 +751,7 @@ class ProgrammeMembershipServiceTest {
     programmeMembership.setTisId(TIS_ID);
     programmeMembership.setPersonId(PERSON_ID);
     programmeMembership.setProgrammeName(PROGRAMME_NAME);
+    programmeMembership.setProgrammeNumber(PROGRAMME_NUMBER);
     programmeMembership.setStartDate(START_DATE);
     programmeMembership.setCurricula(List.of(theCurriculum));
     programmeMembership.setConditionsOfJoining(new ConditionsOfJoining(Instant.MIN));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -45,12 +45,14 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.SPONSORSHI
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTACT_TYPE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.PlacementService.GMC_NUMBER_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.BLOCK_INDEMNITY_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.COJ_SYNCED_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.DEFERRAL_IF_MORE_THAN_DAYS;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.LOCAL_OFFICE_CONTACT_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.LOCAL_OFFICE_CONTACT_TYPE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NAME_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NUMBER_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.START_DATE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.TIS_ID_FIELD;
 
@@ -73,6 +75,8 @@ import org.mockito.ArgumentCaptor;
 import org.quartz.JobDataMap;
 import org.quartz.SchedulerException;
 import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
@@ -95,6 +99,7 @@ class ProgrammeMembershipServiceTest {
   private static final String TIS_ID = "123";
   private static final String PERSON_ID = "abc";
   private static final String PROGRAMME_NAME = "the programme";
+  private static final String PROGRAMME_NUMBER = "the programme number";
   private static final String MANAGING_DEANERY = "the local office";
   private static final LocalDate START_DATE = LocalDate.now().plusYears(1);
   //set a year in the future to allow all notifications to be scheduled
@@ -107,6 +112,11 @@ class ProgrammeMembershipServiceTest {
   private static final String LTFT_VERSION = "v3.4.5";
   private static final String DEFERRAL_VERSION = "v4.5.6";
   private static final String SPONSORSHIP_VERSION = "v5.6.7";
+  private static final String USER_EMAIL = "email@address";
+  private static final String USER_TITLE = "title";
+  private static final String USER_FAMILY_NAME = "family-name";
+  private static final String USER_GIVEN_NAME = "given-name";
+  private static final String USER_GMC = "111111";
 
   ProgrammeMembershipService service;
   HistoryService historyService;
@@ -259,12 +269,17 @@ class ProgrammeMembershipServiceTest {
       String notificationVersion, boolean notifiablePm) throws SchedulerException {
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
 
+    UserDetails userAccountDetails =
+        new UserDetails(
+            null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
+
     when(notificationService.meetsCriteria(programmeMembership, true,
         true)).thenReturn(true);
     when(notificationService.programmeMembershipIsNotifiable(programmeMembership,
         MessageType.IN_APP)).thenReturn(notifiablePm);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
+    when(notificationService.getTraineeDetails(PERSON_ID)).thenReturn(userAccountDetails);
 
     service.addNotifications(programmeMembership);
 
@@ -283,7 +298,13 @@ class ProgrammeMembershipServiceTest {
     Map<String, Object> variables = variablesCaptor.getValue();
     assertThat("Unexpected programme name.", variables.get(PROGRAMME_NAME_FIELD),
         is(PROGRAMME_NAME));
+    assertThat("Unexpected programme number.", variables.get(PROGRAMME_NUMBER_FIELD),
+        is(PROGRAMME_NUMBER));
     assertThat("Unexpected start date.", variables.get(START_DATE_FIELD), is(START_DATE));
+    if (notificationType.equals(LTFT) || notificationType.equals(DEFERRAL)
+        || notificationType.equals(SPONSORSHIP)) {
+      assertThat("Unexpected GMC number.", variables.get(GMC_NUMBER_FIELD), is(USER_GMC));
+    }
 
     Boolean doNotStoreJustLog = doNotStoreJustLogCaptor.getValue();
     assertThat("Unexpected doNotStoreJustLog value.", doNotStoreJustLog, is(!notifiablePm));
@@ -311,7 +332,7 @@ class ProgrammeMembershipServiceTest {
         eq(INDEMNITY_INSURANCE_VERSION), variablesCaptor.capture(), anyBoolean());
 
     Map<String, Object> variables = variablesCaptor.getValue();
-    assertThat("Unexpected variable count.", variables.size(), is(3));
+    assertThat("Unexpected variable count.", variables.size(), is(4));
     assertThat("Unexpected programme name.", variables.get(PROGRAMME_NAME_FIELD),
         is(PROGRAMME_NAME));
     assertThat("Unexpected start date.", variables.get(START_DATE_FIELD), is(START_DATE));
@@ -333,6 +354,7 @@ class ProgrammeMembershipServiceTest {
     when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
+    when(notificationService.getTraineeDetails(PERSON_ID)).thenReturn(null);
 
     service.addNotifications(programmeMembership);
 
@@ -404,7 +426,7 @@ class ProgrammeMembershipServiceTest {
         eq(SPONSORSHIP_VERSION), variablesCaptor.capture(), anyBoolean());
 
     Map<String, Object> variables = variablesCaptor.getValue();
-    assertThat("Unexpected variable count.", variables.size(), is(4));
+    assertThat("Unexpected variable count.", variables.size(), is(6));
     assertThat("Unexpected programme name.", variables.get(PROGRAMME_NAME_FIELD),
         is(PROGRAMME_NAME));
     assertThat("Unexpected start date.", variables.get(START_DATE_FIELD), is(START_DATE));
@@ -412,6 +434,77 @@ class ProgrammeMembershipServiceTest {
         is(contact));
     assertThat("Unexpected local office contact type.",
         variables.get(LOCAL_OFFICE_CONTACT_TYPE_FIELD), is(contactType.getHrefTypeName()));
+  }
+
+  @Test
+  void shouldAddUnknownGmcInInAppNotificationWhenTraineeDetailsNull()
+      throws SchedulerException {
+    Curriculum theCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "any specialty", true);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(TIS_ID);
+    programmeMembership.setPersonId(PERSON_ID);
+    programmeMembership.setProgrammeName(PROGRAMME_NAME);
+    programmeMembership.setStartDate(START_DATE);
+    programmeMembership.setCurricula(List.of(theCurriculum));
+    programmeMembership.setConditionsOfJoining(new ConditionsOfJoining(Instant.MIN));
+    programmeMembership.setManagingDeanery(MANAGING_DEANERY);
+
+    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+
+    when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
+    when(notificationService.getHrefTypeForContact(any())).thenReturn("");
+    when(notificationService.getTraineeDetails(PERSON_ID)).thenReturn(null);
+
+    service.addNotifications(programmeMembership);
+
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
+    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(LTFT),
+        eq(LTFT_VERSION), variablesCaptor.capture(), anyBoolean());
+    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(DEFERRAL),
+        eq(DEFERRAL_VERSION), variablesCaptor.capture(), anyBoolean());
+    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(SPONSORSHIP),
+        eq(SPONSORSHIP_VERSION), variablesCaptor.capture(), anyBoolean());
+
+    Map<String, Object> variables = variablesCaptor.getValue();
+    assertThat("Unexpected GMC number.", variables.get(GMC_NUMBER_FIELD), is("unknown"));
+  }
+
+  @Test
+  void shouldAddUnknownGmcInInAppNotificationWhenMissingGmcInTraineeDetails()
+      throws SchedulerException {
+    Curriculum theCurriculum = new Curriculum(MEDICAL_CURRICULUM_1, "any specialty", true);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(TIS_ID);
+    programmeMembership.setPersonId(PERSON_ID);
+    programmeMembership.setProgrammeName(PROGRAMME_NAME);
+    programmeMembership.setStartDate(START_DATE);
+    programmeMembership.setCurricula(List.of(theCurriculum));
+    programmeMembership.setConditionsOfJoining(new ConditionsOfJoining(Instant.MIN));
+    programmeMembership.setManagingDeanery(MANAGING_DEANERY);
+
+    UserDetails userAccountDetails =
+        new UserDetails(
+            null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, null);
+
+    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+
+    when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
+    when(notificationService.getHrefTypeForContact(any())).thenReturn("");
+    when(notificationService.getTraineeDetails(PERSON_ID)).thenReturn(null);
+    when(notificationService.getTraineeDetails(PERSON_ID)).thenReturn(userAccountDetails);
+
+    service.addNotifications(programmeMembership);
+
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
+    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(LTFT),
+        eq(LTFT_VERSION), variablesCaptor.capture(), anyBoolean());
+    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(DEFERRAL),
+        eq(DEFERRAL_VERSION), variablesCaptor.capture(), anyBoolean());
+    verify(inAppService).createNotifications(eq(PERSON_ID), any(), eq(SPONSORSHIP),
+        eq(SPONSORSHIP_VERSION), variablesCaptor.capture(), anyBoolean());
+
+    Map<String, Object> variables = variablesCaptor.getValue();
+    assertThat("Unexpected GMC number.", variables.get(GMC_NUMBER_FIELD), is("unknown"));
   }
 
   @Test


### PR DESCRIPTION
Adding meaningful subject to the "mailto" link.

**Programme notifications:**
eg. Normal subject text - GMC: 1234567, Prog No: ABC1234

**Placement notifications:**
eg. Normal subject text - GMC: 1234567, Start Date: 00/00/0000

**If the data is missing, it will appear as "unknown":**
eg. Normal subject text - GMC: unknown, Start Date: unknown

TIS21-5893
TIS21-5930
TIS21-5931
TIS21-5932