### PR TITLE
feat: new getAllHistoryForTrainee method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.25.4"
+version = "1.25.5"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -169,6 +169,16 @@ public class HistoryService {
   }
 
   /**
+   * Find all historic notifications for the given Trainee as full history items.
+   *
+   * @param traineeId The ID of the trainee to get notifications for.
+   * @return The found notifications, empty if none found.
+   */
+  public List<History> findAllHistoryForTrainee(String traineeId) {
+    return repository.findAllByRecipient_IdOrderBySentAtDesc(traineeId);
+  }
+
+  /**
    * Find all sent historic notifications for the given Trainee.
    *
    * @param traineeId The ID of the trainee to get notifications for.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -32,9 +32,9 @@ import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSO
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_NOTIFICATION_TYPE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_OWNER_FIELD;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,8 +47,8 @@ import org.quartz.JobDataMap;
 import org.quartz.SchedulerException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
+import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
@@ -70,6 +70,7 @@ public class ProgrammeMembershipService {
   public static final String LOCAL_OFFICE_CONTACT_FIELD = "localOfficeContact";
   public static final String LOCAL_OFFICE_CONTACT_TYPE_FIELD = "localOfficeContactType";
   public static final String COJ_SYNCED_FIELD = "conditionsOfJoiningSyncedAt";
+  public static final Integer DEFERRAL_IF_MORE_THAN_DAYS = 89;
 
   private static final List<String> INCLUDE_CURRICULUM_SUBTYPES
       = List.of("MEDICAL_CURRICULUM", "MEDICAL_SPR");
@@ -156,35 +157,32 @@ public class ProgrammeMembershipService {
   }
 
   /**
-   * Get a map of notification types and the instant they were sent for a given trainee and
+   * Get a map of notification types and the most recent one that was sent for a given trainee and
    * programme membership from the notification history.
    *
    * @param traineeId             The trainee TIS ID.
    * @param programmeMembershipId The programme membership TIS ID.
-   * @return The map of notification types and when they were sent.
+   * @return The map of notification types and the notification item most recently sent.
    */
-  private Map<NotificationType, Instant> getNotificationsSent(String traineeId,
+  private Map<NotificationType, History> getLatestNotificationsSent(String traineeId,
       String programmeMembershipId) {
-    EnumMap<NotificationType, Instant> notifications = new EnumMap<>(NotificationType.class);
-    List<HistoryDto> correspondence = historyService.findAllForTrainee(traineeId);
+    EnumMap<NotificationType, History> notifications = new EnumMap<>(NotificationType.class);
+    List<History> correspondence = historyService.findAllHistoryForTrainee(traineeId);
 
     Set<NotificationType> notificationTypes = new HashSet<>(
         NotificationType.getProgrammeUpdateNotificationTypes());
-    notificationTypes.add(DEFERRAL);
-    notificationTypes.add(E_PORTFOLIO);
-    notificationTypes.add(INDEMNITY_INSURANCE);
-    notificationTypes.add(LTFT);
+
     notificationTypes.add(SPONSORSHIP);
 
     for (NotificationType milestone : notificationTypes) {
-      Optional<HistoryDto> sentItem = correspondence.stream()
+      Optional<History> sentItem = correspondence.stream()
           .filter(c -> c.tisReference() != null)
           .filter(c ->
               c.tisReference().type().equals(TisReferenceType.PROGRAMME_MEMBERSHIP)
-                  && c.subject().equals(milestone)
+                  && c.type().equals(milestone)
                   && c.tisReference().id().equals(programmeMembershipId))
-          .findFirst();
-      sentItem.ifPresent(historyDto -> notifications.put(milestone, historyDto.sentAt()));
+          .max(Comparator.comparing(History::sentAt)); //get most recent sent
+      sentItem.ifPresent(history -> notifications.put(milestone, history));
     }
     return notifications;
   }
@@ -204,8 +202,9 @@ public class ProgrammeMembershipService {
     log.info("Programme membership {}: excluded {}.", programmeMembership.getTisId(), isExcluded);
 
     if (!isExcluded) {
-      Map<NotificationType, Instant> notificationsAlreadySent
-          = getNotificationsSent(programmeMembership.getPersonId(), programmeMembership.getTisId());
+      Map<NotificationType, History> notificationsAlreadySent
+          = getLatestNotificationsSent(programmeMembership.getPersonId(),
+          programmeMembership.getTisId());
 
       createDirectNotifications(programmeMembership, notificationsAlreadySent);
       createInAppNotifications(programmeMembership, notificationsAlreadySent);
@@ -219,13 +218,15 @@ public class ProgrammeMembershipService {
    * @param notificationsAlreadySent Previously sent notifications.
    */
   private void createDirectNotifications(ProgrammeMembership programmeMembership,
-      Map<NotificationType, Instant> notificationsAlreadySent) {
+      Map<NotificationType, History> notificationsAlreadySent) {
 
-    NotificationType milestone = PROGRAMME_CREATED; //do not handle other programme notifications
-    boolean shouldSchedule = shouldScheduleNotification(milestone, notificationsAlreadySent);
+    //only handle 'programme created' notifications
+    boolean shouldSchedule
+        = shouldScheduleProgrammeCreatedNotification(programmeMembership, notificationsAlreadySent);
 
     if (shouldSchedule) {
-      log.info("Processing notification {} for {}.", milestone, programmeMembership.getTisId());
+      log.info("Processing notification {} for {}.", PROGRAMME_CREATED,
+          programmeMembership.getTisId());
 
       JobDataMap jobDataMap = new JobDataMap();
       jobDataMap.put(TIS_ID_FIELD, programmeMembership.getTisId());
@@ -233,7 +234,7 @@ public class ProgrammeMembershipService {
       jobDataMap.put(PROGRAMME_NAME_FIELD, programmeMembership.getProgrammeName());
       jobDataMap.put(START_DATE_FIELD, programmeMembership.getStartDate());
       jobDataMap.put(TEMPLATE_OWNER_FIELD, programmeMembership.getManagingDeanery());
-      jobDataMap.put(TEMPLATE_NOTIFICATION_TYPE_FIELD, milestone);
+      jobDataMap.put(TEMPLATE_NOTIFICATION_TYPE_FIELD, PROGRAMME_CREATED);
       if (programmeMembership.getConditionsOfJoining() != null) {
         jobDataMap.put(COJ_SYNCED_FIELD,
             programmeMembership.getConditionsOfJoining().syncedAt());
@@ -241,7 +242,7 @@ public class ProgrammeMembershipService {
       // Note the status of the trainee will be retrieved when the job is executed, as will
       // their name and email address and LO contact details.
 
-      String jobId = milestone + "-" + programmeMembership.getTisId();
+      String jobId = PROGRAMME_CREATED + "-" + programmeMembership.getTisId();
       notificationService.executeNow(jobId, jobDataMap);
     }
   }
@@ -253,7 +254,7 @@ public class ProgrammeMembershipService {
    * @param notificationsAlreadySent Previously sent notifications.
    */
   private void createInAppNotifications(ProgrammeMembership programmeMembership,
-      Map<NotificationType, Instant> notificationsAlreadySent) {
+      Map<NotificationType, History> notificationsAlreadySent) {
     // Create ePortfolio notification if the PM qualifies.
     boolean meetsCriteria = notificationService.meetsCriteria(programmeMembership, true, true);
 
@@ -315,7 +316,7 @@ public class ProgrammeMembershipService {
    *                                 and Start Date are populated automatically.
    */
   private void createUniqueInAppNotification(ProgrammeMembership programmeMembership,
-      Map<NotificationType, Instant> notificationsAlreadySent, NotificationType notificationType,
+      Map<NotificationType, History> notificationsAlreadySent, NotificationType notificationType,
       String notificationVersion, Map<String, Object> extraVariables) {
     boolean isUnique = !notificationsAlreadySent.containsKey(notificationType);
 
@@ -352,20 +353,26 @@ public class ProgrammeMembershipService {
   }
 
   /**
-   * Helper function to determine whether a notification should be scheduled.
+   * Helper function to determine whether a programme created notification should be scheduled.
    *
-   * @param milestone                The milestone to consider.
+   * @param programmeMembership      The updated programme membership to consider.
    * @param notificationsAlreadySent The notifications already sent for this entity.
    * @return true if it should be scheduled, false otherwise.
    */
-  private boolean shouldScheduleNotification(NotificationType milestone,
-      Map<NotificationType, Instant> notificationsAlreadySent) {
+  private boolean shouldScheduleProgrammeCreatedNotification(
+      ProgrammeMembership programmeMembership,
+      Map<NotificationType, History> notificationsAlreadySent) {
 
-    //do not resend any notification
-    if (notificationsAlreadySent.containsKey(milestone)) {
+    //only resend deferred programme notifications
+    if (notificationsAlreadySent.containsKey(PROGRAMME_CREATED)) {
       return false;
+//      TODO: to be implemented with the actual scheduling in next PR
+//      History lastSent = notificationsAlreadySent.get(PROGRAMME_CREATED);
+//      LocalDate oldStartDate = getProgrammeCreatedProgrammeStartDate(lastSent);
+//      return oldStartDate != null && oldStartDate.plusDays(DEFERRAL_IF_MORE_THAN_DAYS)
+//          .isBefore(programmeMembership.getStartDate());
     }
 
-    return milestone == PROGRAMME_CREATED; //immediately notify of a new programme membership
+    return true; //immediately notify of a new programme membership
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -171,7 +171,10 @@ public class ProgrammeMembershipService {
 
     Set<NotificationType> notificationTypes = new HashSet<>(
         NotificationType.getProgrammeUpdateNotificationTypes());
-
+    notificationTypes.add(DEFERRAL);
+    notificationTypes.add(E_PORTFOLIO);
+    notificationTypes.add(INDEMNITY_INSURANCE);
+    notificationTypes.add(LTFT);
     notificationTypes.add(SPONSORSHIP);
 
     for (NotificationType milestone : notificationTypes) {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -196,6 +196,84 @@ class HistoryServiceIntegrationTest {
   }
 
   @Test
+  void shouldNotFindNotificationsHistoryWhenTraineeIdNotMatches() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
+        templateInfo, SENT_AT, READ_AT, SENT, null, null);
+    service.save(history);
+
+    List<History> foundHistory = service.findAllHistoryForTrainee("notFound");
+
+    assertThat("Unexpected history count.", foundHistory.size(), is(0));
+  }
+
+  @Test
+  void shouldFindNotificationsHistoryWhenTraineeIdMatches() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
+        templateInfo, SENT_AT, READ_AT, SENT, null, null);
+    History savedHistory = service.save(history);
+
+    List<History> foundHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", foundHistory.size(), is(1));
+
+    History historyReceived = foundHistory.get(0);
+    assertThat("Unexpected history id.", historyReceived.id(), is(savedHistory.id()));
+    assertThat("Unexpected history type.", historyReceived.type(), is(FORM_UPDATED));
+    RecipientInfo recipientInfoReceived = historyReceived.recipient();
+    assertThat("Unexpected history recipient type.", recipientInfoReceived.type(),
+        is(EMAIL));
+    assertThat("Unexpected history recipient contact.", recipientInfoReceived.contact(),
+        is(TRAINEE_CONTACT));
+    assertThat("Unexpected history recipient id.", recipientInfoReceived.id(),
+        is(TRAINEE_ID));
+    assertThat("Unexpected history sent at.", historyReceived.sentAt(), is(SENT_AT));
+    assertThat("Unexpected history read at.", historyReceived.readAt(), is(READ_AT));
+  }
+
+  @Test
+  void shouldSortFoundNotificationsHistoryBySentAtWhenMultipleFound() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
+        now, now, SENT, null, null));
+
+    Instant before = SENT_AT.minus(Duration.ofDays(1));
+    Instant after = SENT_AT.plus(Duration.ofDays(1));
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
+        before, after, SENT, null, null));
+
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
+        after, before, SENT, null, null));
+
+    List<History> foundHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", foundHistory.size(), is(3));
+
+    History history1 = foundHistory.get(0);
+    assertThat("Unexpected history sent at.", history1.sentAt(), is(after));
+
+    History history2 = foundHistory.get(1);
+    assertThat("Unexpected history sent at.", history2.sentAt(), is(now));
+
+    History history3 = foundHistory.get(2);
+    assertThat("Unexpected history sent at.", history3.sentAt(), is(before));
+  }
+
+  @Test
   void shouldSortFoundSentNotificationsBySentAtWhenMultipleFound() {
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
     TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -368,7 +368,7 @@ class HistoryServiceTest {
   }
 
   @Test
-  void shouldFindNoHistoryForTraineeWhenNotificationsNotExist() {
+  void shouldFindNoHistoryDtoForTraineeWhenNotificationsNotExist() {
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(List.of());
 
     List<HistoryDto> historyDtos = service.findAllForTrainee(TRAINEE_ID);
@@ -378,7 +378,7 @@ class HistoryServiceTest {
 
   @ParameterizedTest
   @MethodSource("uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getTemplateCombinations")
-  void shouldFindHistoryForTraineeWhenNotificationsExist(MessageType messageType,
+  void shouldFindHistoryDtosForTraineeWhenNotificationsExist(MessageType messageType,
       NotificationType notificationType) {
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, messageType, TRAINEE_CONTACT);
     TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
@@ -404,7 +404,7 @@ class HistoryServiceTest {
 
     HistoryDto historyDto1 = historyDtos.get(0);
     assertThat("Unexpected history id.", historyDto1.id(), is(id1.toString()));
-    TisReferenceInfo referenceInfo = historyDtos.get(0).tisReference();
+    TisReferenceInfo referenceInfo = historyDto1.tisReference();
     assertThat("Unexpected history TIS reference type.", referenceInfo.type(),
         is(TIS_REFERENCE_TYPE));
     assertThat("Unexpected history TIS reference id.", referenceInfo.id(),
@@ -417,7 +417,7 @@ class HistoryServiceTest {
 
     HistoryDto historyDto2 = historyDtos.get(1);
     assertThat("Unexpected history id.", historyDto2.id(), is(id2.toString()));
-    TisReferenceInfo referenceInfo2 = historyDtos.get(0).tisReference();
+    TisReferenceInfo referenceInfo2 = historyDto2.tisReference();
     assertThat("Unexpected history TIS reference type.", referenceInfo2.type(),
         is(TIS_REFERENCE_TYPE));
     assertThat("Unexpected history TIS reference id.", referenceInfo2.id(),
@@ -427,6 +427,69 @@ class HistoryServiceTest {
     assertThat("Unexpected history contact.", historyDto2.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected history sent at.", historyDto2.sentAt(), is(Instant.MAX));
     assertThat("Unexpected history read at.", historyDto2.readAt(), is(Instant.MIN));
+  }
+
+  @ParameterizedTest
+  @MethodSource("uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getTemplateCombinations")
+  void shouldFindHistoryForTraineeWhenNotificationsExist(MessageType messageType,
+      NotificationType notificationType) {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, messageType, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id1 = ObjectId.get();
+    History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
+        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+
+    ObjectId id2 = ObjectId.get();
+    History history2 = new History(id2, tisReferenceInfo, notificationType, recipientInfo,
+        templateInfo, Instant.MAX, Instant.MIN, SENT, null, null);
+
+    when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
+        List.of(history1, history2));
+
+    when(templateService.process(any(), any(), anyMap())).thenReturn("");
+
+    List<History> histories = service.findAllHistoryForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", histories.size(), is(2));
+
+    History historyReceived1 = histories.get(0);
+    assertThat("Unexpected history id.", historyReceived1.id(), is(id1));
+    TisReferenceInfo referenceInfo = historyReceived1.tisReference();
+    assertThat("Unexpected history TIS reference type.", referenceInfo.type(),
+        is(TIS_REFERENCE_TYPE));
+    assertThat("Unexpected history TIS reference id.", referenceInfo.id(),
+        is(TIS_REFERENCE_ID));
+    assertThat("Unexpected history type.", historyReceived1.type(), is(notificationType));
+    RecipientInfo recipientInfoReceived = historyReceived1.recipient();
+    assertThat("Unexpected history recipient type.", recipientInfoReceived.type(),
+        is(messageType));
+    assertThat("Unexpected history recipient contact.", recipientInfoReceived.contact(),
+        is(TRAINEE_CONTACT));
+    assertThat("Unexpected history recipient id.", recipientInfoReceived.id(),
+        is(TRAINEE_ID));
+    assertThat("Unexpected history sent at.", historyReceived1.sentAt(), is(Instant.MIN));
+    assertThat("Unexpected history read at.", historyReceived1.readAt(), is(Instant.MAX));
+
+    History historyReceived2 = histories.get(1);
+    assertThat("Unexpected history id.", historyReceived2.id(), is(id2));
+    TisReferenceInfo referenceInfo2 = historyReceived2.tisReference();
+    assertThat("Unexpected history TIS reference type.", referenceInfo2.type(),
+        is(TIS_REFERENCE_TYPE));
+    assertThat("Unexpected history TIS reference id.", referenceInfo2.id(),
+        is(TIS_REFERENCE_ID));
+    assertThat("Unexpected history type.", historyReceived2.type(), is(notificationType));
+    RecipientInfo recipientInfoReceived2 = historyReceived2.recipient();
+    assertThat("Unexpected history recipient type.", recipientInfoReceived2.type(),
+        is(messageType));
+    assertThat("Unexpected history recipient contact.", recipientInfoReceived2.contact(),
+        is(TRAINEE_CONTACT));
+    assertThat("Unexpected history recipient id.", recipientInfoReceived2.id(),
+        is(TRAINEE_ID));
+    assertThat("Unexpected history sent at.", historyReceived2.sentAt(), is(Instant.MAX));
+    assertThat("Unexpected history read at.", historyReceived2.readAt(), is(Instant.MIN));
   }
 
   @Test


### PR DESCRIPTION
And some refactoring of programme membership service tests.

To make it easier to review,
https://github.com/Health-Education-England/tis-trainee-notifications/pull/167 is being split up. This is the first part.

And here is the second part: https://github.com/Health-Education-England/tis-trainee-notifications/pull/170

TIS21-5991