### PR TITLE
fix: read mongo Dates as LocalDates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.25.6"
+version = "1.25.7"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfiguration.java
@@ -31,6 +31,9 @@ import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.tis.trainee.notifications.model.History;
 
+/**
+ * Custom configuration for Mongo collections.
+ */
 @Configuration
 @Order()
 @Slf4j

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import uk.nhs.tis.trainee.notifications.model.History;
+
+@Configuration
+@Order()
+@Slf4j
+public class MongoCollectionConfiguration {
+
+  private final MongoTemplate template;
+
+  MongoCollectionConfiguration(MongoTemplate template) {
+    this.template = template;
+  }
+
+  /**
+   * Add custom indexes to the Mongo collections.
+   */
+  @PostConstruct
+  public void initIndexes() {
+    IndexOperations indexOps = template.indexOps(History.class);
+    indexOps.ensureIndex(new Index().on("recipient.id", Direction.ASC));
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.Jsr310Converters;
 import org.springframework.data.convert.ReadingConverter;
-import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -43,6 +42,13 @@ import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 @Slf4j
 public class MongoConfiguration {
 
+  /**
+   * Mongo template with custom converter.
+   *
+   * @param dbFactory The Mongo Database Factory to use.
+   * @param mongoConverter The Mapping Mongo Converter to use.
+   * @return the Mongo template.
+   */
   @Bean
   public MongoTemplate mongoTemplate(MongoDatabaseFactory dbFactory,
       MappingMongoConverter mongoConverter) {
@@ -56,11 +62,19 @@ public class MongoConfiguration {
     return new MongoTemplate(dbFactory, mongoConverter);
   }
 
+  /**
+   * Map dates to LocalDate when the target is an Object.
+   */
   @ReadingConverter
   public static class DateToObjectConverter implements Converter<Date, Object> {
 
     public static final DateToObjectConverter INSTANCE = new DateToObjectConverter();
 
+    /**
+     * Convert a Date to an Object of type LocalDate.
+     * @param source the source object to convert, which must be an instance of {@code S} (never {@code null})
+     * @return The LocalDate Object if it can be converted, otherwise null or the source Date.
+     */
     public Object convert(Date source) {
       if (source == null) {
         return null;

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/MongoConfiguration.java
@@ -72,7 +72,9 @@ public class MongoConfiguration {
 
     /**
      * Convert a Date to an Object of type LocalDate.
-     * @param source the source object to convert, which must be an instance of {@code S} (never {@code null})
+     *
+     * @param source the source object to convert, which must be an instance of {@code S}
+     *               (never {@code null})
      * @return The LocalDate Object if it can be converted, otherwise null or the source Date.
      */
     public Object convert(Date source) {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
@@ -32,6 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
+import uk.nhs.tis.trainee.notifications.config.MongoCollectionConfiguration;
 import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
 
 @SpringBootTest
@@ -39,7 +40,7 @@ import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
 class TisTraineeNotificationsApplicationTest {
 
   @MockBean
-  private MongoConfiguration mongoConfiguration;
+  private MongoCollectionConfiguration mongoConfiguration;
 
   @MockBean
   private QuartzAutoConfiguration quartzConfiguration;
@@ -52,7 +53,7 @@ class TisTraineeNotificationsApplicationTest {
 
   @Test
   void contextLoads() {
-    assertThat("Unexpected bean.", context.getBean(MongoConfiguration.class),
+    assertThat("Unexpected bean.", context.getBean(MongoCollectionConfiguration.class),
         is(mongoConfiguration));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
@@ -33,7 +33,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import uk.nhs.tis.trainee.notifications.config.MongoCollectionConfiguration;
-import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/DateToObjectConverterTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/DateToObjectConverterTest.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.tis.trainee.notifications.config.MongoConfiguration.DateToObjectConverter;
+
+class DateToObjectConverterTest {
+
+  private DateToObjectConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new DateToObjectConverter();
+  }
+
+
+  @Test
+  void shouldConvertToLocalDateWhenDateIsNotNull() {
+    Instant now = Instant.now();
+    Date date = Date.from(now);
+
+    Object convertedDate = converter.convert(date);
+
+    assertThat("Unexpected converted type.", convertedDate, instanceOf(LocalDate.class));
+
+    LocalDate localDate = (LocalDate) convertedDate;
+    assertThat("Unexpected local date.", localDate,
+        is(LocalDate.from(now.atZone(ZoneId.of("UTC")))));
+  }
+
+  @Test
+  void shouldConvertToNullWhenDateIsNull() {
+    Object convertedDate = converter.convert(null);
+
+    assertThat("Unexpected converted type.", convertedDate, nullValue());
+  }
+
+  @Test
+  void shouldConvertToMinimumLocalDateWhenDateIsMinimum() {
+    Date date = new Date(Long.MIN_VALUE);
+
+    Object convertedDate = converter.convert(date);
+
+    assertThat("Unexpected converted type.", convertedDate, instanceOf(LocalDate.class));
+
+    LocalDate localDate = (LocalDate) convertedDate;
+    assertThat("Unexpected local date.", localDate, is(LocalDate.MIN));
+  }
+
+  @Test
+  void shouldConvertToMaximumLocalDateWhenDateIsMaximum() {
+    Date date = new Date(Long.MAX_VALUE);
+
+    Object convertedDate = converter.convert(date);
+
+    assertThat("Unexpected converted type.", convertedDate, instanceOf(LocalDate.class));
+
+    LocalDate localDate = (LocalDate) convertedDate;
+    assertThat("Unexpected local date.", localDate, is(LocalDate.MAX));
+  }
+
+  @Test
+  void shouldReturnOriginalDateWhenCanNotGetTime() {
+    Date date = mock(Date.class);
+    when(date.getTime()).thenThrow(RuntimeException.class);
+
+    Object convertedDate = converter.convert(date);
+
+    assertThat("Unexpected converted type.", convertedDate, instanceOf(Date.class));
+    assertThat("Unexpected date instance.", convertedDate, sameInstance(date));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfigurationTest.java
@@ -39,16 +39,16 @@ import org.springframework.data.mongodb.core.index.IndexDefinition;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.tis.trainee.notifications.model.History;
 
-class MongoConfigurationTest {
+class MongoCollectionConfigurationTest {
 
-  private MongoConfiguration configuration;
+  private MongoCollectionConfiguration configuration;
 
   private MongoTemplate template;
 
   @BeforeEach
   void setUp() {
     template = mock(MongoTemplate.class);
-    configuration = new MongoConfiguration(template);
+    configuration = new MongoCollectionConfiguration(template);
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfigurationTest.java
@@ -66,7 +66,7 @@ class MongoCollectionConfigurationTest {
 
     List<String> indexKeys = indexes.stream()
         .flatMap(i -> i.getIndexKeys().keySet().stream())
-        .collect(Collectors.toList());
+            .toList();
     assertThat("Unexpected number of index keys.", indexKeys.size(), is(1));
     assertThat("Unexpected index.", indexKeys, hasItems("recipient.id"));
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoCollectionConfigurationTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationIntegrationTest.java
@@ -49,7 +49,7 @@ import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
 @ActiveProfiles({"mongodb", "test"})
 @Testcontainers(disabledWithoutDocker = true)
 @DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
-class MongoConfigurationTest {
+class MongoConfigurationIntegrationTest {
 
   private MongoConfiguration configuration;
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
@@ -23,6 +23,7 @@ package uk.nhs.tis.trainee.notifications.config;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
@@ -30,6 +31,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 import java.sql.Date;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.Map;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,7 +85,8 @@ class MongoConfigurationTest {
   @Test
   void shouldRetrieveNullDateAsNullWhenTargetIsObject() {
     ObjectId objectId = ObjectId.get();
-    Map<String, Object> variables = Map.of("date", null);
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("date", null);
     TemplateInfo templateInfo = new TemplateInfo(null, null, variables);
     History history = new History(objectId, null, null, null, templateInfo, null,
         null, null, null, null);
@@ -94,7 +97,7 @@ class MongoConfigurationTest {
 
     assert savedHistory != null;
     Map<String, Object> savedVariables = savedHistory.template().variables();
-    assertThat(savedVariables.get("date"), isNull());
+    assertThat(savedVariables.get("date"), is(nullValue()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
 
 import java.sql.Date;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+
+@SpringBootTest(properties = {"embedded.containers.enabled=true", "embedded.mongodb.enabled=true"})
+@ActiveProfiles({"mongodb", "test"})
+@Testcontainers(disabledWithoutDocker = true)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+class MongoConfigurationTest {
+
+  private MongoConfiguration configuration;
+
+  @Autowired
+  private MongoTemplate template;
+
+  @Autowired
+  private MappingMongoConverter mongoConverter;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new MongoConfiguration();
+  }
+
+  @Test
+  void shouldRetrieveDateAsLocalDateWhenTargetIsObject() {
+    ObjectId objectId = ObjectId.get();
+    Map<String, Object> variables = Map.of("date", Date.from(Instant.now()));
+    TemplateInfo templateInfo = new TemplateInfo(null, null, variables);
+    History history = new History(objectId, null, null, null, templateInfo, null,
+        null, null, null, null);
+
+    template.save(history);
+
+    History savedHistory = template.findById(objectId, History.class);
+
+    assert savedHistory != null;
+    Map<String, Object> savedVariables = savedHistory.template().variables();
+    assertThat(savedVariables.get("date"), instanceOf(LocalDate.class));
+  }
+
+  @Test
+  void shouldRetrieveNullDateAsNullWhenTargetIsObject() {
+    ObjectId objectId = ObjectId.get();
+    Map<String, Object> variables = Map.of("date", null);
+    TemplateInfo templateInfo = new TemplateInfo(null, null, variables);
+    History history = new History(objectId, null, null, null, templateInfo, null,
+        null, null, null, null);
+
+    template.save(history);
+
+    History savedHistory = template.findById(objectId, History.class);
+
+    assert savedHistory != null;
+    Map<String, Object> savedVariables = savedHistory.template().variables();
+    assertThat(savedVariables.get("date"), isNull());
+  }
+
+  @Test
+  void shouldRetrieveMinimumDateAsMinimumLocalDateWhenTargetIsObject() {
+    ObjectId objectId = ObjectId.get();
+    Map<String, Object> variables = Map.of("date", new Date(Long.MIN_VALUE));
+    TemplateInfo templateInfo = new TemplateInfo(null, null, variables);
+    History history = new History(objectId, null, null, null, templateInfo, null,
+        null, null, null, null);
+
+    template.save(history);
+
+    History savedHistory = template.findById(objectId, History.class);
+
+    assert savedHistory != null;
+    Map<String, Object> savedVariables = savedHistory.template().variables();
+    assertThat(savedVariables.get("date"), is(LocalDate.MIN));
+  }
+
+  @Test
+  void shouldRetrieveMaximumDateAsMaximumLocalDateWhenTargetIsObject() {
+    ObjectId objectId = ObjectId.get();
+    Map<String, Object> variables = Map.of("date", new Date(Long.MAX_VALUE));
+    TemplateInfo templateInfo = new TemplateInfo(null, null, variables);
+    History history = new History(objectId, null, null, null, templateInfo, null,
+        null, null, null, null);
+
+    template.save(history);
+
+    History savedHistory = template.findById(objectId, History.class);
+
+    assert savedHistory != null;
+    Map<String, Object> savedVariables = savedHistory.template().variables();
+    assertThat(savedVariables.get("date"), is(LocalDate.MAX));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/repository/FlywayMigrationsTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/repository/FlywayMigrationsTest.java
@@ -31,7 +31,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
+import uk.nhs.tis.trainee.notifications.config.MongoCollectionConfiguration;
 
 @SpringBootTest(properties = {"embedded.containers.enabled=true", "embedded.mysql.enabled=true"})
 @ActiveProfiles({"test", "mysql"})
@@ -39,7 +39,7 @@ import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
 class FlywayMigrationsTest implements TestExecutionListener {
 
   @MockBean
-  private MongoConfiguration mongoConfiguration;
+  private MongoCollectionConfiguration mongoConfiguration;
 
   @Autowired
   Flyway flyway;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
@@ -52,7 +52,7 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeTy
 import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
 import software.amazon.awssdk.services.cognitoidentityprovider.paginators.ListUsersIterable;
-import uk.nhs.tis.trainee.notifications.config.MongoConfiguration;
+import uk.nhs.tis.trainee.notifications.config.MongoCollectionConfiguration;
 
 @SpringBootTest(properties = {"embedded.containers.enabled=true", "embedded.redis.enabled=true"})
 @ActiveProfiles({"redis", "test"})
@@ -68,7 +68,7 @@ class UserAccountServiceIntegrationTest {
   private static final String ATTRIBUTE_USER_ID = "sub";
 
   @MockBean
-  private MongoConfiguration mongoConfiguration;
+  private MongoCollectionConfiguration mongoConfiguration;
 
   @MockBean
   private CognitoIdentityProviderClient cognitoClient;


### PR DESCRIPTION
...if the target field is an Object.

This feels like it exposes us to unintended consequences if a true Date is held in the template variables, when it would be converted to a LocalDate, so I'm not sure if it really resolves the original 'gotcha' :/

NO-TICKET