### PR TITLE
fix: get user details without increasing MAU

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.26.1"
+version = "1.26.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/UserAccountListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/UserAccountListener.java
@@ -99,7 +99,7 @@ public class UserAccountListener {
     UUID userId = event.userId();
     log.info("Handling account update event for user {}.", userId);
 
-    UserDetails userDetails = userAccountService.getUserDetails(userId.toString());
+    UserDetails userDetails = userAccountService.getUserDetailsById(userId.toString());
 
     Map<String, Object> newEmailVariables = new HashMap<>();
     newEmailVariables.put("familyName", userDetails.familyName());

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -245,7 +245,7 @@ public class EmailService {
    * @throws UserNotFoundException if the user account could not be found.
    */
   public UserDetails getRecipientAccountByEmail(String email) throws UserNotFoundException {
-    return userAccountService.getUserDetails(email);
+    return userAccountService.getUserDetailsByEmail(email);
   }
 
   /**
@@ -259,7 +259,7 @@ public class EmailService {
 
     return switch (userAccountIds.size()) {
       case 0 -> throw new IllegalArgumentException("No user account found for the given ID.");
-      case 1 -> userAccountService.getUserDetails(userAccountIds.iterator().next());
+      case 1 -> userAccountService.getUserDetailsById(userAccountIds.iterator().next());
       default ->
           throw new IllegalArgumentException("Multiple user accounts found for the given ID.");
     };

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -121,7 +121,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
       throws Exception {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, missingValue, missingValue, GMC));
 
     // Spy on the email service and inject a missing domain.
@@ -167,7 +167,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
   void shouldSendFullyTailoredCojConfirmationWhenAllTemplateVariablesAvailable() throws Exception {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(SYNCED_AT));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -207,7 +207,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
   void shouldSendCojConfirmationWithTailoredNameWhenAvailable() throws Exception {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -243,7 +243,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
   void shouldSendCojConfirmationWithTailoredLocalOfficeWhenAvailable() throws Exception {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -281,7 +281,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
   void shouldSendCojConfirmationWithTailoredSyncedAtWhenAvailable() throws Exception {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(SYNCED_AT));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -319,7 +319,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
   void shouldSendCojConfirmationWithTailoredDomainWhenAvailable() throws Exception {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(null));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);
@@ -355,7 +355,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
   void shouldStoreCojReceivedNotificationHistoryWhenMessageSent() throws MessagingException {
     CojSignedEvent event = new CojSignedEvent(PERSON_ID,
         new ConditionsOfJoining(SYNCED_AT));
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleConditionsOfJoiningReceived(event);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
@@ -126,7 +126,7 @@ class CredentialListenerIntegrationTest {
   void shouldSendDefaultRevocationNoticeWhenTemplateVariablesNotAvailable(String missingValue)
       throws Exception {
     CredentialEvent event = new CredentialEvent(null, missingValue, null, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, missingValue, missingValue, GMC));
 
     // Spy on the email service and inject a missing domain.
@@ -171,7 +171,7 @@ class CredentialListenerIntegrationTest {
   @Test
   void shouldSendFullyTailoredRevocationNoticeWhenAllTemplateVariablesAvailable() throws Exception {
     CredentialEvent event = new CredentialEvent(null, CREDENTIAL_TYPE, ISSUED_AT, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleCredentialRevoked(event);
@@ -212,7 +212,7 @@ class CredentialListenerIntegrationTest {
   @Test
   void shouldSendRevocationNoticeWithTailoredNameWhenAvailable() throws Exception {
     CredentialEvent event = new CredentialEvent(null, null, null, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleCredentialRevoked(event);
@@ -250,7 +250,7 @@ class CredentialListenerIntegrationTest {
   void shouldSendRevocationNoticeWithTailoredCredentialTypeWhenAvailable(String credentialType)
       throws Exception {
     CredentialEvent event = new CredentialEvent(null, credentialType, null, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleCredentialRevoked(event);
@@ -290,7 +290,7 @@ class CredentialListenerIntegrationTest {
   @Test
   void shouldSendRevocationNoticeWithTailoredIssuedAtWhenAvailable() throws Exception {
     CredentialEvent event = new CredentialEvent(null, null, ISSUED_AT, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleCredentialRevoked(event);
@@ -328,7 +328,7 @@ class CredentialListenerIntegrationTest {
   @Test
   void shouldSendRevocationNoticeWithTailoredDomainWhenAvailable() throws Exception {
     CredentialEvent event = new CredentialEvent(null, null, null, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleCredentialRevoked(event);
@@ -364,7 +364,7 @@ class CredentialListenerIntegrationTest {
   @Test
   void shouldSendRevocationNoticeTailoredForTrainingPlacement() throws Exception {
     CredentialEvent event = new CredentialEvent(null, "Training Placement", null, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleCredentialRevoked(event);
@@ -392,7 +392,7 @@ class CredentialListenerIntegrationTest {
   @Test
   void shouldSendRevocationNoticeTailoredForTrainingProgramme() throws Exception {
     CredentialEvent event = new CredentialEvent(null, "Training Programme", null, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
     listener.handleCredentialRevoked(event);
@@ -420,7 +420,7 @@ class CredentialListenerIntegrationTest {
   @Test
   void shouldStoreCredentialRevokedNotificationHistoryWhenMessageSent() throws MessagingException {
     CredentialEvent event = new CredentialEvent(null, CREDENTIAL_TYPE, ISSUED_AT, TRAINEE_ID);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleCredentialRevoked(event);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
@@ -129,7 +129,7 @@ class FormListenerIntegrationTest {
     FormUpdateEvent event = new FormUpdateEvent(missingValue, missingValue, PERSON_ID,
         missingValue, null, FORM_CONTENT);
 
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, missingValue, missingValue, GMC));
 
     // Spy on the email service and inject a missing domain.
@@ -175,7 +175,7 @@ class FormListenerIntegrationTest {
       throws Exception {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_SUBMITTED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);
@@ -219,7 +219,7 @@ class FormListenerIntegrationTest {
       throws Exception {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_UNSUBMITTED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);
@@ -263,7 +263,7 @@ class FormListenerIntegrationTest {
       throws Exception {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_DELETED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);
@@ -304,7 +304,7 @@ class FormListenerIntegrationTest {
   void shouldStoreFormUpdatedNotificationHistoryWhenMessageSent() throws MessagingException {
     FormUpdateEvent event = new FormUpdateEvent(FORM_NAME, FORM_SUBMITTED, PERSON_ID,
         FORM_TYPE, FORM_UPDATED_AT, FORM_CONTENT);
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
     listener.handleFormUpdate(event);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/UserAccountListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/UserAccountListenerTest.java
@@ -91,7 +91,7 @@ class UserAccountListenerTest {
   @ValueSource(strings = {"EMAIL_UPDATED_OLD", "EMAIL_UPDATED_NEW"})
   void shouldThrowExceptionWhenEmailUpdateNotificationFails(NotificationType notificationType)
       throws MessagingException {
-    when(userAccountService.getUserDetails(USER_ID.toString())).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID.toString())).thenReturn(
         UserDetails.builder().build());
 
     doThrow(MessagingException.class).when(emailService)
@@ -106,7 +106,7 @@ class UserAccountListenerTest {
     UserDetails userDetails = UserDetails.builder()
         .familyName(FAMILY_NAME)
         .build();
-    when(userAccountService.getUserDetails(USER_ID.toString())).thenReturn(userDetails);
+    when(userAccountService.getUserDetailsById(USER_ID.toString())).thenReturn(userDetails);
 
     AccountUpdatedEvent event = new AccountUpdatedEvent(USER_ID, TRAINEE_ID, EMAIL_OLD, EMAIL);
     listener.handleAccountUpdate(event);
@@ -128,7 +128,7 @@ class UserAccountListenerTest {
     UserDetails userDetails = UserDetails.builder()
         .familyName(FAMILY_NAME)
         .build();
-    when(userAccountService.getUserDetails(USER_ID.toString())).thenReturn(userDetails);
+    when(userAccountService.getUserDetailsById(USER_ID.toString())).thenReturn(userDetails);
 
     AccountUpdatedEvent event = new AccountUpdatedEvent(USER_ID, TRAINEE_ID, EMAIL_OLD, EMAIL);
     listener.handleAccountUpdate(event);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -99,7 +99,7 @@ class EmailServiceIntegrationTest {
       "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getEmailTemplateTypeAndVersions")
   void shouldIncludeSubjectInTemplates(NotificationType notificationType, String templateVersion)
       throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, null));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
@@ -116,7 +116,7 @@ class EmailServiceIntegrationTest {
       "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getEmailTemplateTypeAndVersions")
   void shouldIncludeContentInTemplates(NotificationType notificationType, String templateVersion)
       throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, null));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
@@ -133,7 +133,7 @@ class EmailServiceIntegrationTest {
       "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getEmailTemplateTypeAndVersions")
   void shouldGreetExistingUsersConsistentlyWhenNameNotAvailable(NotificationType notificationType,
       String templateVersion) throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, null));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
@@ -155,7 +155,7 @@ class EmailServiceIntegrationTest {
       "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getEmailTemplateTypeAndVersions")
   void shouldGreetExistingUsersConsistentlyWhenNameAvailable(NotificationType notificationType,
       String templateVersion) throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, "Gilliam", "Anthony", null));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion, Map.of(), null);
@@ -183,7 +183,7 @@ class EmailServiceIntegrationTest {
       "uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getEmailTemplateTypeAndVersions")
   void shouldGreetExistingUsersConsistentlyWhenNameProvided(NotificationType notificationType,
       String templateVersion) throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, "Gilliam", "Anthony", null));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, templateVersion,
@@ -213,7 +213,7 @@ class EmailServiceIntegrationTest {
       throws Exception {
     //version is fixed, since a different test will inevitably be needed for later revisions
     String templateVersion = "v1.0.0";
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, "Gilliam", "Anthony", null));
 
     service.sendMessageToExistingUser(PERSON_ID, PLACEMENT_UPDATED_WEEK_12,
@@ -237,7 +237,7 @@ class EmailServiceIntegrationTest {
       throws Exception {
     //version is fixed, since a different test will inevitably be needed for later revisions
     String templateVersion = "v1.0.0";
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, "Gilliam", "Anthony", null));
 
     service.sendMessageToExistingUser(PERSON_ID, PLACEMENT_UPDATED_WEEK_12,
@@ -259,7 +259,7 @@ class EmailServiceIntegrationTest {
   @ValueSource(strings = {"PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED"})
   void shouldIncludeGmcInMailtoSubjectWhenGmcAvailable(NotificationType notificationType)
       throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, GMC));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, TEMPLATE_VERSION,
@@ -280,7 +280,7 @@ class EmailServiceIntegrationTest {
   @ValueSource(strings = {"PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED"})
   void shouldIncludeUnknownGmcInMailtoSubjectWhenGmcIsEmpty(NotificationType notificationType)
       throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, GMC));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, TEMPLATE_VERSION,
@@ -301,7 +301,7 @@ class EmailServiceIntegrationTest {
   @ValueSource(strings = {"PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED"})
   void shouldIncludeUnknownGmcInMailtoSubjectWhenGmcIsMissing(NotificationType notificationType)
       throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, null));
 
     service.sendMessageToExistingUser(PERSON_ID, notificationType, TEMPLATE_VERSION,
@@ -320,7 +320,7 @@ class EmailServiceIntegrationTest {
 
   @Test
   void shouldIncludeProgNoInMailtoSubjectWhenProgNoAvailable() throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, GMC));
 
     service.sendMessageToExistingUser(PERSON_ID, PROGRAMME_CREATED, TEMPLATE_VERSION,
@@ -339,7 +339,7 @@ class EmailServiceIntegrationTest {
 
   @Test
   void shouldIncludeUnknownProgNoInMailtoSubjectWhenProgNoIsMissing() throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, GMC));
 
     service.sendMessageToExistingUser(PERSON_ID, PROGRAMME_CREATED, TEMPLATE_VERSION,
@@ -358,7 +358,7 @@ class EmailServiceIntegrationTest {
 
   @Test
   void shouldIncludeStartDateInMailtoSubjectWhenStartDateAvailable() throws Exception {
-    when(userAccountService.getUserDetails(USER_ID)).thenReturn(
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, null, null, null, GMC));
 
     service.sendMessageToExistingUser(PERSON_ID, PLACEMENT_UPDATED_WEEK_12, TEMPLATE_VERSION,


### PR DESCRIPTION
Cognito is charged based on monthly active users, this is usually a fairly low number and within free limits. However, it was found that the usage of `AdminGetUser` causes the requested account to be marked as active for that month.
After reloading all placement/PM data to trigger notification generation, that resulted in 66k active users. Most of which were not actually active.

Update the UserAccountService to use a filtered `listUsers` request instead of the `AdminGetUser` request. The only difference between the results is some minor structure changes and some MFA attributes not being included in `listUsers`. For our case both of these differences are acceptable.
The `sub` and `email` are both unique, so there is no need to handle multiple results.

TIS21-6103
TIS21-6104