### PR TITLE
fix: handle empty user collection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.26.2"
+version = "1.26.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/UserAccountService.java
@@ -163,7 +163,7 @@ public class UserAccountService {
   private UserDetails getUserDetails(ListUsersRequest request) {
     ListUsersResponse response = cognitoClient.listUsers(request);
 
-    if (!response.hasUsers()) {
+    if (!response.hasUsers() || response.users().isEmpty()) {
       throw UserNotFoundException.builder().message("No matching user exists.").build();
     }
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -252,6 +253,16 @@ class UserAccountServiceTest {
   void shouldThrowExceptionGettingUserDetailsWhenUserNotFoundByEmail() {
     when(cognitoClient.listUsers(any(ListUsersRequest.class))).thenReturn(
         ListUsersResponse.builder().build());
+
+    assertThrows(UserNotFoundException.class, () -> service.getUserDetailsByEmail(EMAIL));
+  }
+
+  @Test
+  void shouldThrowExceptionGettingUserDetailsWhenUsersFoundByEmailIsEmptyCollection() {
+    ListUsersResponse listUsersResponse
+        = ListUsersResponse.builder().users(new ArrayList<>()).build();
+    when(cognitoClient.listUsers(any(ListUsersRequest.class))).thenReturn(
+        listUsersResponse);
 
     assertThrows(UserNotFoundException.class, () -> service.getUserDetailsByEmail(EMAIL));
   }


### PR DESCRIPTION
As per error

2024-05-31T09:27:39.382Z	Caused by:
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0 at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex at java.base/java.util.ArrayList.get(Unknown Source) at java.base/java.util.Collections$UnmodifiableList.get(Unknown Source) uk.nhs.tis.trainee.notifications.service.UserAccountService.getUserDetails(UserAccountService.java:170)

and guidance on the hasUsers() method: "For responses, this returns true if the service returned a value for the Users property. This DOES NOT check that the value is non-empty (for which, you should check the isEmpty() method on the property)."

NO-TICKET