### PR TITLE
feat: broadcast notification events

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -61,6 +61,10 @@
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/programme-membership/deleted"
         },
         {
+          "name": "NOTIFICATIONS_EVENT_TOPIC_ARN",
+          "valueFrom": "tis-trainee-${environment}-notifications-event"
+        },
+        {
           "name": "EMAIL_SENDER",
           "valueFrom": "/tis/trainee/${environment}/email-sender"
         },

--- a/README.md
+++ b/README.md
@@ -35,21 +35,22 @@ associated document for details of how to provide the region.
 
 #### Environmental Variables
 
-| Name                    | Description                                                        | Default   |
-|-------------------------|--------------------------------------------------------------------|-----------|
-| ACCOUNT_CONFIRMED_QUEUE | The queue URL for account confirmation events.                     |           |
-| APP_DOMAIN              | The domain to be used for links in email notifications. (Optional) |           |
-| AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host. (Optional)                               |           |
-| COGNITO_USER_POOL_ID    | The user pool to get user details from.                            |           |
-| COJ_RECEIVED_QUEUE      | The queue URL for Conditions of Joining received events.           |           |
-| ENVIRONMENT             | The environment to log events against.                             | local     |
-| EMAIL_SENDER            | Where email notifications are to be sent from.                     |           |
-| REDIS_HOST              | Redis server host                                                  | localhost |
-| REDIS_PASSWORD          | Login password of the redis server.                                | password  |
-| REDIS_PORT              | Redis server port.                                                 | 6379      |
-| REDIS_SSL               | Whether to enable SSL support.                                     | false     |
-| REDIS_USERNAME          | Login username of the redis server                                 | default   |
-| SENTRY_DSN              | A Sentry error monitoring Data Source Name. (Optional)             |           |
+| Name                          | Description                                                        | Default   |
+|-------------------------------|--------------------------------------------------------------------|-----------|
+| ACCOUNT_CONFIRMED_QUEUE       | The queue URL for account confirmation events.                     |           |
+| APP_DOMAIN                    | The domain to be used for links in email notifications. (Optional) |           |
+| AWS_XRAY_DAEMON_ADDRESS       | The AWS XRay daemon host. (Optional)                               |           |
+| COGNITO_USER_POOL_ID          | The user pool to get user details from.                            |           |
+| COJ_RECEIVED_QUEUE            | The queue URL for Conditions of Joining received events.           |           |
+| ENVIRONMENT                   | The environment to log events against.                             | local     |
+| EMAIL_SENDER                  | Where email notifications are to be sent from.                     |           |
+| NOTIFICATIONS_EVENT_TOPIC_ARN | Broadcast endpoint for notification events                         |           |
+| REDIS_HOST                    | Redis server host                                                  | localhost |
+| REDIS_PASSWORD                | Login password of the redis server.                                | password  |
+| REDIS_PORT                    | Redis server port.                                                 | 6379      |
+| REDIS_SSL                     | Whether to enable SSL support.                                     | false     |
+| REDIS_USERNAME                | Login username of the redis server                                 | default   |
+| SENTRY_DSN                    | A Sentry error monitoring Data Source Name. (Optional)             |           |
 
 #### Usage Examples
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.26.3"
+version = "1.27.0"
 
 configurations {
   compileOnly {
@@ -42,6 +42,7 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-test")
 
   implementation("io.awspring.cloud:spring-cloud-aws-starter-ses")
+  implementation("io.awspring.cloud:spring-cloud-aws-starter-sns")
   implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
   implementation("software.amazon.awssdk:cognitoidentityprovider")
   implementation("com.amazonaws:aws-xray-recorder-sdk-spring:2.15.1")

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/EventNotificationProperties.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/EventNotificationProperties.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -16,25 +16,29 @@
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications;
+package uk.nhs.tis.trainee.notifications.config;
 
-import io.mongock.runner.springboot.EnableMongock;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * An application for the management and sending of trainee notifications.
+ * A representation of the notifications event endpoint properties.
+ *
+ * @param notificationsEvent The notification event ARN
  */
-@EnableMongock
-@SpringBootApplication
-@ConfigurationPropertiesScan
-public class TisTraineeNotificationsApplication {
+@ConfigurationProperties(prefix = "application.sns")
+public record EventNotificationProperties(
+    SnsRoute notificationsEvent) {
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeNotificationsApplication.class);
+  /**
+   * An SNS route with a message attribute for routing purposes.
+   *
+   * @param arn              The SNS ARN.
+   * @param messageAttribute The message attribute to use.
+   */
+  public record SnsRoute(String arn, String messageAttribute) {
+
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/ObjectIdSerializerModule.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/ObjectIdSerializerModule.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.io.IOException;
+import org.bson.types.ObjectId;
+
+/**
+ * Customise the Jackson serializer to represent Mongo ObjectIds as strings.
+ */
+public class ObjectIdSerializerModule extends SimpleModule {
+
+  public ObjectIdSerializerModule() {
+    this.addSerializer(ObjectId.class, new ToStringSerializer());
+  }
+}
+

--- a/src/main/java/uk/nhs/tis/trainee/notifications/config/ObjectIdSerializerModule.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/config/ObjectIdSerializerModule.java
@@ -21,14 +21,8 @@
 
 package uk.nhs.tis.trainee.notifications.config;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.io.IOException;
 import org.bson.types.ObjectId;
 
 /**
@@ -36,6 +30,9 @@ import org.bson.types.ObjectId;
  */
 public class ObjectIdSerializerModule extends SimpleModule {
 
+  /**
+   * Initialise the custom serializer module for ObjectIds.
+   */
   public ObjectIdSerializerModule() {
     this.addSerializer(ObjectId.class, new ToStringSerializer());
   }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
@@ -25,5 +25,5 @@ package uk.nhs.tis.trainee.notifications.model;
  * An enumeration of possible notification statuses.
  */
 public enum NotificationStatus {
-  ARCHIVED, FAILED, READ, SENT, UNREAD
+  ARCHIVED, FAILED, READ, SENT, UNREAD, DELETED
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.sns.model.PublishRequest.Builder;
 import software.amazon.awssdk.services.sns.model.SnsException;
 import uk.nhs.tis.trainee.notifications.config.EventNotificationProperties;
 import uk.nhs.tis.trainee.notifications.config.EventNotificationProperties.SnsRoute;
+import uk.nhs.tis.trainee.notifications.config.ObjectIdSerializerModule;
 import uk.nhs.tis.trainee.notifications.model.History;
 
 /**
@@ -63,9 +64,11 @@ public class EventBroadcastService {
    * @param history The history event to publish.
    */
   public void publishNotificationsEvent(History history) {
+
     ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .registerModule(new ObjectIdSerializerModule());
 
     PublishRequest request = null;
     SnsRoute snsTopic = eventNotificationProperties.notificationsEvent();

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishRequest.Builder;
+import software.amazon.awssdk.services.sns.model.SnsException;
+import uk.nhs.tis.trainee.notifications.config.EventNotificationProperties;
+import uk.nhs.tis.trainee.notifications.config.EventNotificationProperties.SnsRoute;
+import uk.nhs.tis.trainee.notifications.model.History;
+
+/**
+ * A service for broadcasting form events to SNS.
+ */
+@Slf4j
+@Service
+public class EventBroadcastService {
+
+  private final SnsClient snsClient;
+
+  private final EventNotificationProperties eventNotificationProperties;
+
+  EventBroadcastService(SnsClient snsClient,
+      EventNotificationProperties eventNotificationProperties) {
+    this.snsClient = snsClient;
+    this.eventNotificationProperties = eventNotificationProperties;
+  }
+
+  /**
+   * Publish a notification history event to SNS.
+   *
+   * @param history The history event to publish.
+   */
+  public void publishNotificationsEvent(History history) {
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    PublishRequest request = null;
+    SnsRoute snsTopic = eventNotificationProperties.notificationsEvent();
+
+    if (snsTopic != null && history != null) {
+      JsonNode eventJson = objectMapper.valueToTree(history);
+      request = buildSnsRequest(eventJson, snsTopic, history.id());
+    }
+
+    if (request != null) {
+      try {
+        snsClient.publish(request);
+        log.info("Broadcast event sent to SNS for notification event {}.",
+            history.id());
+      } catch (SnsException e) {
+        String message = String.format(
+            "Failed to broadcast event to SNS topic '%s' for notification event '%s'",
+            snsTopic, history.id());
+        log.error(message, e);
+      }
+    }
+  }
+
+  /**
+   * Build an SNS publish request.
+   *
+   * @param eventJson The SNS message contents.
+   * @param snsTopic  The SNS topic to send the message to.
+   * @param id        The event id.
+   * @return the built request.
+   */
+  private PublishRequest buildSnsRequest(JsonNode eventJson, SnsRoute snsTopic,
+      ObjectId id) {
+    Builder request = PublishRequest.builder()
+        .message(eventJson.toString())
+        .topicArn(snsTopic.arn());
+
+    if (snsTopic.messageAttribute() != null) {
+      MessageAttributeValue messageAttributeValue = MessageAttributeValue.builder()
+          .dataType("String")
+          .stringValue(snsTopic.messageAttribute())
+          .build();
+      request.messageAttributes(Map.of("event_type", messageAttributeValue));
+    }
+
+    if (snsTopic.arn().endsWith(".fifo")) {
+      // Create a message group to ensure FIFO per unique object.
+      String messageGroup = String.format("%s_%s_%s", "notifications", "event", id);
+      request.messageGroupId(messageGroup);
+    }
+
+    return request.build();
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
@@ -45,6 +45,8 @@ import uk.nhs.tis.trainee.notifications.model.History;
 @Service
 public class EventBroadcastService {
 
+  public final static String MESSAGE_GROUP_ID_PREFIX = "notifications_event";
+
   private final SnsClient snsClient;
 
   private final EventNotificationProperties eventNotificationProperties;
@@ -111,7 +113,7 @@ public class EventBroadcastService {
 
     if (snsTopic.arn().endsWith(".fifo")) {
       // Create a message group to ensure FIFO per unique object.
-      String messageGroup = String.format("%s_%s_%s", "notifications", "event", id);
+      String messageGroup = String.format("%s_%s", MESSAGE_GROUP_ID_PREFIX, id);
       request.messageGroupId(messageGroup);
     }
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastService.java
@@ -45,7 +45,7 @@ import uk.nhs.tis.trainee.notifications.model.History;
 @Service
 public class EventBroadcastService {
 
-  public final static String MESSAGE_GROUP_ID_PREFIX = "notifications_event";
+  public static final String MESSAGE_GROUP_ID_PREFIX = "notifications_event";
 
   private final SnsClient snsClient;
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -24,6 +24,7 @@ package uk.nhs.tis.trainee.notifications.service;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.ARCHIVED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.DELETED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.READ;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
@@ -237,6 +238,7 @@ public class HistoryService {
    */
   public void deleteHistoryForTrainee(ObjectId id, String traineeId) {
     repository.deleteByIdAndRecipient_Id(id, traineeId);
+    eventBroadcastService.publishNotificationsDeleteEvent(id);
     log.info("Removed notification history {} for {}", id, traineeId);
   }
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -60,6 +60,7 @@ public class HistoryService {
 
   private final HistoryRepository repository;
   private final TemplateService templateService;
+  private final EventBroadcastService eventBroadcastService;
   private final HistoryMapper mapper;
 
   /**
@@ -70,9 +71,10 @@ public class HistoryService {
    * @param mapper          The mapper between History data types.
    */
   public HistoryService(HistoryRepository repository, TemplateService templateService,
-      HistoryMapper mapper) {
+      EventBroadcastService eventBroadcastService, HistoryMapper mapper) {
     this.repository = repository;
     this.templateService = templateService;
+    this.eventBroadcastService = eventBroadcastService;
     this.mapper = mapper;
   }
 
@@ -83,7 +85,9 @@ public class HistoryService {
    * @return The saved notification history.
    */
   public History save(History history) {
-    return repository.save(history);
+    History savedHistory = repository.save(history);
+    eventBroadcastService.publishNotificationsEvent(history);
+    return savedHistory;
   }
 
   /**
@@ -151,6 +155,7 @@ public class HistoryService {
 
     history = mapper.updateStatus(history, status, detail);
     history = repository.save(history);
+    eventBroadcastService.publishNotificationsEvent(history);
     return Optional.of(toDto(history));
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,9 @@ application:
     placement-deleted: ${PLACEMENT_DELETED_QUEUE}
     programme-membership-updated: ${PROGRAMME_MEMBERSHIP_UPDATED_QUEUE}
     programme-membership-deleted: ${PROGRAMME_MEMBERSHIP_DELETED_QUEUE}
+  sns:
+    notifications-event:
+      arn: ${NOTIFICATIONS_EVENT_TOPIC_ARN:}
   template-versions:
     coj-confirmation:
       email: v1.0.0

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastServiceTest.java
@@ -194,10 +194,7 @@ class EventBroadcastServiceTest {
     Map<String, Object> message = objectMapper.readValue(request.message(),
         new TypeReference<>() {
         });
-    LinkedHashMap<?, ?> id
-        = objectMapper.convertValue(message.get("id"), LinkedHashMap.class);
-    assertThat("Unexpected message history id.", id.get("timestamp"),
-        is(HISTORY_ID.getTimestamp()));
+    assertThat("Unexpected message id.", message.get("id"), is(HISTORY_ID.toString()));
 
     LinkedHashMap<?, ?> tisReference
         = objectMapper.convertValue(message.get("tisReference"), LinkedHashMap.class);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastServiceTest.java
@@ -1,0 +1,230 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
+import static uk.nhs.tis.trainee.notifications.service.EventBroadcastService.MESSAGE_GROUP_ID_PREFIX;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.SnsException;
+import uk.nhs.tis.trainee.notifications.config.EventNotificationProperties;
+import uk.nhs.tis.trainee.notifications.config.EventNotificationProperties.SnsRoute;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
+
+class EventBroadcastServiceTest {
+
+  private static final String MESSAGE_ATTRIBUTE = "message-attribute";
+  private static final String MESSAGE_ARN = "the-arn";
+
+  private static final String TRAINEE_ID = "40";
+  private static final String TRAINEE_CONTACT = "test@tis.nhs.uk";
+
+  private static final String NOTIFICATION_ID = ObjectId.get().toString();
+  private static final ObjectId HISTORY_ID = ObjectId.get();
+
+  private static final String TEMPLATE_NAME = "test/template";
+  private static final String TEMPLATE_VERSION = "v1.2.3";
+  private static final Map<String, Object> TEMPLATE_VARIABLES = Map.of("key1", "value1");
+
+  private static final TisReferenceType TIS_REFERENCE_TYPE = TisReferenceType.PLACEMENT;
+  private static final String TIS_REFERENCE_ID = UUID.randomUUID().toString();
+
+  private EventBroadcastService service;
+
+  private ObjectMapper objectMapper;
+  private SnsClient snsClient;
+  private EventNotificationProperties eventNotificationProperties;
+
+  @BeforeEach
+  void setUp() {
+    snsClient = mock(SnsClient.class);
+    SnsRoute snsRoute = new SnsRoute(MESSAGE_ARN, MESSAGE_ATTRIBUTE);
+    eventNotificationProperties = new EventNotificationProperties(snsRoute);
+    objectMapper = new ObjectMapper();
+    service = new EventBroadcastService(snsClient, eventNotificationProperties);
+  }
+
+  @Test
+  void shouldNotPublishNotificationEventIfSnsIsNull() {
+    RecipientInfo recipientInfo = new RecipientInfo(null, null, null);
+    TemplateInfo templateInfo = new TemplateInfo(null, null, Map.of());
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(null, null);
+    Instant sent = Instant.now();
+    Instant read = Instant.now().plus(Duration.ofDays(1));
+    History history = new History(null, tisReferenceInfo, NotificationType.PROGRAMME_CREATED,
+        recipientInfo, templateInfo, sent, read, SENT, null, null);
+
+    eventNotificationProperties = new EventNotificationProperties(null);
+    service = new EventBroadcastService(snsClient, eventNotificationProperties);
+
+    service.publishNotificationsEvent(history);
+
+    verifyNoInteractions(snsClient);
+  }
+
+  @Test
+  void shouldNotPublishNotificationEventIfEventDtoIsNull() {
+    service.publishNotificationsEvent(null);
+
+    verifyNoInteractions(snsClient);
+  }
+
+  @Test
+  void shouldNotThrowSnsExceptionsWhenBroadcastingEvent() {
+    RecipientInfo recipientInfo = new RecipientInfo(null, null, null);
+    TemplateInfo templateInfo = new TemplateInfo(null, null, Map.of());
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(null, null);
+    Instant sent = Instant.now();
+    Instant read = Instant.now().plus(Duration.ofDays(1));
+    History history = new History(null, tisReferenceInfo, NotificationType.PROGRAMME_CREATED,
+        recipientInfo, templateInfo, sent, read, SENT, null, null);
+
+    when(snsClient.publish(any(PublishRequest.class))).thenThrow(SnsException.builder().build());
+
+    assertDoesNotThrow(() -> service.publishNotificationsEvent(history));
+  }
+
+  @Test
+  void shouldSetMessageGroupIdOnIssuedEventWhenFifoQueue() {
+    RecipientInfo recipientInfo = new RecipientInfo(null, null, null);
+    TemplateInfo templateInfo = new TemplateInfo(null, null, Map.of());
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(null, null);
+    Instant sent = Instant.now();
+    Instant read = Instant.now().plus(Duration.ofDays(1));
+    History history = new History(HISTORY_ID, tisReferenceInfo, NotificationType.PROGRAMME_CREATED,
+        recipientInfo, templateInfo, sent, read, SENT, null, null);
+
+    SnsRoute fifoSns = new SnsRoute(MESSAGE_ARN + ".fifo", MESSAGE_ATTRIBUTE);
+    eventNotificationProperties = new EventNotificationProperties(fifoSns);
+    service = new EventBroadcastService(snsClient, eventNotificationProperties);
+
+    service.publishNotificationsEvent(history);
+
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsClient).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+    assertThat("Unexpected message group id.", request.messageGroupId(),
+        is(MESSAGE_GROUP_ID_PREFIX + "_" + HISTORY_ID));
+
+    verifyNoMoreInteractions(snsClient);
+  }
+
+  @Test
+  void shouldNotSetMessageAttributeIfNotRequired() {
+    RecipientInfo recipientInfo = new RecipientInfo(null, null, null);
+    TemplateInfo templateInfo = new TemplateInfo(null, null, Map.of());
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(null, null);
+    Instant sent = Instant.now();
+    Instant read = Instant.now().plus(Duration.ofDays(1));
+    History history = new History(HISTORY_ID, tisReferenceInfo, NotificationType.PROGRAMME_CREATED,
+        recipientInfo, templateInfo, sent, read, SENT, null, null);
+
+    eventNotificationProperties
+        = new EventNotificationProperties(new SnsRoute(MESSAGE_ARN, null));
+    service = new EventBroadcastService(snsClient, eventNotificationProperties);
+
+    service.publishNotificationsEvent(history);
+
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsClient).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+
+    Map<String, MessageAttributeValue> messageAttributes = request.messageAttributes();
+    assertNull(messageAttributes.get("event_type"), "Unexpected message attribute value.");
+
+    verifyNoMoreInteractions(snsClient);
+  }
+
+  @Test
+  void shouldPublishNotificationEvent() throws JsonProcessingException {
+    RecipientInfo recipientInfo = new RecipientInfo(null, null, null);
+    TemplateInfo templateInfo = new TemplateInfo(null, null, Map.of());
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    Instant sent = Instant.now();
+    Instant read = Instant.now().plus(Duration.ofDays(1));
+    History history = new History(HISTORY_ID, tisReferenceInfo, NotificationType.PROGRAMME_CREATED,
+        recipientInfo, templateInfo, sent, read, SENT, null, null);
+
+    service.publishNotificationsEvent(history);
+
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsClient).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+    assertThat("Unexpected topic ARN.", request.topicArn(), is(MESSAGE_ARN));
+
+    Map<String, Object> message = objectMapper.readValue(request.message(),
+        new TypeReference<>() {
+        });
+    LinkedHashMap<?, ?> id
+        = objectMapper.convertValue(message.get("id"), LinkedHashMap.class);
+    assertThat("Unexpected message history id.", id.get("timestamp"),
+        is(HISTORY_ID.getTimestamp()));
+    //TODO: more attribs
+
+    LinkedHashMap<?, ?> tisReference
+        = objectMapper.convertValue(message.get("tisReference"), LinkedHashMap.class);
+    assertThat("Unexpected message tis reference type.",
+        tisReference.get("type"), is(TIS_REFERENCE_TYPE.toString()));
+    assertThat("Unexpected message tis reference id.",
+        tisReference.get("id"), is(TIS_REFERENCE_ID));
+
+    Map<String, MessageAttributeValue> messageAttributes = request.messageAttributes();
+    assertThat("Unexpected message attribute value.",
+        messageAttributes.get("event_type").stringValue(), is(MESSAGE_ATTRIBUTE));
+    assertThat("Unexpected message attribute data type.",
+        messageAttributes.get("event_type").dataType(), is("String"));
+
+    verifyNoMoreInteractions(snsClient);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -44,11 +44,13 @@ import org.bson.types.ObjectId;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -84,6 +86,9 @@ class HistoryServiceIntegrationTest {
   private static final Instant SENT_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
   private static final Instant READ_AT = Instant.now().plus(Duration.ofDays(1))
       .truncatedTo(ChronoUnit.MILLIS);
+
+  @MockBean
+  EventBroadcastService eventBroadcastService;
 
   @Autowired
   private HistoryService service;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -44,7 +44,6 @@ import org.bson.types.ObjectId;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -85,12 +85,15 @@ class HistoryServiceTest {
   private HistoryService service;
   private HistoryRepository repository;
   private TemplateService templateService;
+  private EventBroadcastService eventBroadcastService;
 
   @BeforeEach
   void setUp() {
     repository = mock(HistoryRepository.class);
     templateService = mock(TemplateService.class);
-    service = new HistoryService(repository, templateService, new HistoryMapperImpl());
+    eventBroadcastService = mock(EventBroadcastService.class);
+    service = new HistoryService(repository, templateService, eventBroadcastService,
+        new HistoryMapperImpl());
   }
 
   @ParameterizedTest

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -55,7 +55,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import uk.nhs.tis.trainee.notifications.dto.HistoryDto;
+import uk.nhs.tis.trainee.notifications.mapper.HistoryMapper;
 import uk.nhs.tis.trainee.notifications.mapper.HistoryMapperImpl;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
@@ -86,6 +88,7 @@ class HistoryServiceTest {
   private HistoryRepository repository;
   private TemplateService templateService;
   private EventBroadcastService eventBroadcastService;
+  private HistoryMapper mapper = new HistoryMapperImpl();
 
   @BeforeEach
   void setUp() {
@@ -93,7 +96,7 @@ class HistoryServiceTest {
     templateService = mock(TemplateService.class);
     eventBroadcastService = mock(EventBroadcastService.class);
     service = new HistoryService(repository, templateService, eventBroadcastService,
-        new HistoryMapperImpl());
+        mapper);
   }
 
   @ParameterizedTest
@@ -127,6 +130,8 @@ class HistoryServiceTest {
     assertThat("Unexpected read at.", savedHistory.readAt(), is(read));
     assertThat("Unexpected status.", savedHistory.status(), is(SENT));
     assertThat("Unexpected status detail.", savedHistory.statusDetail(), nullValue());
+
+    verify(eventBroadcastService).publishNotificationsEvent(history);
   }
 
   @ParameterizedTest
@@ -154,6 +159,7 @@ class HistoryServiceTest {
         () -> service.updateStatus(NOTIFICATION_ID, status, ""));
 
     verify(repository, never()).save(any());
+    verifyNoInteractions(eventBroadcastService);
   }
 
   @ParameterizedTest
@@ -189,6 +195,13 @@ class HistoryServiceTest {
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));
+
+    ArgumentCaptor<History> historyPublished = ArgumentCaptor.forClass(History.class);
+    verify(eventBroadcastService).publishNotificationsEvent(historyPublished.capture());
+
+    History historyPublishedValue = historyPublished.getValue();
+    assertThat("Unexpected history published.", mapper.toDto(historyPublishedValue),
+        is(history));
   }
 
   @ParameterizedTest
@@ -206,6 +219,7 @@ class HistoryServiceTest {
         () -> service.updateStatus(NOTIFICATION_ID, status, ""));
 
     verify(repository, never()).save(any());
+    verifyNoInteractions(eventBroadcastService);
   }
 
   @ParameterizedTest
@@ -246,6 +260,13 @@ class HistoryServiceTest {
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));
+
+    ArgumentCaptor<History> historyPublished = ArgumentCaptor.forClass(History.class);
+    verify(eventBroadcastService).publishNotificationsEvent(historyPublished.capture());
+
+    History historyPublishedValue = historyPublished.getValue();
+    HistoryDto publishedDto = mapper.toDto(historyPublishedValue, "Test Subject");
+    assertThat("Unexpected history published.", publishedDto, is(history));
   }
 
   @ParameterizedTest
@@ -274,6 +295,7 @@ class HistoryServiceTest {
         () -> service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, status));
 
     verify(repository, never()).save(any());
+    verifyNoInteractions(eventBroadcastService);
   }
 
   @ParameterizedTest
@@ -309,6 +331,13 @@ class HistoryServiceTest {
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));
+
+    ArgumentCaptor<History> historyPublished = ArgumentCaptor.forClass(History.class);
+    verify(eventBroadcastService).publishNotificationsEvent(historyPublished.capture());
+
+    History historyPublishedValue = historyPublished.getValue();
+    assertThat("Unexpected history published.", mapper.toDto(historyPublishedValue),
+        is(history));
   }
 
   @ParameterizedTest
@@ -328,6 +357,7 @@ class HistoryServiceTest {
         () -> service.updateStatus(TRAINEE_ID, NOTIFICATION_ID, status));
 
     verify(repository, never()).save(any());
+    verifyNoInteractions(eventBroadcastService);
   }
 
   @ParameterizedTest
@@ -368,6 +398,14 @@ class HistoryServiceTest {
     assertThat("Unexpected contact.", history.contact(), is(TRAINEE_CONTACT));
     assertThat("Unexpected sent at.", history.sentAt(), is(Instant.MIN));
     assertThat("Unexpected read at.", history.readAt(), is(Instant.MAX));
+
+    ArgumentCaptor<History> historyPublished = ArgumentCaptor.forClass(History.class);
+    verify(eventBroadcastService).publishNotificationsEvent(historyPublished.capture());
+
+    History historyPublishedValue = historyPublished.getValue();
+    HistoryDto publishedDto = mapper.toDto(historyPublishedValue, "Test Subject");
+    assertThat("Unexpected history published.", publishedDto,
+        is(history));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -146,7 +146,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"FAILED", "SENT"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
+      names = {"FAILED", "SENT", "DELETED"})
   void shouldThrowExceptionWhenUpdatingEmailHistoryWithInvalidStatus(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
@@ -163,8 +164,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"ARCHIVED", "READ",
-      "UNREAD"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
+      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
   void shouldUpdateValidStatusWhenEmailHistoryFound(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
@@ -205,8 +206,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"ARCHIVED", "READ",
-      "UNREAD"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
+      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
   void shouldThrowExceptionWhenUpdatingInAppHistoryWithInvalidStatus(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
@@ -223,7 +224,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"FAILED", "SENT"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
+      names = {"FAILED", "SENT", "DELETED"})
   void shouldUpdateValidStatusWhenInAppHistoryFound(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
@@ -299,8 +301,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"ARCHIVED", "READ",
-      "UNREAD"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
+      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
   void shouldUpdateValidStatusForTraineeWhenEmailHistoryFound(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
@@ -341,8 +343,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"ARCHIVED", "READ",
-      "UNREAD"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
+      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
   void shouldThrowExceptionWhenUpdatingInAppHistoryForTraineeWithInvalidStatus(
       NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
@@ -361,7 +363,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"FAILED", "SENT"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
+      names = {"FAILED", "SENT", "DELETED"})
   void shouldUpdateValidStatusForTraineeWhenInAppHistoryFound(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
@@ -714,6 +717,7 @@ class HistoryServiceTest {
     service.deleteHistoryForTrainee(HISTORY_ID, TRAINEE_ID);
 
     verify(repository).deleteByIdAndRecipient_Id(HISTORY_ID, TRAINEE_ID);
+    verify(eventBroadcastService).publishNotificationsDeleteEvent(HISTORY_ID);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Note: at present History deletes are 'faked' by broadcasting a dummy record with NotificationStatus=DELETED (the actual records are deleted from the local repository)

TIS21-6085