### PR TITLE
fix: bad SSM parameter for SNS

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -62,7 +62,7 @@
         },
         {
           "name": "NOTIFICATIONS_EVENT_TOPIC_ARN",
-          "valueFrom": "tis-trainee-${environment}-notifications-event"
+          "valueFrom": "/tis/trainee/notifications/${environment}/topic-arn/event-fifo"
         },
         {
           "name": "EMAIL_SENDER",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.27.0"
+version = "1.27.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
Currently won't start with ' invalid ssm parameters: tis-trainee-preprod-notifications-event'.

NO-TICKET