### PR TITLE
fix: broadcast saved History (with non-null id)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.27.1"
+version = "1.27.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -87,7 +87,7 @@ public class HistoryService {
    */
   public History save(History history) {
     History savedHistory = repository.save(history);
-    eventBroadcastService.publishNotificationsEvent(history);
+    eventBroadcastService.publishNotificationsEvent(savedHistory);
     return savedHistory;
   }
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -131,7 +131,8 @@ class HistoryServiceTest {
     assertThat("Unexpected status.", savedHistory.status(), is(SENT));
     assertThat("Unexpected status detail.", savedHistory.statusDetail(), nullValue());
 
-    verify(eventBroadcastService).publishNotificationsEvent(history);
+    //some Histories are saved with null id; the saved object will have a proper id assigned to it.
+    verify(eventBroadcastService).publishNotificationsEvent(savedHistory);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Some in-app Histories are created with null id, leading to messages in the ndw notification event queue like
`{"id": null, ....}` which will cause problems since the id is used for the filename. Using the saved object means the id will be populated.

NO-TICKET