### PR TITLE
Feat/handle SCHEDULED status of notifications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.30.1"
+version = "1.31.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/PlacementListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/PlacementListener.java
@@ -80,8 +80,8 @@ public class PlacementListener {
     if (event.recrd() != null && event.recrd().getData() != null) {
       Placement placement = mapper.toEntity(event.recrd().getData());
       placement.setTisId(event.tisId()); //delete messages used to have empty record data
-      placementService.deleteNotifications(placement);
-      placementService.deleteScheduledInAppNotifications(placement);
+      placementService.deleteNotificationsFromScheduler(placement);
+      placementService.deleteScheduledNotificationsFromDb(placement);
     } else {
       log.info("Ignoring non placement delete event: {}", event);
     }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
@@ -80,7 +80,8 @@ public class ProgrammeMembershipListener {
     if (event.recrd() != null && event.recrd().getData() != null) {
       ProgrammeMembership programmeMembership = new ProgrammeMembership();
       programmeMembership.setTisId(event.tisId()); //delete messages have empty recrd data
-      programmeMembershipService.deleteNotifications(programmeMembership);
+      programmeMembershipService.deleteNotificationsFromScheduler(programmeMembership);
+      programmeMembershipService.deleteScheduledNotificationsFromDb(programmeMembership);
     } else {
       log.info("Ignoring non programme membership delete event: {}", event);
     }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/HistoryMapper.java
@@ -84,6 +84,45 @@ public interface HistoryMapper {
   HistoryDto toDto(History entity, String subjectText);
 
   /**
+   * Convert a history entity to a history DTO.
+   *
+   * @param entity The history entity to convert.
+   * @param status A pre-generated status for in-app.
+   * @return The converted history DTOs.
+   */
+  @Mapping(target = "id", expression = "java(entity.id().toString())")
+  @Mapping(target = "type", source = "entity.recipient.type")
+  @Mapping(target = "tisReference", source = "entity.tisReference")
+  @Mapping(target = "subject", source = "entity.type")
+  @Mapping(target = "subjectText", ignore = true)
+  @Mapping(target = "contact", source = "entity.recipient.contact")
+  @Mapping(target = "sentAt", source = "entity.sentAt")
+  @Mapping(target = "readAt", source = "entity.readAt")
+  @Mapping(target = "status", source = "status")
+  @Mapping(target = "statusDetail", source = "entity.statusDetail")
+  HistoryDto toDto(History entity, NotificationStatus status);
+
+  /**
+   * Convert a history entity to a history DTO.
+   *
+   * @param entity      The history entity to convert.
+   * @param subjectText A pre-generated subject text.
+   * @param status A pre-generated status for in-app.
+   * @return The converted history DTOs.
+   */
+  @Mapping(target = "id", expression = "java(entity.id().toString())")
+  @Mapping(target = "type", source = "entity.recipient.type")
+  @Mapping(target = "tisReference", source = "entity.tisReference")
+  @Mapping(target = "subject", source = "entity.type")
+  @Mapping(target = "subjectText", source = "subjectText")
+  @Mapping(target = "contact", source = "entity.recipient.contact")
+  @Mapping(target = "sentAt", source = "entity.sentAt")
+  @Mapping(target = "readAt", source = "entity.readAt")
+  @Mapping(target = "status", source = "status")
+  @Mapping(target = "statusDetail", source = "entity.statusDetail")
+  HistoryDto toDto(History entity, String subjectText, NotificationStatus status);
+
+  /**
    * Update the status of the given history entity.
    *
    * @param entity The history to update the status of.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationStatus.java
@@ -25,5 +25,5 @@ package uk.nhs.tis.trainee.notifications.model;
  * An enumeration of possible notification statuses.
  */
 public enum NotificationStatus {
-  ARCHIVED, FAILED, READ, SENT, UNREAD, DELETED
+  ARCHIVED, FAILED, READ, SCHEDULED, SENT, UNREAD, DELETED
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -136,6 +136,16 @@ public class EmailService {
       NotificationStatus status;
       String statusDetail = null;
 
+      // find scheduled history from DB
+      History scheduledHistory = null;
+      if (tisReferenceInfo != null) {
+        scheduledHistory = historyService.findScheduledEmailForTraineeByRefAndType(
+            traineeId, tisReferenceInfo.type(), tisReferenceInfo.id(), notificationType);
+        if (scheduledHistory != null) {
+          notificationId = scheduledHistory.id();
+        }
+      }
+
       if (recipient != null) {
         MimeMessageHelper helper = buildMessageHelper(recipient, templateName, templateVariables,
             notificationId);

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -26,6 +26,7 @@ import static org.quartz.TriggerBuilder.newTrigger;
 import static uk.nhs.tis.trainee.notifications.model.HrefType.ABSOLUTE_URL;
 import static uk.nhs.tis.trainee.notifications.model.HrefType.NON_HREF;
 import static uk.nhs.tis.trainee.notifications.model.HrefType.PROTOCOL_EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.TIS_ID_FIELD;
@@ -45,6 +46,7 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.bson.types.ObjectId;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -59,9 +61,11 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
+import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
 import uk.nhs.tis.trainee.notifications.model.Placement;
 import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
@@ -92,6 +96,7 @@ public class NotificationService implements Job {
   public static final String CONTACT_FIELD = "contact";
 
   private final EmailService emailService;
+  private final HistoryService historyService;
   private final RestTemplate restTemplate;
   private final String templateVersion;
   private final String serviceUrl;
@@ -117,8 +122,9 @@ public class NotificationService implements Job {
    *                                   local office information.
    * @param notificationsWhitelist     The whitelist of (tester) trainee TIS IDs.
    */
-  public NotificationService(EmailService emailService, RestTemplate restTemplate,
-      Scheduler scheduler, MessagingControllerService messagingControllerService,
+  public NotificationService(EmailService emailService, HistoryService historyService,
+      RestTemplate restTemplate, Scheduler scheduler,
+      MessagingControllerService messagingControllerService,
       @Value("${application.template-versions.form-updated.email}") String templateVersion,
       @Value("${service.trainee.url}") String serviceUrl,
       @Value("${service.reference.url}") String referenceUrl,
@@ -126,6 +132,7 @@ public class NotificationService implements Job {
       @Value("${application.notifications-whitelist}") List<String> notificationsWhitelist,
       @Value("${application.timezone}") String timezone) {
     this.emailService = emailService;
+    this.historyService = historyService;
     this.restTemplate = restTemplate;
     this.scheduler = scheduler;
     this.templateVersion = templateVersion;
@@ -157,35 +164,12 @@ public class NotificationService implements Job {
     TisReferenceInfo tisReferenceInfo = null;
     LocalDate startDate = null;
 
+    // Enrich User Account and Local Office details to
+    jobDetails = enrichJobDetails(jobDetails);
+
     UserDetails userTraineeDetails = getTraineeDetails(personId);
-
-    if (userTraineeDetails == null) {
-      String message = String.format(
-          "The requested notification is for unknown or unavailable trainee '%s'.", personId);
-      throw new IllegalArgumentException(message);
-    }
-
     UserDetails userCognitoAccountDetails = getCognitoAccountDetails(userTraineeDetails.email());
     UserDetails userAccountDetails = mapUserDetails(userCognitoAccountDetails, userTraineeDetails);
-
-    if (userAccountDetails != null) {
-      jobDetails.putIfAbsent("isRegistered", userAccountDetails.isRegistered());
-      jobDetails.putIfAbsent("title", userAccountDetails.title());
-      jobDetails.putIfAbsent("familyName", userAccountDetails.familyName());
-      jobDetails.putIfAbsent("givenName", userAccountDetails.givenName());
-      jobDetails.putIfAbsent("email", userAccountDetails.email());
-      jobDetails.putIfAbsent("gmcNumber", userAccountDetails.gmcNumber());
-    }
-
-    String owner = jobDetails.getString(TEMPLATE_OWNER_FIELD);
-    List<Map<String, String>> ownerContactList = getOwnerContactList(owner);
-    String contact = getOwnerContact(ownerContactList, LocalOfficeContactType.ONBOARDING_SUPPORT,
-        LocalOfficeContactType.TSS_SUPPORT);
-    jobDetails.putIfAbsent(TEMPLATE_OWNER_CONTACT_FIELD, contact);
-    jobDetails.putIfAbsent(TEMPLATE_CONTACT_HREF_FIELD, getHrefTypeForContact(contact));
-    String website = getOwnerContact(ownerContactList, LocalOfficeContactType.LOCAL_OFFICE_WEBSITE,
-        null);
-    jobDetails.putIfAbsent(TEMPLATE_OWNER_WEBSITE_FIELD, website);
 
     NotificationType notificationType =
         NotificationType.valueOf(jobDetails.get(TEMPLATE_NOTIFICATION_TYPE_FIELD).toString());
@@ -223,14 +207,6 @@ public class NotificationService implements Job {
 
     if (isActionableJob) {
       if (userAccountDetails != null) {
-        jobDetails.putIfAbsent("isRegistered", userAccountDetails.isRegistered());
-        jobDetails.putIfAbsent("title", userAccountDetails.title());
-        jobDetails.putIfAbsent("familyName", userAccountDetails.familyName());
-        jobDetails.putIfAbsent("givenName", userAccountDetails.givenName());
-        jobDetails.putIfAbsent("email", userAccountDetails.email());
-        jobDetails.putIfAbsent("gmcNumber", userAccountDetails.gmcNumber());
-        jobDetails.putIfAbsent("isValidGmc", isValidGmc(userAccountDetails.gmcNumber()));
-
         try {
           emailService.sendMessage(personId, userAccountDetails.email(), notificationType,
               templateVersion, jobDetails.getWrappedMap(), tisReferenceInfo, !actuallySendEmail);
@@ -276,6 +252,7 @@ public class NotificationService implements Job {
    */
   public void scheduleNotification(String jobId, JobDataMap jobDataMap, Date when)
       throws SchedulerException {
+    // schedule notification in Scheduler
     JobDetail job = newJob(NotificationService.class)
         .withIdentity(jobId)
         .usingJobData(jobDataMap)
@@ -289,6 +266,9 @@ public class NotificationService implements Job {
 
     Date scheduledDate = scheduler.scheduleJob(job, trigger);
     log.info("Notification for {} scheduled for {}", jobId, scheduledDate);
+
+    // save SCHEDULED history in DB
+    saveScheduleHistory(jobDataMap, when);
   }
 
   /**
@@ -383,6 +363,85 @@ public class NotificationService implements Job {
     } else {
       return null;
     }
+  }
+
+  /**
+   * Build notification details for sending message and DB history.
+   *
+   * @param jobDetails The job details.
+   */
+  protected JobDataMap enrichJobDetails(JobDataMap jobDetails) {
+    String personId = jobDetails.getString(PERSON_ID_FIELD);
+    UserDetails userTraineeDetails = getTraineeDetails(personId);
+
+    if (userTraineeDetails == null) {
+      String message = String.format(
+          "The requested notification is for unknown or unavailable trainee '%s'.", personId);
+      throw new IllegalArgumentException(message);
+    }
+    UserDetails userCognitoAccountDetails = getCognitoAccountDetails(userTraineeDetails.email());
+
+    String owner = jobDetails.getString(TEMPLATE_OWNER_FIELD);
+    List<Map<String, String>> ownerContactList = getOwnerContactList(owner);
+    String contact = getOwnerContact(ownerContactList, LocalOfficeContactType.ONBOARDING_SUPPORT,
+        LocalOfficeContactType.TSS_SUPPORT);
+    jobDetails.putIfAbsent(TEMPLATE_OWNER_CONTACT_FIELD, contact);
+    jobDetails.putIfAbsent(TEMPLATE_CONTACT_HREF_FIELD, getHrefTypeForContact(contact));
+    String website = getOwnerContact(ownerContactList, LocalOfficeContactType.LOCAL_OFFICE_WEBSITE,
+        null);
+    jobDetails.putIfAbsent(TEMPLATE_OWNER_WEBSITE_FIELD, website);
+
+    UserDetails userAccountDetails = mapUserDetails(userCognitoAccountDetails, userTraineeDetails);
+    if (userAccountDetails != null) {
+      jobDetails.putIfAbsent("isRegistered", userAccountDetails.isRegistered());
+      jobDetails.putIfAbsent("title", userAccountDetails.title());
+      jobDetails.putIfAbsent("familyName", userAccountDetails.familyName());
+      jobDetails.putIfAbsent("givenName", userAccountDetails.givenName());
+      jobDetails.putIfAbsent("email", userAccountDetails.email());
+      jobDetails.putIfAbsent("gmcNumber", userAccountDetails.gmcNumber());
+    }
+
+    return jobDetails;
+  }
+
+  /**
+   * Store history in DB for scheduled notification.
+   *
+   * @param jobDetails The job details.
+   */
+  protected void saveScheduleHistory(JobDataMap jobDetails, Date when) {
+    jobDetails = enrichJobDetails(jobDetails);
+
+    NotificationType notificationType =
+        NotificationType.valueOf(jobDetails.get(TEMPLATE_NOTIFICATION_TYPE_FIELD).toString());
+
+    TisReferenceInfo tisReferenceInfo = null;
+    if (notificationType == NotificationType.PROGRAMME_CREATED
+        || notificationType == NotificationType.PROGRAMME_DAY_ONE) {
+      tisReferenceInfo = new TisReferenceInfo(PROGRAMME_MEMBERSHIP,
+          jobDetails.get(ProgrammeMembershipService.TIS_ID_FIELD).toString());
+    } else if (notificationType == NotificationType.PLACEMENT_UPDATED_WEEK_12) {
+      tisReferenceInfo = new TisReferenceInfo(PLACEMENT,
+          jobDetails.get(PlacementService.TIS_ID_FIELD).toString());
+    }
+
+    History.RecipientInfo recipientInfo = new History.RecipientInfo(
+        jobDetails.getString(PERSON_ID_FIELD), EMAIL, jobDetails.getString("email"));
+    History.TemplateInfo templateInfo = new History.TemplateInfo(notificationType.getTemplateName(),
+        templateVersion, jobDetails.getWrappedMap());
+
+    History history = new History(
+        ObjectId.get(),
+        tisReferenceInfo,
+        notificationType,
+        recipientInfo,
+        templateInfo,
+        when.toInstant(),
+        null,
+        NotificationStatus.SCHEDULED,
+        null,
+        null);
+    historyService.save(history);
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -177,8 +177,8 @@ public class PlacementService {
       throws SchedulerException {
 
     //first delete any stale notifications
-    deleteNotifications(placement);
-    deleteScheduledInAppNotifications(placement);
+    deleteNotificationsFromScheduler(placement);
+    deleteScheduledNotificationsFromDb(placement);
 
     boolean isExcluded = isExcluded(placement);
     log.info("Placement {}: excluded {}.", placement.getTisId(), isExcluded);
@@ -193,12 +193,12 @@ public class PlacementService {
   }
 
   /**
-   * Remove notifications for a placement.
+   * Remove notifications for a placement from scheduler.
    *
    * @param placement The placement.
    * @throws SchedulerException if any one of the notification jobs could not be removed.
    */
-  public void deleteNotifications(Placement placement)
+  public void deleteNotificationsFromScheduler(Placement placement)
       throws SchedulerException {
     String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + placement.getTisId();
     notificationService.removeNotification(jobId); //remove existing notification if it exists
@@ -360,14 +360,14 @@ public class PlacementService {
   }
 
   /**
-   * Remove scheduled in-app notifications for a placement.
+   * Remove scheduled notifications for a placement from DB.
    *
    * @param placement The placement.
    */
-  public void deleteScheduledInAppNotifications(Placement placement) {
+  public void deleteScheduledNotificationsFromDb(Placement placement) {
 
     List<History> scheduledHistories = historyService
-        .findAllScheduledInAppForTrainee(placement.getPersonId(), PLACEMENT, placement.getTisId());
+        .findAllScheduledForTrainee(placement.getPersonId(), PLACEMENT, placement.getTisId());
 
     for (History history : scheduledHistories) {
       historyService.deleteHistoryForTrainee(history.id(), placement.getPersonId());

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -219,8 +219,8 @@ public class ProgrammeMembershipService {
       throws SchedulerException {
 
     //first delete any stale notifications
-    deleteNotifications(programmeMembership);
-    deleteScheduledInAppNotifications(programmeMembership);
+    deleteNotificationsFromScheduler(programmeMembership);
+    deleteScheduledNotificationsFromDb(programmeMembership);
 
     boolean isExcluded = isExcluded(programmeMembership);
     log.info("Programme membership {}: excluded {}.", programmeMembership.getTisId(), isExcluded);
@@ -439,7 +439,7 @@ public class ProgrammeMembershipService {
    * @param programmeMembership The programme membership.
    * @throws SchedulerException if any one of the notification jobs could not be removed.
    */
-  public void deleteNotifications(ProgrammeMembership programmeMembership)
+  public void deleteNotificationsFromScheduler(ProgrammeMembership programmeMembership)
       throws SchedulerException {
 
     for (NotificationType milestone : NotificationType.getProgrammeUpdateNotificationTypes()) {
@@ -450,14 +450,14 @@ public class ProgrammeMembershipService {
   }
 
   /**
-   * Remove scheduled in-app notifications for a programme membership.
+   * Remove scheduled notifications for a programme membership from DB.
    *
    * @param programmeMembership The programmeMembership.
    */
-  protected void deleteScheduledInAppNotifications(ProgrammeMembership programmeMembership) {
+  public void deleteScheduledNotificationsFromDb(ProgrammeMembership programmeMembership) {
 
     List<History> scheduledHistories = historyService
-        .findAllScheduledInAppForTrainee(programmeMembership.getPersonId(), PROGRAMME_MEMBERSHIP,
+        .findAllScheduledForTrainee(programmeMembership.getPersonId(), PROGRAMME_MEMBERSHIP,
             programmeMembership.getTisId());
 
     for (History history : scheduledHistories) {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/PlacementListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/PlacementListenerTest.java
@@ -97,8 +97,8 @@ class PlacementListenerTest {
 
     listener.handlePlacementDelete(event);
 
-    verify(placementService).deleteNotifications(placementCaptor.capture());
-    verify(placementService).deleteScheduledInAppNotifications(placementCaptor.capture());
+    verify(placementService).deleteNotificationsFromScheduler(placementCaptor.capture());
+    verify(placementService).deleteScheduledNotificationsFromDb(placementCaptor.capture());
 
     Placement placement = placementCaptor.getValue();
     assertThat("Unexpected placement id", placement.getTisId(), is(TIS_ID));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
@@ -94,7 +94,10 @@ class ProgrammeMembershipListenerTest {
 
     listener.handleProgrammeMembershipDelete(event);
 
-    verify(programmeMembershipService).deleteNotifications(expectedProgrammeMembership);
+    verify(programmeMembershipService).deleteNotificationsFromScheduler(
+        expectedProgrammeMembership);
+    verify(programmeMembershipService).deleteScheduledNotificationsFromDb(
+        expectedProgrammeMembership);
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -363,6 +363,8 @@ class HistoryServiceIntegrationTest {
         new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID_2);
     TisReferenceInfo tisReferenceInfo4 =
         new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo5 =
+        new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_REFERENCE_ID_2);
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo, templateInfo,
@@ -372,6 +374,8 @@ class HistoryServiceIntegrationTest {
     service.save(new History(null, tisReferenceInfo3, PROGRAMME_DAY_ONE, recipientInfo,
         templateInfo, now, now, SCHEDULED, null, null));
     service.save(new History(null, tisReferenceInfo4, PROGRAMME_DAY_ONE, recipientInfo,
+        templateInfo, now, now, SCHEDULED, null, null));
+    service.save(new History(null, tisReferenceInfo5, PROGRAMME_DAY_ONE, recipientInfo,
         templateInfo, now, now, SCHEDULED, null, null));
 
     History foundHistory = service.findScheduledEmailForTraineeByRefAndType(

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -26,12 +26,15 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MONGODB;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SCHEDULED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_DAY_ONE;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -320,7 +323,7 @@ class HistoryServiceIntegrationTest {
   }
 
   @Test
-  void shouldSortFoundScheduledInAppNotificationsBySentAt() {
+  void shouldSortFoundScheduledNotificationsBySentAt() {
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
     TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
         TEMPLATE_VARIABLES);
@@ -338,7 +341,7 @@ class HistoryServiceIntegrationTest {
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
         after, before, SENT, null, null));
 
-    List<History> foundHistory = service.findAllScheduledInAppForTrainee(
+    List<History> foundHistory = service.findAllScheduledForTrainee(
         TRAINEE_ID, TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
 
     assertThat("Unexpected history count.", foundHistory.size(), is(1));
@@ -348,28 +351,62 @@ class HistoryServiceIntegrationTest {
   }
 
   @Test
-  void shouldNotSortEmailNotificationsBySentAt() {
+  void shouldSortScheduledEmailNotificationsByRefAndType() {
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
     TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
         TEMPLATE_VARIABLES);
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo1 =
+        new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo2 =
+        new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo3 =
+        new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID_2);
+    TisReferenceInfo tisReferenceInfo4 =
+        new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
+    service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo, templateInfo,
         now, now, SENT, null, null));
+    service.save(new History(null, tisReferenceInfo2, PROGRAMME_DAY_ONE, recipientInfo,
+        templateInfo, now, now, SCHEDULED, null, null));
+    service.save(new History(null, tisReferenceInfo3, PROGRAMME_DAY_ONE, recipientInfo,
+        templateInfo, now, now, SCHEDULED, null, null));
+    service.save(new History(null, tisReferenceInfo4, PROGRAMME_DAY_ONE, recipientInfo,
+        templateInfo, now, now, SCHEDULED, null, null));
 
-    Instant before = SENT_AT.minus(Duration.ofDays(1));
-    Instant after = SENT_AT.plus(Duration.ofDays(1));
-    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        before, after, SENT, null, null));
+    History foundHistory = service.findScheduledEmailForTraineeByRefAndType(
+        TRAINEE_ID, TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID, PROGRAMME_DAY_ONE);
 
-    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        after, before, SENT, null, null));
+    assertThat("Unexpected history message type.", foundHistory.recipient().type(), is(EMAIL));
+    assertThat("Unexpected history reference type.", foundHistory.tisReference().type(),
+        is(TisReferenceType.PROGRAMME_MEMBERSHIP));
+    assertThat("Unexpected history reference id.", foundHistory.tisReference().id(),
+        is(TIS_REFERENCE_ID));
+    assertThat("Unexpected history notification type.", foundHistory.type(),
+        is(PROGRAMME_DAY_ONE));
+    assertThat("Unexpected history status.", foundHistory.status(), is(SCHEDULED));
+  }
 
-    List<History> foundHistory = service.findAllScheduledInAppForTrainee(
-        TRAINEE_ID, TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
+  @Test
+  void shouldNotReturnInAppNotificationsBySentAt() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo1 =
+        new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo2 =
+        new TisReferenceInfo(TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID);
 
-    assertThat("Unexpected history count.", foundHistory.size(), is(0));
+    Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo, templateInfo,
+        now, now, SENT, null, null));
+    service.save(new History(null, tisReferenceInfo2, PROGRAMME_DAY_ONE, recipientInfo,
+        templateInfo, now, now, SCHEDULED, null, null));
+
+    History foundHistory = service.findScheduledEmailForTraineeByRefAndType(
+        TRAINEE_ID, TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID, PROGRAMME_DAY_ONE);
+
+    assertThat("Unexpected history count.", foundHistory, is(nullValue()));
   }
 
   @Test
@@ -394,7 +431,7 @@ class HistoryServiceIntegrationTest {
     service.save(new History(null, tisRefInfoPlacement2, FORM_UPDATED, recipientInfo, templateInfo,
         after, after, SENT, null, null));
 
-    List<History> foundHistory = service.findAllScheduledInAppForTrainee(
+    List<History> foundHistory = service.findAllScheduledForTrainee(
         TRAINEE_ID, TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
 
     assertThat("Unexpected history count.", foundHistory.size(), is(1));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -610,7 +610,7 @@ class HistoryServiceTest {
   void shouldFindNoHistoryForTraineeWhenScheduledInAppNotificationsNotExist() {
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(List.of());
 
-    List<History> history = service.findAllScheduledInAppForTrainee(
+    List<History> history = service.findAllScheduledForTrainee(
         TRAINEE_ID, TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     assertThat("Unexpected history count.", history.size(), is(0));
@@ -618,7 +618,7 @@ class HistoryServiceTest {
 
   @ParameterizedTest
   @MethodSource("uk.nhs.tis.trainee.notifications.MethodArgumentUtil#getTemplateCombinations")
-  void shouldFindHistoryForTraineeWhenScheduledInAppNotificationsExist(MessageType messageType,
+  void shouldFindHistoryForTraineeWhenScheduledNotificationsExist(MessageType messageType,
                                                              NotificationType notificationType) {
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, messageType, TRAINEE_CONTACT);
     TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
@@ -643,24 +643,20 @@ class HistoryServiceTest {
 
     when(templateService.process(any(), any(), anyMap())).thenReturn("");
 
-    List<History> history = service.findAllScheduledInAppForTrainee(
+    List<History> history = service.findAllScheduledForTrainee(
         TRAINEE_ID, TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
-    if (messageType.equals(IN_APP)) {
-      assertThat("Unexpected history count.", history.size(), is(1));
+    assertThat("Unexpected history count.", history.size(), is(1));
 
-      History returnedHistory1 = history.get(0);
-      assertThat("Unexpected history id.", returnedHistory1.id(), is(id3));
-      TisReferenceInfo referenceInfo2 = history.get(0).tisReference();
-      assertThat("Unexpected history TIS reference type.", referenceInfo2.type(),
-          is(TIS_REFERENCE_TYPE));
-      assertThat("Unexpected history TIS reference id.", referenceInfo2.id(),
-          is(TIS_REFERENCE_ID));
-      assertThat("Unexpected history sent at.", returnedHistory1.sentAt(), is(Instant.MAX));
-      assertThat("Unexpected history read at.", returnedHistory1.readAt(), is(Instant.MIN));
-    } else {
-      assertThat("Unexpected history count.", history.size(), is(0));
-    }
+    History returnedHistory1 = history.get(0);
+    assertThat("Unexpected history id.", returnedHistory1.id(), is(id3));
+    TisReferenceInfo referenceInfo2 = history.get(0).tisReference();
+    assertThat("Unexpected history TIS reference type.", referenceInfo2.type(),
+        is(TIS_REFERENCE_TYPE));
+    assertThat("Unexpected history TIS reference id.", referenceInfo2.id(),
+        is(TIS_REFERENCE_ID));
+    assertThat("Unexpected history sent at.", returnedHistory1.sentAt(), is(Instant.MAX));
+    assertThat("Unexpected history read at.", returnedHistory1.readAt(), is(Instant.MIN));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -37,7 +37,9 @@ import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
 import static uk.nhs.tis.trainee.notifications.model.MessageType.IN_APP;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SCHEDULED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
 
@@ -166,7 +168,7 @@ class HistoryServiceTest {
 
   @ParameterizedTest
   @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
-      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
+      names = {"ARCHIVED", "READ", "UNREAD", "SCHEDULED", "DELETED"})
   void shouldUpdateValidStatusWhenEmailHistoryFound(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
@@ -207,8 +209,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
-      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"ARCHIVED", "READ",
+      "SCHEDULED", "UNREAD", "DELETED"})
   void shouldThrowExceptionWhenUpdatingInAppHistoryWithInvalidStatus(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
@@ -302,8 +304,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
-      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"ARCHIVED", "READ",
+      "SCHEDULED", "UNREAD", "DELETED"})
   void shouldUpdateValidStatusForTraineeWhenEmailHistoryFound(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
@@ -344,8 +346,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
-      names = {"ARCHIVED", "READ", "UNREAD", "DELETED"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"ARCHIVED", "READ",
+      "SCHEDULED", "UNREAD", "DELETED"})
   void shouldThrowExceptionWhenUpdatingInAppHistoryForTraineeWithInvalidStatus(
       NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
@@ -364,8 +366,8 @@ class HistoryServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE,
-      names = {"FAILED", "SENT", "DELETED"})
+  @EnumSource(value = NotificationStatus.class, mode = Mode.EXCLUDE, names = {"FAILED", "SENT",
+      "DELETED"})
   void shouldUpdateValidStatusForTraineeWhenInAppHistoryFound(NotificationStatus status) {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
@@ -803,6 +805,66 @@ class HistoryServiceTest {
 
     HistoryDto historyDto = historyDtos.get(0);
     assertThat("Unexpected history subject text.", historyDto.subjectText(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldSetScheduledStatusInFoundHistoryWhenInAppNotificationWithFutureSentAt(
+      NotificationType notificationType) {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id1 = ObjectId.get();
+    History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
+        templateInfo, Instant.MAX, null, UNREAD, null, null);
+
+    when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
+        List.of(history1));
+
+    String templatePath = "type/test/template/v1.2.3";
+    when(templateService.getTemplatePath(IN_APP, TEMPLATE_NAME, TEMPLATE_VERSION)).thenReturn(
+        templatePath);
+    when(templateService.process(templatePath, Set.of("subject"), TEMPLATE_VARIABLES)).thenReturn(
+        "rebuiltSubject");
+
+    List<HistoryDto> historyDtos = service.findAllForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", historyDtos.size(), is(1));
+
+    HistoryDto historyDto = historyDtos.get(0);
+    assertThat("Unexpected history status.", historyDto.status(), is(SCHEDULED));
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldNotChangeStatusInFoundHistoryWhenInAppNotificationWithPastSentAt(
+      NotificationType notificationType) {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id1 = ObjectId.get();
+    History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
+        templateInfo, Instant.MIN, null, UNREAD, null, null);
+
+    when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
+        List.of(history1));
+
+    String templatePath = "type/test/template/v1.2.3";
+    when(templateService.getTemplatePath(IN_APP, TEMPLATE_NAME, TEMPLATE_VERSION)).thenReturn(
+        templatePath);
+    when(templateService.process(templatePath, Set.of("subject"), TEMPLATE_VARIABLES)).thenReturn(
+        "rebuiltSubject");
+
+    List<HistoryDto> historyDtos = service.findAllForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected history count.", historyDtos.size(), is(1));
+
+    HistoryDto historyDto = historyDtos.get(0);
+    assertThat("Unexpected history status.", historyDto.status(), is(UNREAD));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -22,6 +22,7 @@
 package uk.nhs.tis.trainee.notifications.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -43,8 +44,11 @@ import static uk.nhs.tis.trainee.notifications.model.HrefType.ABSOLUTE_URL;
 import static uk.nhs.tis.trainee.notifications.model.HrefType.NON_HREF;
 import static uk.nhs.tis.trainee.notifications.model.HrefType.PROTOCOL_EMAIL;
 import static uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType.ONBOARDING_SUPPORT;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SCHEDULED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
+import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTACT_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTACT_TYPE_FIELD;
@@ -93,6 +97,7 @@ import org.springframework.web.client.RestTemplate;
 import org.testcontainers.shaded.org.apache.commons.lang3.time.DateUtils;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
+import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.MessageType;
@@ -146,6 +151,7 @@ class NotificationServiceTest {
   private NotificationService service;
   private NotificationService serviceWhitelisted;
   private EmailService emailService;
+  private HistoryService historyService;
   private RestTemplate restTemplate;
   private Scheduler scheduler;
   private MessagingControllerService messagingControllerService;
@@ -155,6 +161,7 @@ class NotificationServiceTest {
   void setUp() {
     jobExecutionContext = mock(JobExecutionContext.class);
     emailService = mock(EmailService.class);
+    historyService = mock(HistoryService.class);
     restTemplate = mock(RestTemplate.class);
     scheduler = mock(Scheduler.class);
     messagingControllerService = mock(MessagingControllerService.class);
@@ -187,11 +194,11 @@ class NotificationServiceTest {
         .usingJobData(placementJobDataMap)
         .build();
 
-    service = new NotificationService(emailService, restTemplate, scheduler,
+    service = new NotificationService(emailService, historyService, restTemplate, scheduler,
         messagingControllerService, TEMPLATE_VERSION, SERVICE_URL, REFERENCE_URL,
         NOTIFICATION_DELAY, NOT_WHITELISTED, TIMEZONE);
-    serviceWhitelisted = new NotificationService(emailService, restTemplate, scheduler,
-        messagingControllerService, TEMPLATE_VERSION, SERVICE_URL, REFERENCE_URL,
+    serviceWhitelisted = new NotificationService(emailService, historyService, restTemplate,
+        scheduler, messagingControllerService, TEMPLATE_VERSION, SERVICE_URL, REFERENCE_URL,
         NOTIFICATION_DELAY, WHITELISTED, TIMEZONE);
   }
 
@@ -507,7 +514,8 @@ class NotificationServiceTest {
 
   @Test
   void shouldScheduleProgrammeMembershipNotification() throws SchedulerException {
-    String jobId = PROGRAMME_CREATED + "-" + TIS_ID;
+    NotificationType notificationType = NotificationType.PROGRAMME_CREATED;
+    String jobId = notificationType + "-" + TIS_ID;
 
     LocalDate expectedDate = START_DATE.minusDays(0);
     Date when = Date.from(expectedDate
@@ -515,8 +523,16 @@ class NotificationServiceTest {
         .atZone(ZoneId.of(TIMEZONE))
         .toInstant());
 
+    UserDetails userAccountDetails =
+        new UserDetails(
+            false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+
     service.scheduleNotification(jobId, programmeJobDataMap, when);
 
+    // create job in scheduler
     ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.captor();
     ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.captor();
     verify(scheduler).scheduleJob(jobDetailCaptor.capture(), triggerCaptor.capture());
@@ -525,11 +541,44 @@ class NotificationServiceTest {
     TriggerKey expectedTriggerKey = TriggerKey.triggerKey("trigger-" + jobId);
     assertThat("Unexpected trigger id", trigger.getKey(), is(expectedTriggerKey));
     assertThat("Unexpected trigger start time", trigger.getStartTime(), is(when));
+
+    // save scheduled history in DB
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected notification id.", history.id(), notNullValue());
+    assertThat("Unexpected notification type.", history.type(), is(notificationType));
+    assertThat("Unexpected sent at.", history.sentAt(), notNullValue());
+    assertThat("Unexpected status.", history.status(), is(SCHEDULED));
+    assertThat("Unexpected status detail.", history.statusDetail(), nullValue());
+
+    History.RecipientInfo recipient = history.recipient();
+    assertThat("Unexpected recipient id.", recipient.id(), is(PERSON_ID));
+    assertThat("Unexpected message type.", recipient.type(), is(EMAIL));
+    assertThat("Unexpected contact.", recipient.contact(), is(USER_EMAIL));
+
+    TisReferenceInfo tisReference = history.tisReference();
+    assertThat("Unexpected reference table.", tisReference.type(), is(PROGRAMME_MEMBERSHIP));
+    assertThat("Unexpected reference id key.", tisReference.id(), is(TIS_ID));
+
+    History.TemplateInfo templateInfo = history.template();
+    assertThat("Unexpected template name.", templateInfo.name(),
+        is(notificationType.getTemplateName()));
+    assertThat("Unexpected template version.", templateInfo.version(), is(TEMPLATE_VERSION));
+
+    Map<String, Object> storedVariables = templateInfo.variables();
+    assertThat("Unexpected template variable.", storedVariables.get(TIS_ID_FIELD), is(TIS_ID));
+    assertThat("Unexpected template variable.", storedVariables.get(START_DATE_FIELD),
+        is(START_DATE));
+    assertThat("Unexpected template variable.", storedVariables.get(PERSON_ID_FIELD),
+        is(PERSON_ID));
   }
 
   @Test
   void shouldSchedulePlacementNotification() throws SchedulerException {
-    String jobId = NotificationType.PLACEMENT_UPDATED_WEEK_12 + "-" + TIS_ID;
+    NotificationType notificationType = NotificationType.PLACEMENT_UPDATED_WEEK_12;
+    String jobId = notificationType + "-" + TIS_ID;
 
     LocalDate expectedDate = START_DATE.minusDays(84);
     Date when = Date.from(expectedDate
@@ -537,8 +586,16 @@ class NotificationServiceTest {
         .atZone(ZoneId.of(TIMEZONE))
         .toInstant());
 
+    UserDetails userAccountDetails =
+        new UserDetails(
+            false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
+    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
+    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
+        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
+
     service.scheduleNotification(jobId, placementJobDataMap, when);
 
+    // create job in scheduler
     ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.captor();
     ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.captor();
     verify(scheduler).scheduleJob(jobDetailCaptor.capture(), triggerCaptor.capture());
@@ -547,6 +604,38 @@ class NotificationServiceTest {
     TriggerKey expectedTriggerKey = TriggerKey.triggerKey("trigger-" + jobId);
     assertThat("Unexpected trigger id", trigger.getKey(), is(expectedTriggerKey));
     assertThat("Unexpected trigger start time", trigger.getStartTime(), is(when));
+
+    // save scheduled history in DB
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected notification id.", history.id(), notNullValue());
+    assertThat("Unexpected notification type.", history.type(), is(notificationType));
+    assertThat("Unexpected sent at.", history.sentAt(), notNullValue());
+    assertThat("Unexpected status.", history.status(), is(SCHEDULED));
+    assertThat("Unexpected status detail.", history.statusDetail(), nullValue());
+
+    History.RecipientInfo recipient = history.recipient();
+    assertThat("Unexpected recipient id.", recipient.id(), is(PERSON_ID));
+    assertThat("Unexpected message type.", recipient.type(), is(EMAIL));
+    assertThat("Unexpected contact.", recipient.contact(), is(USER_EMAIL));
+
+    TisReferenceInfo tisReference = history.tisReference();
+    assertThat("Unexpected reference table.", tisReference.type(), is(PLACEMENT));
+    assertThat("Unexpected reference id key.", tisReference.id(), is(TIS_ID));
+
+    History.TemplateInfo templateInfo = history.template();
+    assertThat("Unexpected template name.", templateInfo.name(),
+        is(notificationType.getTemplateName()));
+    assertThat("Unexpected template version.", templateInfo.version(), is(TEMPLATE_VERSION));
+
+    Map<String, Object> storedVariables = templateInfo.variables();
+    assertThat("Unexpected template variable.", storedVariables.get(TIS_ID_FIELD), is(TIS_ID));
+    assertThat("Unexpected template variable.", storedVariables.get(START_DATE_FIELD),
+        is(START_DATE));
+    assertThat("Unexpected template variable.", storedVariables.get(PERSON_ID_FIELD),
+        is(PERSON_ID));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -493,7 +493,7 @@ class PlacementServiceTest {
     Placement placement = new Placement();
     placement.setTisId(TIS_ID);
 
-    service.deleteNotifications(placement);
+    service.deleteNotificationsFromScheduler(placement);
 
     String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + TIS_ID;
     verify(notificationService).removeNotification(jobId);
@@ -799,10 +799,10 @@ class PlacementServiceTest {
         .status(UNREAD)
         .build();
 
-    when(historyService.findAllScheduledInAppForTrainee(PERSON_ID, PLACEMENT, TIS_ID))
+    when(historyService.findAllScheduledForTrainee(PERSON_ID, PLACEMENT, TIS_ID))
         .thenReturn(List.of(history1, history2));
 
-    service.deleteScheduledInAppNotifications(placement);
+    service.deleteScheduledNotificationsFromDb(placement);
 
     verify(historyService).deleteHistoryForTrainee(HISTORY_ID_1, PERSON_ID);
     verify(historyService).deleteHistoryForTrainee(HISTORY_ID_2, PERSON_ID);
@@ -819,10 +819,10 @@ class PlacementServiceTest {
     placement.setSpecialty(SPECIALTY);
     placement.setSite(SITE);
 
-    when(historyService.findAllScheduledInAppForTrainee(PERSON_ID, PLACEMENT, TIS_ID))
+    when(historyService.findAllScheduledForTrainee(PERSON_ID, PLACEMENT, TIS_ID))
         .thenReturn(List.of());
 
-    service.deleteScheduledInAppNotifications(placement);
+    service.deleteScheduledNotificationsFromDb(placement);
 
     verify(historyService, never()).deleteHistoryForTrainee(any(), any());
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -1452,7 +1452,7 @@ class ProgrammeMembershipServiceTest {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(TIS_ID);
 
-    service.deleteNotifications(programmeMembership);
+    service.deleteNotificationsFromScheduler(programmeMembership);
 
     for (NotificationType milestone : NotificationType.getProgrammeUpdateNotificationTypes()) {
       String jobId = milestone.toString() + "-" + TIS_ID;
@@ -1478,10 +1478,10 @@ class ProgrammeMembershipServiceTest {
         .status(UNREAD)
         .build();
 
-    when(historyService.findAllScheduledInAppForTrainee(PERSON_ID, PROGRAMME_MEMBERSHIP, TIS_ID))
+    when(historyService.findAllScheduledForTrainee(PERSON_ID, PROGRAMME_MEMBERSHIP, TIS_ID))
         .thenReturn(List.of(history1, history2));
 
-    service.deleteScheduledInAppNotifications(programmeMembership);
+    service.deleteScheduledNotificationsFromDb(programmeMembership);
 
     verify(historyService).deleteHistoryForTrainee(HISTORY_ID_1, PERSON_ID);
     verify(historyService).deleteHistoryForTrainee(HISTORY_ID_2, PERSON_ID);
@@ -1491,10 +1491,10 @@ class ProgrammeMembershipServiceTest {
   void shouldNotDeleteWhenNoScheduledInAppNotifications() {
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
 
-    when(historyService.findAllScheduledInAppForTrainee(PERSON_ID, PROGRAMME_MEMBERSHIP, TIS_ID))
+    when(historyService.findAllScheduledForTrainee(PERSON_ID, PROGRAMME_MEMBERSHIP, TIS_ID))
         .thenReturn(List.of());
 
-    service.deleteScheduledInAppNotifications(programmeMembership);
+    service.deleteScheduledNotificationsFromDb(programmeMembership);
 
     verify(historyService, never()).deleteHistoryForTrainee(any(), any());
   }


### PR DESCRIPTION
In-App Notifications:
- Return future In-App notifications with SCHEDULED status
  (For In-App notifications, only return SCHEDULED status in DTO but not storing in DB)


Email Notifications:
- Save tisReference, recipient, template variables and everything the template needed of the scheduled Emails to the database with status SCHEDULED
- Currently non-pilot will also be scheduled in the Quartz, they will be excluded just before it is sent out. I have keep this unchanged in Quartz, but only save notifications of New starter in Pilot with correct notification type to History DB, so only the actionable notification will be shown on TIS Notification tab.
- Update scheduled history in DB when it is sent


Sample of SCHEDULED email in History collection.
![image](https://github.com/user-attachments/assets/e37aab8b-cbf0-40cf-946e-233a83defbac)

TIS21-6014
TIS21-6077
TIS21-6076