### PR TITLE
fix: set `isValidGmc` flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.31.2"
+version = "1.31.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -385,6 +385,7 @@ public class NotificationService implements Job {
       jobDetails.putIfAbsent("gmcNumber", userAccountDetails.gmcNumber());
     }
 
+    jobDetails.putIfAbsent("isValidGmc", isValidGmc(jobDetails.getString("gmcNumber")));
     return jobDetails;
   }
 


### PR DESCRIPTION
The `isValidGmc` flag is not being set, resulting the template including both the GMC number and a message that the GMC number is invalid/not available.

Calculate and include the GMC number validity when enriching the job details.

TIS21-6449