### PR TITLE
feat: remove PM pilot filtering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.31.3"
+version = "1.32.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerService.java
@@ -43,8 +43,6 @@ public class MessagingControllerService {
   private static final String PROGRAMME_MEMBERSHIP_ID_FIELD = "programmeMembershipId";
   protected static final String API_PLACEMENT_IS_PILOT_2024
       = "/api/placement/ispilot2024/{traineeTisId}/{placementId}";
-  protected static final String API_PROGRAMME_MEMBERSHIP_IS_PILOT_2024
-      = "/api/programme-membership/ispilot2024/{traineeTisId}/{programmeMembershipId}";
   protected static final String API_PROGRAMME_MEMBERSHIP_NEW_STARTER
       = "/api/programme-membership/isnewstarter/{traineeTisId}/{programmeMembershipId}";
 
@@ -109,26 +107,6 @@ public class MessagingControllerService {
         Boolean.class, Map.of(TRAINEE_TIS_ID_FIELD, traineeId, PLACEMENT_ID_FIELD, placementId));
     if (isPilot == null || !isPilot) {
       log.info("Trainee {} placement {} is not in the pilot 2024.", traineeId, placementId);
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Identifies if a programme membership falls within the pilot group 2024.
-   *
-   * @param traineeId             The trainee TIS ID whose placement it is.
-   * @param programmeMembershipId The programme membership ID.
-   * @return true if the programme membership is in the pilot group, otherwise false.
-   */
-  public boolean isProgrammeMembershipInPilot2024(String traineeId, String programmeMembershipId) {
-    Boolean isPilot = restTemplate.getForObject(serviceUrl
-            + API_PROGRAMME_MEMBERSHIP_IS_PILOT_2024, Boolean.class,
-        Map.of(TRAINEE_TIS_ID_FIELD, traineeId,
-            PROGRAMME_MEMBERSHIP_ID_FIELD, programmeMembershipId));
-    if (isPilot == null || !isPilot) {
-      log.info("Trainee {} programme membership {} is not in the pilot 2024.",
-          traineeId, programmeMembershipId);
       return false;
     }
     return true;

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -412,7 +412,7 @@ public class NotificationService implements Job {
       actuallySendEmail
           = inWhitelist
           || (messagingControllerService.isValidRecipient(personId, MessageType.EMAIL)
-          && meetsCriteria(minimalPm, true, true));
+          && meetsCriteria(minimalPm, true));
 
     } else if (notificationType == NotificationType.PLACEMENT_UPDATED_WEEK_12) {
 
@@ -512,11 +512,9 @@ public class NotificationService implements Job {
    *
    * @param programmeMembership The programme membership to check.
    * @param checkNewStarter     Whether the trainee must be a new starter.
-   * @param checkPilot          Whether the trainee must be in a pilot.
    * @return true if all criteria met, or false if one or more criteria fail.
    */
-  public boolean meetsCriteria(ProgrammeMembership programmeMembership,
-      boolean checkNewStarter, boolean checkPilot) {
+  public boolean meetsCriteria(ProgrammeMembership programmeMembership, boolean checkNewStarter) {
     String traineeId = programmeMembership.getPersonId();
     String pmId = programmeMembership.getTisId();
 
@@ -526,16 +524,6 @@ public class NotificationService implements Job {
 
       if (!isNewStarter) {
         log.info("Skipping notification creation as trainee {} is not a new starter.", traineeId);
-        return false;
-      }
-    }
-
-    if (checkPilot) {
-      boolean isInPilot
-          = messagingControllerService.isProgrammeMembershipInPilot2024(traineeId, pmId);
-
-      if (!isInPilot) {
-        log.info("Skipping notification creation as trainee {} is not in the pilot.", traineeId);
         return false;
       }
     }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -317,7 +317,7 @@ public class ProgrammeMembershipService {
   private void createInAppNotifications(ProgrammeMembership programmeMembership,
       Map<NotificationType, History> notificationsAlreadySent) {
     // Create ePortfolio notification if the PM qualifies.
-    boolean meetsCriteria = notificationService.meetsCriteria(programmeMembership, true, true);
+    boolean meetsCriteria = notificationService.meetsCriteria(programmeMembership, true);
 
     if (meetsCriteria) {
       // E_PORTFOLIO

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceTest.java
@@ -378,8 +378,8 @@ class EmailServiceTest {
   @EnumSource(NotificationType.class)
   void shouldStoreHistoryWhenMessageSent(NotificationType notificationType)
       throws MessagingException {
-    when(historyService.findScheduledEmailForTraineeByRefAndType(any(), any(), any(), any())).
-        thenReturn(null);
+    when(historyService.findScheduledEmailForTraineeByRefAndType(any(), any(), any(), any()))
+        .thenReturn(null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, "Mr", "Gilliam",
             "Anthony", GMC));
@@ -428,8 +428,8 @@ class EmailServiceTest {
     ObjectId notificationId = ObjectId.get();
     History scheduledHistory = new History(notificationId, null, notificationType,
         null, null, null, null, SCHEDULED, null, null);
-    when(historyService.findScheduledEmailForTraineeByRefAndType(any(), any(), any(), any())).
-        thenReturn(scheduledHistory);
+    when(historyService.findScheduledEmailForTraineeByRefAndType(any(), any(), any(), any()))
+        .thenReturn(scheduledHistory);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, RECIPIENT, "Mr", "Gilliam",
             "Anthony", GMC));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/MessagingControllerServiceTest.java
@@ -129,32 +129,4 @@ class MessagingControllerServiceTest {
         service.isProgrammeMembershipNewStarter("123", "abc"),
         is(true));
   }
-
-  @ParameterizedTest
-  @NullSource
-  @ValueSource(booleans = false)
-  void isProgrammeMembershipInPilotShouldReturnFalseIfApiNotTrue(Boolean apiResult) {
-    when(restTemplate
-        .getForObject(
-            "the-url/api/programme-membership/ispilot2024/{traineeTisId}/{programmeMembershipId}",
-            Boolean.class, Map.of("traineeTisId", "123",
-                "programmeMembershipId", "abc"))).thenReturn(apiResult);
-
-    assertThat("Unexpected isProgrammeMembershipInPilot2024() result.",
-        service.isProgrammeMembershipInPilot2024("123", "abc"),
-        is(false));
-  }
-
-  @Test
-  void isProgrammeMembershipInPilotShouldReturnTrueIfApiTrue() {
-    when(restTemplate
-        .getForObject(
-            "the-url/api/programme-membership/ispilot2024/{traineeTisId}/{programmeMembershipId}",
-            Boolean.class, Map.of("traineeTisId", "123",
-                "programmeMembershipId", "abc"))).thenReturn(true);
-
-    assertThat("Unexpected isProgrammeMembershipInPilot2024() result.",
-        service.isProgrammeMembershipInPilot2024("123", "abc"),
-        is(true));
-  }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -338,8 +338,6 @@ class NotificationServiceTest {
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
         .thenReturn(!apiResult);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
-        .thenReturn(apiResult);
 
     service.execute(jobExecutionContext);
 
@@ -382,8 +380,6 @@ class NotificationServiceTest {
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(apiResult);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
         .thenReturn(!apiResult);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
-        .thenReturn(apiResult);
 
     serviceWhitelisted.execute(jobExecutionContext);
 
@@ -422,8 +418,6 @@ class NotificationServiceTest {
         Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any())).thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
-        .thenReturn(true);
 
     service.execute(jobExecutionContext);
 
@@ -466,8 +460,6 @@ class NotificationServiceTest {
 
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any())).thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any())).thenReturn(
-        true);
 
     JobDataMap jobData = new JobDataMap(Map.of(
         PERSON_ID_FIELD, PERSON_ID,
@@ -495,8 +487,6 @@ class NotificationServiceTest {
 
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any())).thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any())).thenReturn(
-        true);
 
     JobDataMap jobData = new JobDataMap(Map.of(
         PERSON_ID_FIELD, PERSON_ID,
@@ -519,8 +509,6 @@ class NotificationServiceTest {
 
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any())).thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any())).thenReturn(
-        true);
 
     boolean result = service.shouldActuallySendEmail(notificationType, PERSON_ID, TIS_ID);
 
@@ -545,8 +533,6 @@ class NotificationServiceTest {
         Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
-        .thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
         .thenReturn(true);
 
     String jobId = notificationType + "-" + TIS_ID;
@@ -682,8 +668,6 @@ class NotificationServiceTest {
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(false);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
         .thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
-        .thenReturn(true);
 
     String jobId = notificationType + "-" + TIS_ID;
     service.scheduleNotification(jobId, programmeJobDataMap, when);
@@ -709,36 +693,6 @@ class NotificationServiceTest {
         Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
-        .thenReturn(false);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
-        .thenReturn(true);
-
-    String jobId = notificationType + "-" + TIS_ID;
-    service.scheduleNotification(jobId, programmeJobDataMap, when);
-
-    verify(historyService, never()).save(any());
-  }
-
-  @Test
-  void shouldNotSaveSchedulePmNotificationHistoryWhenNotInPilot() throws SchedulerException {
-    NotificationType notificationType = NotificationType.PROGRAMME_DAY_ONE;
-
-    LocalDate expectedDate = START_DATE.minusDays(0);
-    Date when = Date.from(expectedDate
-        .atStartOfDay()
-        .atZone(ZoneId.of(TIMEZONE))
-        .toInstant());
-
-    UserDetails userAccountDetails =
-        new UserDetails(
-            false, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
-    when(emailService.getRecipientAccountByEmail(USER_EMAIL)).thenReturn(userAccountDetails);
-    when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
-        Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
-    when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
-        .thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
         .thenReturn(false);
 
     String jobId = notificationType + "-" + TIS_ID;
@@ -848,8 +802,6 @@ class NotificationServiceTest {
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
         .thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
-        .thenReturn(true);
 
     List<Map<String, String>> contacts = new ArrayList<>();
     Map<String, String> contact1 = new HashMap<>();
@@ -901,8 +853,6 @@ class NotificationServiceTest {
         Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
     when(messagingControllerService.isValidRecipient(any(), any())).thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(any(), any()))
-        .thenReturn(true);
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(any(), any()))
         .thenReturn(true);
 
     List<Map<String, String>> contacts = new ArrayList<>();
@@ -1073,41 +1023,33 @@ class NotificationServiceTest {
   }
 
   @Test
-  void shouldMeetPmCriteriaWhenIsNewStarterAndIsInPilot() {
+  void shouldMeetPmCriteriaWhenIsNewStarter() {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(TIS_ID);
     programmeMembership.setPersonId(PERSON_ID);
 
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(PERSON_ID, TIS_ID))
-        .thenReturn(true);
     when(messagingControllerService.isProgrammeMembershipNewStarter(PERSON_ID, TIS_ID))
         .thenReturn(true);
 
-    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true, true);
+    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true);
 
     assertThat("Unexpected unmet programme membership criteria.", meetsCriteria, is(true));
 
     verify(messagingControllerService).isProgrammeMembershipNewStarter(PERSON_ID, TIS_ID);
-    verify(messagingControllerService).isProgrammeMembershipInPilot2024(PERSON_ID, TIS_ID);
   }
 
   @Test
-  void shouldNotMeetPmCriteriaWhenNotNewStarterAndNotInPilot() {
+  void shouldNotMeetPmCriteriaWhenNotNewStarter() {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(TIS_ID);
     programmeMembership.setPersonId(PERSON_ID);
 
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(PERSON_ID, TIS_ID))
-        .thenReturn(false);
     when(messagingControllerService.isProgrammeMembershipNewStarter(PERSON_ID, TIS_ID))
         .thenReturn(false);
 
-    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true, true);
+    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true);
 
     assertThat("Unexpected unmet programme membership criteria.", meetsCriteria, is(false));
-
-    // Verify that we short-circuit on the first false result.
-    verify(messagingControllerService, never()).isProgrammeMembershipInPilot2024(any(), any());
   }
 
   @Test
@@ -1119,8 +1061,7 @@ class NotificationServiceTest {
     when(messagingControllerService.isProgrammeMembershipNewStarter(PERSON_ID, TIS_ID)).thenReturn(
         true);
 
-    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true,
-        false);
+    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true);
 
     assertThat("Unexpected unmet programme membership criteria.", meetsCriteria, is(true));
   }
@@ -1134,8 +1075,7 @@ class NotificationServiceTest {
     when(messagingControllerService.isProgrammeMembershipNewStarter(PERSON_ID, TIS_ID)).thenReturn(
         false);
 
-    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true,
-        false);
+    boolean meetsCriteria = service.meetsCriteria(programmeMembership, true);
 
     assertThat("Unexpected unmet programme membership criteria.", meetsCriteria, is(false));
 
@@ -1144,39 +1084,16 @@ class NotificationServiceTest {
   }
 
   @Test
-  void shouldMeetPmCriteriaWhenNewStartCheckSkippedAndIsInPilot() {
+  void shouldMeetPmCriteriaWhenNewStartCheckSkipped() {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(TIS_ID);
     programmeMembership.setPersonId(PERSON_ID);
 
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(PERSON_ID, TIS_ID)).thenReturn(
-        true);
-
-    boolean meetsCriteria = service.meetsCriteria(programmeMembership, false,
-        true);
+    boolean meetsCriteria = service.meetsCriteria(programmeMembership, false);
 
     assertThat("Unexpected unmet programme membership criteria.", meetsCriteria, is(true));
 
-    verify(messagingControllerService).isProgrammeMembershipInPilot2024(PERSON_ID, TIS_ID);
-    verifyNoMoreInteractions(messagingControllerService);
-  }
-
-  @Test
-  void shouldNotMeetPmCriteriaWhenNewStartCheckSkippedAndNotInPilot() {
-    ProgrammeMembership programmeMembership = new ProgrammeMembership();
-    programmeMembership.setTisId(TIS_ID);
-    programmeMembership.setPersonId(PERSON_ID);
-
-    when(messagingControllerService.isProgrammeMembershipInPilot2024(PERSON_ID, TIS_ID)).thenReturn(
-        false);
-
-    boolean meetsCriteria = service.meetsCriteria(programmeMembership, false,
-        true);
-
-    assertThat("Unexpected unmet programme membership criteria.", meetsCriteria, is(false));
-
-    verify(messagingControllerService).isProgrammeMembershipInPilot2024(PERSON_ID, TIS_ID);
-    verifyNoMoreInteractions(messagingControllerService);
+    verifyNoInteractions(messagingControllerService);
   }
 
   @Test
@@ -1185,8 +1102,7 @@ class NotificationServiceTest {
     programmeMembership.setTisId(TIS_ID);
     programmeMembership.setPersonId(PERSON_ID);
 
-    boolean meetsCriteria = service.meetsCriteria(programmeMembership, false,
-        false);
+    boolean meetsCriteria = service.meetsCriteria(programmeMembership, false);
 
     assertThat("Unexpected unmet programme membership criteria.", meetsCriteria, is(true));
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -289,8 +289,7 @@ class ProgrammeMembershipServiceTest {
         new UserDetails(
             null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, USER_GMC);
 
-    when(notificationService.meetsCriteria(programmeMembership, true,
-        true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.programmeMembershipIsNotifiable(programmeMembership,
         MessageType.IN_APP)).thenReturn(notifiablePm);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
@@ -343,7 +342,7 @@ class ProgrammeMembershipServiceTest {
     programmeMembership.setCurricula(List.of(theCurriculum));
     programmeMembership.setConditionsOfJoining(new ConditionsOfJoining(Instant.MIN));
 
-    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
 
@@ -373,7 +372,7 @@ class ProgrammeMembershipServiceTest {
         new Curriculum(MEDICAL_CURRICULUM_1, "specialty 3", false)
     ));
 
-    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
     when(notificationService.getTraineeDetails(PERSON_ID)).thenReturn(null);
@@ -400,7 +399,7 @@ class ProgrammeMembershipServiceTest {
         new Curriculum(MEDICAL_CURRICULUM_1, "specialty 3", false)
     ));
 
-    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
 
@@ -423,7 +422,7 @@ class ProgrammeMembershipServiceTest {
       throws SchedulerException {
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
 
-    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
 
     List<Map<String, String>> contactList = List.of(
         Map.of(CONTACT_TYPE_FIELD, LocalOfficeContactType.LTFT.getContactTypeName()));
@@ -475,7 +474,7 @@ class ProgrammeMembershipServiceTest {
     programmeMembership.setConditionsOfJoining(new ConditionsOfJoining(Instant.MIN));
     programmeMembership.setManagingDeanery(MANAGING_DEANERY);
 
-    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
 
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
@@ -512,7 +511,7 @@ class ProgrammeMembershipServiceTest {
         new UserDetails(
             null, USER_EMAIL, USER_TITLE, USER_FAMILY_NAME, USER_GIVEN_NAME, null);
 
-    when(notificationService.meetsCriteria(programmeMembership, true, true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
 
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
@@ -537,8 +536,7 @@ class ProgrammeMembershipServiceTest {
   void shouldNotAddInAppNotificationsWhenNotMeetsCriteria() throws SchedulerException {
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
 
-    when(notificationService.meetsCriteria(programmeMembership, true,
-        true)).thenReturn(false);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(false);
 
     service.addNotifications(programmeMembership);
 
@@ -558,8 +556,7 @@ class ProgrammeMembershipServiceTest {
             notificationType, recipientInfo, null, Instant.MIN, Instant.MAX, UNREAD, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
-    when(notificationService.meetsCriteria(programmeMembership, true,
-        true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.programmeMembershipIsNotifiable(programmeMembership,
         MessageType.IN_APP)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
@@ -576,8 +573,7 @@ class ProgrammeMembershipServiceTest {
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
     programmeMembership.setResponsibleOfficer(null);
 
-    when(notificationService.meetsCriteria(programmeMembership, true,
-        true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
 
@@ -599,8 +595,7 @@ class ProgrammeMembershipServiceTest {
         "roGmc", "roPhone");
     programmeMembership.setResponsibleOfficer(theRo);
 
-    when(notificationService.meetsCriteria(programmeMembership, true,
-        true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
 
@@ -622,8 +617,7 @@ class ProgrammeMembershipServiceTest {
         "roGmc", "roPhone");
     programmeMembership.setResponsibleOfficer(theRo);
 
-    when(notificationService.meetsCriteria(programmeMembership, true,
-        true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
 
@@ -645,8 +639,7 @@ class ProgrammeMembershipServiceTest {
         "roGmc", "roPhone");
     programmeMembership.setResponsibleOfficer(theRo);
 
-    when(notificationService.meetsCriteria(programmeMembership, true,
-        true)).thenReturn(true);
+    when(notificationService.meetsCriteria(programmeMembership, true)).thenReturn(true);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("");
 
@@ -773,7 +766,9 @@ class ProgrammeMembershipServiceTest {
     when(notificationService.getOwnerContactList(any())).thenReturn(contactList);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("contact");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("href");
-    when(notificationService.meetsCriteria(any(), anyBoolean(), anyBoolean())).thenReturn(true);
+    when(
+        notificationService.meetsCriteria(any(ProgrammeMembership.class), anyBoolean())).thenReturn(
+        true);
     when(notificationService.programmeMembershipIsNotifiable(any(), any())).thenReturn(true);
 
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
@@ -845,7 +840,9 @@ class ProgrammeMembershipServiceTest {
     when(notificationService.getOwnerContactList(any())).thenReturn(contactList);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("contact");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("href");
-    when(notificationService.meetsCriteria(any(), anyBoolean(), anyBoolean())).thenReturn(true);
+    when(
+        notificationService.meetsCriteria(any(ProgrammeMembership.class), anyBoolean())).thenReturn(
+        true);
     when(notificationService.programmeMembershipIsNotifiable(any(), any())).thenReturn(true);
 
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
@@ -920,7 +917,9 @@ class ProgrammeMembershipServiceTest {
     when(notificationService.getOwnerContactList(any())).thenReturn(contactList);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("contact");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("href");
-    when(notificationService.meetsCriteria(any(), anyBoolean(), anyBoolean())).thenReturn(true);
+    when(
+        notificationService.meetsCriteria(any(ProgrammeMembership.class), anyBoolean())).thenReturn(
+        true);
     when(notificationService.programmeMembershipIsNotifiable(any(), any())).thenReturn(true);
 
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
@@ -988,7 +987,9 @@ class ProgrammeMembershipServiceTest {
     when(notificationService.getOwnerContactList(any())).thenReturn(contactList);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("contact");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("href");
-    when(notificationService.meetsCriteria(any(), anyBoolean(), anyBoolean())).thenReturn(true);
+    when(
+        notificationService.meetsCriteria(any(ProgrammeMembership.class), anyBoolean())).thenReturn(
+        true);
     when(notificationService.programmeMembershipIsNotifiable(any(), any())).thenReturn(true);
 
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
@@ -1082,7 +1083,9 @@ class ProgrammeMembershipServiceTest {
     when(notificationService.getOwnerContactList(any())).thenReturn(contactList);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("contact");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("href");
-    when(notificationService.meetsCriteria(any(), anyBoolean(), anyBoolean())).thenReturn(true);
+    when(
+        notificationService.meetsCriteria(any(ProgrammeMembership.class), anyBoolean())).thenReturn(
+        true);
     when(notificationService.programmeMembershipIsNotifiable(any(), any())).thenReturn(true);
 
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
@@ -1185,7 +1188,9 @@ class ProgrammeMembershipServiceTest {
     when(notificationService.getOwnerContactList(any())).thenReturn(contactList);
     when(notificationService.getOwnerContact(any(), any(), any(), any())).thenReturn("contact");
     when(notificationService.getHrefTypeForContact(any())).thenReturn("href");
-    when(notificationService.meetsCriteria(any(), anyBoolean(), anyBoolean())).thenReturn(true);
+    when(
+        notificationService.meetsCriteria(any(ProgrammeMembership.class), anyBoolean())).thenReturn(
+        true);
     when(notificationService.programmeMembershipIsNotifiable(any(), any())).thenReturn(true);
 
     ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();


### PR DESCRIPTION
The programme membership filtering for the notification pilot is no longer required and can be removed.
The placement filtering is still required but will be changed in tis-trainee-details to include more trainees.

TIS21-6447
TIS21-6560