### PR TITLE
feat: attach PDF to COJ notifications

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -25,8 +25,8 @@
           "valueFrom": "trainee-cognito-pool-id-${environment}-v4"
         },
         {
-          "name": "COJ_RECEIVED_QUEUE",
-          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/coj/received"
+          "name": "COJ_PUBLISHED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/coj/pdf-generated"
         },
         {
           "name": "CREDENTIAL_REVOKED_QUEUE",

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ gradlew bootRun
 
  - A Redis instance for caching Person ID to User ID mappings.
  - A running instance of localstack or access to Amazon SQS, to retrieve
-   messages from the queue given as `COJ_RECEIVED_QUEUE`.
- - `COJ_RECEIVED_QUEUE` should have a visibility timeout longer than the user
+   messages from the queue given as `COJ_PUBLISHED_QUEUE`.
+ - `COJ_PUBLISHED_QUEUE` should have a visibility timeout longer than the user
    cache takes to build, failure to do so may lead to duplicate emails being
    sent. See log message `Total time taken to cache all user accounts was:
    <num>s` for time taken.
@@ -41,7 +41,7 @@ associated document for details of how to provide the region.
 | APP_DOMAIN                    | The domain to be used for links in email notifications. (Optional) |           |
 | AWS_XRAY_DAEMON_ADDRESS       | The AWS XRay daemon host. (Optional)                               |           |
 | COGNITO_USER_POOL_ID          | The user pool to get user details from.                            |           |
-| COJ_RECEIVED_QUEUE            | The queue URL for Conditions of Joining received events.           |           |
+| COJ_PUBLISHED_QUEUE           | The queue URL for Conditions of Joining publish events.            |           |
 | ENVIRONMENT                   | The environment to log events against.                             | local     |
 | EMAIL_SENDER                  | Where email notifications are to be sent from.                     |           |
 | NOTIFICATIONS_EVENT_TOPIC_ARN | Broadcast endpoint for notification events                         |           |
@@ -54,9 +54,9 @@ associated document for details of how to provide the region.
 
 #### Usage Examples
 
-##### Conditions of Joining Received
+##### Conditions of Joining Published
 
-The Conditions of Joining event should be sent to the `COJ_RECEIVED_QUEUE`, with
+The Conditions of Joining event should be sent to the `COJ_PUBLISHED_QUEUE`, with
 the following structure.
 
 ```json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.32.1"
+version = "1.33.0"
 
 configurations {
   compileOnly {
@@ -41,6 +41,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-web")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
 
+  implementation("io.awspring.cloud:spring-cloud-aws-starter-s3")
   implementation("io.awspring.cloud:spring-cloud-aws-starter-ses")
   implementation("io.awspring.cloud:spring-cloud-aws-starter-sns")
   implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/CojPublishedEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/CojPublishedEvent.java
@@ -21,18 +21,22 @@
 
 package uk.nhs.tis.trainee.notifications.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.Instant;
 
 /**
- * A Conditions of Joining signed event.
+ * A Conditions of Joining published event.
  *
  * @param personId            The person associated with the Conditions of joining.
  * @param conditionsOfJoining The Conditions of Joining.
  */
-public record CojSignedEvent(
+public record CojPublishedEvent(
+
+    @JsonAlias("traineeId")
     String personId,
-    ConditionsOfJoining conditionsOfJoining) {
+    ConditionsOfJoining conditionsOfJoining,
+    StoredFile pdf) {
 
   /**
    * Conditions of Joining details.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/StoredFile.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/StoredFile.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,28 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.model;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Data;
-import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent.ConditionsOfJoining;
+package uk.nhs.tis.trainee.notifications.dto;
 
 /**
- * A programme membership.
+ * A reference to a file stored in S3.
+ *
+ * @param bucket The S3 bucket the file was stored in.
+ * @param key    The S3 key for the stored file.
  */
-@Data
-public class ProgrammeMembership {
+public record StoredFile(String bucket, String key) {
 
-  private String tisId;
-  private String personId;
-  private String programmeName;
-  private String programmeNumber;
-  private String managingDeanery;
-  private LocalDate startDate;
-  private List<Curriculum> curricula = new ArrayList<>();
-  private ConditionsOfJoining conditionsOfJoining;
-  private ResponsibleOfficer responsibleOfficer;
-  private String designatedBody;
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListener.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent;
+import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent;
 import uk.nhs.tis.trainee.notifications.service.EmailService;
 
 /**
@@ -55,15 +55,15 @@ public class ConditionsOfJoiningListener {
   }
 
   /**
-   * Handle Conditions of Joining received events.
+   * Handle Conditions of Joining published events.
    *
    * @param event The program membership event.
    * @throws MessagingException If the message could not be sent.
    */
-  @SqsListener("${application.queues.coj-received}")
-  public void handleConditionsOfJoiningReceived(CojSignedEvent event)
+  @SqsListener("${application.queues.coj-published}")
+  public void handleConditionsOfJoiningPublished(CojPublishedEvent event)
       throws MessagingException {
-    log.info("Handling COJ received event {}.", event);
+    log.info("Handling COJ published event {}.", event);
 
     Map<String, Object> templateVariables = new HashMap<>();
 
@@ -73,7 +73,7 @@ public class ConditionsOfJoiningListener {
 
     String traineeId = event.personId();
     emailService.sendMessageToExistingUser(traineeId, COJ_CONFIRMATION, templateVersion,
-        templateVariables, null);
-    log.info("COJ received notification sent for trainee {}.", traineeId);
+        templateVariables, null, event.pdf());
+    log.info("COJ published notification sent for trainee {}.", traineeId);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
@@ -32,7 +32,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
 import org.mapstruct.ReportingPolicy;
-import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent.ConditionsOfJoining;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
 import uk.nhs.tis.trainee.notifications.model.ProgrammeMembership;
 import uk.nhs.tis.trainee.notifications.model.ResponsibleOfficer;

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
@@ -22,12 +22,14 @@
 package uk.nhs.tis.trainee.notifications.model;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import uk.nhs.tis.trainee.notifications.dto.StoredFile;
 
 /**
  * A representation of a historical notification.
@@ -50,6 +52,7 @@ public record History(
     NotificationType type,
     RecipientInfo recipient,
     TemplateInfo template,
+    List<StoredFile> attachments,
     Instant sentAt,
     Instant readAt,
     NotificationStatus status,

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/InAppService.java
@@ -67,7 +67,7 @@ public class InAppService {
         templateVariables);
 
     History history = new History(null, tisReference, notificationType, recipient, template,
-        sendAt, null, UNREAD, null, null);
+        null, sendAt, null, UNREAD, null, null);
     if (!doNotStoreJustLog) {
       historyService.save(history);
     } else {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -468,6 +468,7 @@ public class NotificationService implements Job {
           notificationType,
           recipientInfo,
           templateInfo,
+          null,
           when.toInstant(),
           null,
           NotificationStatus.SCHEDULED,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ application:
       arn: ${NOTIFICATIONS_EVENT_TOPIC_ARN:}
   template-versions:
     coj-confirmation:
-      email: v1.0.0
+      email: v1.1.0
     credential-revoked:
       email: v1.0.0
     day-one:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ application:
   queues:
     account-confirmed: ${ACCOUNT_CONFIRMED_QUEUE}
     account-updated: ${ACCOUNT_UPDATED_QUEUE}
-    coj-received: ${COJ_RECEIVED_QUEUE}
+    coj-published: ${COJ_PUBLISHED_QUEUE}
     credential-revoked: ${CREDENTIAL_REVOKED_QUEUE}
     contact-details-updated: ${CONTACT_DETAILS_UPDATED_QUEUE}
     email-failure: ${EMAIL_FAILURE_QUEUE}

--- a/src/main/resources/templates/email/coj-confirmation/v1.1.0.html
+++ b/src/main/resources/templates/email/coj-confirmation/v1.1.0.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Conditions of Joining Confirmation</title>
+  </head>
+  <body>
+    <h1>Email Message</h1>
+    <h2>Subject</h2>
+    <th:block th:fragment="subject">We've received your Conditions of Joining</th:block>
+    <h2>Content</h2>
+    <th:block th:fragment="content">
+      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+      <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+      <p>
+        We want to inform you that your local NHS England office has received your signed Conditions of Joining<span
+          th:text="${syncedAt} ? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"
+        ></span
+        >.
+      </p>
+      <p>
+        Please find attached a PDF of your signed Conditions of Joining, you can access this at any time by visiting
+        <a th:href="${not #strings.isEmpty(domain)} ? @{{domain}/programmes(domain=${domain})} : _"
+          >TIS Self-Service</a
+        >.
+      </p>
+      <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+    </th:block>
+  </body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
@@ -24,6 +24,7 @@ package uk.nhs.tis.trainee.notifications;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.awspring.cloud.s3.S3Template;
 import org.junit.jupiter.api.Test;
 import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +47,9 @@ class TisTraineeNotificationsApplicationTest {
 
   @MockBean
   private Scheduler scheduler;
+
+  @MockBean
+  private S3Template s3Template;
 
   @Autowired
   ApplicationContext context;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationIntegrationTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MONGODB;
 
+import io.awspring.cloud.s3.S3Template;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -36,6 +37,7 @@ import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -50,6 +52,9 @@ import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
 @ActiveProfiles("test")
 @Testcontainers(disabledWithoutDocker = true)
 class MongoConfigurationIntegrationTest {
+
+  @MockBean
+  private S3Template s3Template;
 
   @Container
   @ServiceConnection

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -101,8 +101,8 @@ class ConditionsOfJoiningListenerIntegrationTest {
   private static final String DEFAULT_GREETING = "Dear Doctor,";
   private static final String DEFAULT_DETAIL = "We want to inform you that your local NHS England"
       + " office has received your signed Conditions of Joining.";
-  private static final String DEFAULT_NEXT_STEPS = "You can access a PDF of your signed Conditions"
-      + " of Joining by visiting TIS Self-Service.";
+  private static final String DEFAULT_NEXT_STEPS = "Please find attached a PDF of your signed"
+      + " Conditions of Joining, you can access this at any time by visiting TIS Self-Service.";
   private static final String DEFAULT_DISCLAIMER = "This email is intended only for use by the "
       + "named addressee. It may contain confidential and/or privileged information. If you are "
       + "not the intended recipient, you should contact us immediately and should not disclose, "
@@ -222,9 +222,7 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
     Element nextSteps = bodyChildren.get(3);
     assertThat("Unexpected element tag.", nextSteps.tagName(), is("p"));
-    assertThat("Unexpected next steps.", nextSteps.text(),
-        is("You can access a PDF of your signed Conditions of Joining by visiting TIS"
-            + " Self-Service."));
+    assertThat("Unexpected next steps.", nextSteps.text(), is(DEFAULT_NEXT_STEPS));
 
     Element disclaimer = bodyChildren.get(5);
     assertThat("Unexpected disclaimer.", disclaimer.text(), is(DEFAULT_DISCLAIMER));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -21,19 +21,31 @@
 
 package uk.nhs.tis.trainee.notifications.event;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_PDF_VALUE;
+import static org.springframework.http.MediaType.MULTIPART_MIXED_VALUE;
+import static org.springframework.http.MediaType.MULTIPART_RELATED_VALUE;
+import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
 
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+import jakarta.activation.DataHandler;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
@@ -56,8 +68,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.ActiveProfiles;
-import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent;
-import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent;
+import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.StoredFile;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
@@ -106,6 +119,9 @@ class ConditionsOfJoiningListenerIntegrationTest {
   @MockBean
   private HistoryService historyService;
 
+  @MockBean
+  private S3Template s3Template;
+
   @Autowired
   private EmailService emailService;
 
@@ -125,8 +141,8 @@ class ConditionsOfJoiningListenerIntegrationTest {
   @NullAndEmptySource
   void shouldSendDefaultCojConfirmationWhenTemplateVariablesNotAvailable(String missingValue)
       throws Exception {
-    CojSignedEvent event = new CojSignedEvent(PERSON_ID,
-        new ConditionsOfJoining(null));
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(null), null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, missingValue, missingValue, GMC));
 
@@ -135,12 +151,12 @@ class ConditionsOfJoiningListenerIntegrationTest {
     doAnswer(inv -> {
       inv.getArgument(3, Map.class).put("domain", URI.create(""));
       return inv.callRealMethod();
-    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any(), any());
+    }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any(), any(), any());
 
     // Create a new listener instance to inject the spy.
     ConditionsOfJoiningListener listener = new ConditionsOfJoiningListener(emailService,
         templateVersion);
-    listener.handleConditionsOfJoiningReceived(event);
+    listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
@@ -176,12 +192,12 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
   @Test
   void shouldSendFullyTailoredCojConfirmationWhenAllTemplateVariablesAvailable() throws Exception {
-    CojSignedEvent event = new CojSignedEvent(PERSON_ID,
-        new ConditionsOfJoining(SYNCED_AT));
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(SYNCED_AT), null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
-    listener.handleConditionsOfJoiningReceived(event);
+    listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
@@ -221,12 +237,12 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
   @Test
   void shouldSendCojConfirmationWithTailoredNameWhenAvailable() throws Exception {
-    CojSignedEvent event = new CojSignedEvent(PERSON_ID,
-        new ConditionsOfJoining(null));
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(null), null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
-    listener.handleConditionsOfJoiningReceived(event);
+    listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
@@ -262,12 +278,12 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
   @Test
   void shouldSendCojConfirmationWithTailoredLocalOfficeWhenAvailable() throws Exception {
-    CojSignedEvent event = new CojSignedEvent(PERSON_ID,
-        new ConditionsOfJoining(null));
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(null), null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
-    listener.handleConditionsOfJoiningReceived(event);
+    listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
@@ -302,12 +318,12 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
   @Test
   void shouldSendCojConfirmationWithTailoredSyncedAtWhenAvailable() throws Exception {
-    CojSignedEvent event = new CojSignedEvent(PERSON_ID,
-        new ConditionsOfJoining(SYNCED_AT));
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(SYNCED_AT), null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
-    listener.handleConditionsOfJoiningReceived(event);
+    listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
@@ -345,12 +361,12 @@ class ConditionsOfJoiningListenerIntegrationTest {
 
   @Test
   void shouldSendCojConfirmationWithTailoredDomainWhenAvailable() throws Exception {
-    CojSignedEvent event = new CojSignedEvent(PERSON_ID,
-        new ConditionsOfJoining(null));
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(null), null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, null, null, GMC));
 
-    listener.handleConditionsOfJoiningReceived(event);
+    listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
     verify(mailSender).send(messageCaptor.capture());
@@ -385,13 +401,64 @@ class ConditionsOfJoiningListenerIntegrationTest {
   }
 
   @Test
-  void shouldStoreCojReceivedNotificationHistoryWhenMessageSent() throws MessagingException {
-    CojSignedEvent event = new CojSignedEvent(PERSON_ID,
-        new ConditionsOfJoining(SYNCED_AT));
+  void shouldSendMultipartCojConfirmationWhenPdfAvailable() throws Exception {
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
+        new UserDetails(true, EMAIL, TITLE, null, null, GMC));
+
+    S3Resource s3Resource = mock(S3Resource.class);
+    when(s3Resource.getFilename()).thenReturn("file.pdf");
+    when(s3Resource.contentType()).thenReturn(APPLICATION_PDF_VALUE);
+    when(s3Resource.getContentAsByteArray()).thenReturn("test".getBytes());
+    when(s3Template.download("my-bucket", "my-key.pdf")).thenReturn(s3Resource);
+
+    StoredFile pdf = new StoredFile("my-bucket", "my-key.pdf");
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(null), pdf);
+
+    listener.handleConditionsOfJoiningPublished(event);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    assertThat("Unexpected content java type.", message.getContent(),
+        instanceOf(MimeMultipart.class));
+
+    MimeMultipart mixedContent = (MimeMultipart) message.getContent();
+    assertThat("Unexpected content type.", mixedContent.getContentType(),
+        startsWith(MULTIPART_MIXED_VALUE));
+    assertThat("Unexpected content part count.", mixedContent.getCount(), is(2));
+
+    MimeMultipart relatedContent = (MimeMultipart) mixedContent.getBodyPart(0).getContent();
+    assertThat("Unexpected content type.", relatedContent.getContentType(),
+        startsWith(MULTIPART_RELATED_VALUE));
+    assertThat("Unexpected content part count.", relatedContent.getCount(), is(1));
+
+    DataHandler content = relatedContent.getBodyPart(0).getDataHandler();
+    assertThat("Unexpected content type.", content.getContentType(), startsWith(TEXT_HTML_VALUE));
+    Document document = Jsoup.parse((String) content.getContent());
+    Elements bodyChildren = document.body().children();
+    assertThat("Unexpected body children count.", bodyChildren.size(), is(6));
+
+    DataHandler attachment = mixedContent.getBodyPart(1).getDataHandler();
+    assertThat("Unexpected attachment type.", attachment.getContentType(),
+        is(APPLICATION_PDF_VALUE));
+    assertThat("Unexpected attachment name.", attachment.getName(), is("file.pdf"));
+
+    Object attachmentContent = attachment.getContent();
+    assertThat("Unexpected attachment.", attachmentContent, instanceOf(ByteArrayInputStream.class));
+    assertThat("Unexpected attachment content.",
+        ((ByteArrayInputStream) attachmentContent).readAllBytes(), is("test".getBytes()));
+  }
+
+  @Test
+  void shouldStoreCojPublishedNotificationHistoryWhenMessageSent() throws MessagingException {
+    CojPublishedEvent event = new CojPublishedEvent(PERSON_ID,
+        new ConditionsOfJoining(SYNCED_AT), null);
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
 
-    listener.handleConditionsOfJoiningReceived(event);
+    listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
     verify(historyService).save(historyCaptor.capture());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ContactDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ContactDetailsListenerTest.java
@@ -53,7 +53,7 @@ class ContactDetailsListenerTest {
 
   @Test
   void shouldNotThrowAnExceptionOnNonRecordEvents() {
-    //ensure events with COJ_RECEIVED structure (and any other) are ignored, and not requeued
+    //ensure events with COJ_PUBLISHED structure (and any other) are ignored, and not requeued
     ContactDetailsEvent event = new ContactDetailsEvent(TIS_ID, null);
 
     assertDoesNotThrow(() -> listener.handleUpdate(event));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/CredentialListenerIntegrationTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.CREDENTIAL_REVOKED;
 
+import io.awspring.cloud.s3.S3Template;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -111,6 +112,9 @@ class CredentialListenerIntegrationTest {
 
   @MockBean
   private HistoryService historyService;
+
+  @MockBean
+  private S3Template s3Template;
 
   @Autowired
   private EmailService emailService;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/FormListenerIntegrationTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
 
+import io.awspring.cloud.s3.S3Template;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -112,6 +113,9 @@ class FormListenerIntegrationTest {
 
   @MockBean
   private HistoryService historyService;
+
+  @MockBean
+  private S3Template s3Template;
 
   @Autowired
   private EmailService emailService;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
@@ -56,7 +56,7 @@ class ProgrammeMembershipListenerTest {
 
   @Test
   void shouldNotThrowAnExceptionOnNonRecordEvents() {
-    //ensure events with COJ_RECEIVED structure (and any other) are ignored, and not requeued
+    //ensure events with COJ_PUBLISHED structure (and any other) are ignored, and not requeued
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, null);
 
     assertDoesNotThrow(() -> listener.handleProgrammeMembershipUpdate(event));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent.ConditionsOfJoining;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.dto.RecordDto;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/InsertScheduledEmailHistoryTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/InsertScheduledEmailHistoryTest.java
@@ -198,6 +198,7 @@ class InsertScheduledEmailHistoryTest {
         null,
         null,
         null,
+        null,
         NotificationStatus.SCHEDULED,
         null,
         null);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
@@ -30,12 +30,14 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
 
+import io.awspring.cloud.s3.S3Template;
 import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -56,6 +58,9 @@ class PopulateNotificationHistoryStatusIntegrationTest {
 
   @SpyBean
   private MongoTemplate mongoTemplate;
+
+  @MockBean
+  private S3Template s3Template;
 
   private PopulateNotificationHistoryStatus migrator;
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/repository/FlywayMigrationsTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/repository/FlywayMigrationsTest.java
@@ -23,6 +23,7 @@ package uk.nhs.tis.trainee.notifications.repository;
 
 import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MYSQL;
 
+import io.awspring.cloud.s3.S3Template;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +60,9 @@ class FlywayMigrationsTest implements TestExecutionListener {
 
   @MockBean
   private MongoCollectionConfiguration mongoConfiguration;
+
+  @MockBean
+  private S3Template s3Template;
 
   @Autowired
   Flyway flyway;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
@@ -148,6 +148,6 @@ class ContactDetailsServiceTest {
 
     ObjectId id1 = ObjectId.get();
     return new History(id1, tisReferenceInfo, PROGRAMME_CREATED, recipient,
-        templateInfo, Instant.MIN, Instant.MAX, FAILED, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, FAILED, null, null);
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -35,6 +35,7 @@ import static uk.nhs.tis.trainee.notifications.service.PlacementService.START_DA
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.GMC_NUMBER_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PROGRAMME_NUMBER_FIELD;
 
+import io.awspring.cloud.s3.S3Template;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import java.time.LocalDate;
@@ -85,6 +86,9 @@ class EmailServiceIntegrationTest {
 
   @MockBean
   private RestTemplate restTemplate;
+
+  @MockBean
+  private S3Template s3Template;
 
   @Autowired
   private EmailService service;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EventBroadcastServiceTest.java
@@ -183,7 +183,7 @@ class EventBroadcastServiceTest {
         = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, TEMPLATE_VARIABLES);
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
     History history = new History(HISTORY_ID, tisReferenceInfo, NOTIFICATION_TYPE,
-        recipientInfo, templateInfo, SENT_AT, READ_AT, NOTIFICATION_STATUS,
+        recipientInfo, templateInfo, null, SENT_AT, READ_AT, NOTIFICATION_STATUS,
         NOTIFICATION_STATUS_DETAIL, LAST_RETRY);
 
     service.publishNotificationsEvent(history);
@@ -239,7 +239,7 @@ class EventBroadcastServiceTest {
         is(NOTIFICATION_STATUS.toString()));
 
     assertThat("Unexpected message notification status detail.", message.get("statusDetail"),
-        is(NOTIFICATION_STATUS_DETAIL.toString()));
+        is(NOTIFICATION_STATUS_DETAIL));
 
     assertThat("Unexpected message last retry.", message.get("lastRetry"),
         is(LAST_RETRY.toString()));
@@ -299,6 +299,6 @@ class EventBroadcastServiceTest {
     TemplateInfo templateInfo = new TemplateInfo(null, null, Map.of());
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(null, null);
     return new History(HISTORY_ID, tisReferenceInfo, NOTIFICATION_TYPE,
-        recipientInfo, templateInfo, SENT_AT, READ_AT, NOTIFICATION_STATUS, null, null);
+        recipientInfo, templateInfo, null, SENT_AT, READ_AT, NOTIFICATION_STATUS, null, null);
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -115,7 +115,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, READ_AT, SENT, null, null);
+        templateInfo, null, SENT_AT, READ_AT, SENT, null, null);
     History savedHistory = service.save(history);
 
     assertThat("Unexpected ID.", savedHistory.id(), instanceOf(ObjectId.class));
@@ -149,7 +149,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, READ_AT, SENT, null, null);
+        templateInfo, null, SENT_AT, READ_AT, SENT, null, null);
     service.save(history);
 
     List<HistoryDto> foundHistory = service.findAllForTrainee("notFound");
@@ -165,7 +165,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, READ_AT, SENT, null, null);
+        templateInfo, null, SENT_AT, READ_AT, SENT, null, null);
     History savedHistory = service.save(history);
 
     List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
@@ -190,15 +190,15 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        now, now, SENT, null, null));
+        null, now, now, SENT, null, null));
 
     Instant before = SENT_AT.minus(Duration.ofDays(1));
     Instant after = SENT_AT.plus(Duration.ofDays(1));
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        before, after, SENT, null, null));
+        null, before, after, SENT, null, null));
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        after, before, SENT, null, null));
+        null, after, before, SENT, null, null));
 
     List<HistoryDto> foundHistory = service.findAllForTrainee(TRAINEE_ID);
 
@@ -222,7 +222,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, READ_AT, SENT, null, null);
+        templateInfo, null, SENT_AT, READ_AT, SENT, null, null);
     service.save(history);
 
     List<History> foundHistory = service.findAllHistoryForTrainee("notFound");
@@ -238,7 +238,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
-        templateInfo, SENT_AT, READ_AT, SENT, null, null);
+        templateInfo, null, SENT_AT, READ_AT, SENT, null, null);
     History savedHistory = service.save(history);
 
     List<History> foundHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
@@ -268,15 +268,15 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        now, now, SENT, null, null));
+        null, now, now, SENT, null, null));
 
     Instant before = SENT_AT.minus(Duration.ofDays(1));
     Instant after = SENT_AT.plus(Duration.ofDays(1));
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        before, after, SENT, null, null));
+        null, before, after, SENT, null, null));
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        after, before, SENT, null, null));
+        null, after, before, SENT, null, null));
 
     List<History> foundHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
 
@@ -301,15 +301,15 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        now, now, SENT, null, null));
+        null, now, now, SENT, null, null));
 
     Instant before = SENT_AT.minus(Duration.ofDays(1));
     Instant after = SENT_AT.plus(Duration.ofDays(1));
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        before, after, SENT, null, null));
+        null, before, after, SENT, null, null));
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        after, before, SENT, null, null));
+        null, after, before, SENT, null, null));
 
     List<HistoryDto> foundHistory = service.findAllSentForTrainee(TRAINEE_ID);
 
@@ -331,15 +331,15 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        now, now, SENT, null, null));
+        null, now, now, SENT, null, null));
 
     Instant before = SENT_AT.minus(Duration.ofDays(1));
     Instant after = SENT_AT.plus(Duration.ofDays(1));
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        before, after, SENT, null, null));
+        null, before, after, SENT, null, null));
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo, templateInfo,
-        after, before, SENT, null, null));
+        null, after, before, SENT, null, null));
 
     List<History> foundHistory = service.findAllScheduledForTrainee(
         TRAINEE_ID, TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
@@ -368,15 +368,15 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo, templateInfo,
-        now, now, SENT, null, null));
+        null, now, now, SENT, null, null));
     service.save(new History(null, tisReferenceInfo2, PROGRAMME_DAY_ONE, recipientInfo,
-        templateInfo, now, now, SCHEDULED, null, null));
+        templateInfo, null, now, now, SCHEDULED, null, null));
     service.save(new History(null, tisReferenceInfo3, PROGRAMME_DAY_ONE, recipientInfo,
-        templateInfo, now, now, SCHEDULED, null, null));
+        templateInfo, null, now, now, SCHEDULED, null, null));
     service.save(new History(null, tisReferenceInfo4, PROGRAMME_DAY_ONE, recipientInfo,
-        templateInfo, now, now, SCHEDULED, null, null));
+        templateInfo, null, now, now, SCHEDULED, null, null));
     service.save(new History(null, tisReferenceInfo5, PROGRAMME_DAY_ONE, recipientInfo,
-        templateInfo, now, now, SCHEDULED, null, null));
+        templateInfo, null, now, now, SCHEDULED, null, null));
 
     History foundHistory = service.findScheduledEmailForTraineeByRefAndType(
         TRAINEE_ID, TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID, PROGRAMME_DAY_ONE);
@@ -403,9 +403,9 @@ class HistoryServiceIntegrationTest {
 
     Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
     service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo, templateInfo,
-        now, now, SENT, null, null));
+        null, now, now, SENT, null, null));
     service.save(new History(null, tisReferenceInfo2, PROGRAMME_DAY_ONE, recipientInfo,
-        templateInfo, now, now, SCHEDULED, null, null));
+        templateInfo, null, now, now, SCHEDULED, null, null));
 
     History foundHistory = service.findScheduledEmailForTraineeByRefAndType(
         TRAINEE_ID, TisReferenceType.PROGRAMME_MEMBERSHIP, TIS_REFERENCE_ID, PROGRAMME_DAY_ONE);
@@ -427,13 +427,13 @@ class HistoryServiceIntegrationTest {
 
     Instant after = SENT_AT.plus(Duration.ofDays(1));
     service.save(new History(null, tisRefInfoPm, FORM_UPDATED, recipientInfo, templateInfo,
-        after, after, SENT, null, null));
+        null, after, after, SENT, null, null));
 
     service.save(new History(null, tisRefInfoPlacement, FORM_UPDATED, recipientInfo, templateInfo,
-        after, after, SENT, null, null));
+        null, after, after, SENT, null, null));
 
     service.save(new History(null, tisRefInfoPlacement2, FORM_UPDATED, recipientInfo, templateInfo,
-        after, after, SENT, null, null));
+        null, after, after, SENT, null, null));
 
     List<History> foundHistory = service.findAllScheduledForTrainee(
         TRAINEE_ID, TisReferenceType.PLACEMENT, TIS_REFERENCE_ID);
@@ -465,7 +465,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null, null);
+        recipientInfo, templateInfo, null, Instant.now(), Instant.now(), SENT, null, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(NOTIFICATION_ID.toString());
@@ -499,7 +499,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null, null);
+        recipientInfo, templateInfo, null, Instant.now(), Instant.now(), SENT, null, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(NOTIFICATION_ID.toString());
@@ -540,7 +540,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), Instant.now(), SENT, null, null);
+        recipientInfo, templateInfo, null, Instant.now(), Instant.now(), SENT, null, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID.toString());
@@ -574,7 +574,7 @@ class HistoryServiceIntegrationTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(NOTIFICATION_ID, tisReferenceInfo, notificationType,
-        recipientInfo, templateInfo, Instant.now(), Instant.now(), UNREAD, null, null);
+        recipientInfo, templateInfo, null, Instant.now(), Instant.now(), UNREAD, null, null);
     service.save(history);
 
     Optional<String> message = service.rebuildMessage(TRAINEE_ID, NOTIFICATION_ID.toString());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -110,14 +110,14 @@ class HistoryServiceTest {
     Instant sent = Instant.now();
     Instant read = Instant.now().plus(Duration.ofDays(1));
     History history = new History(null, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, sent, read, SENT, null, null);
+        templateInfo, null, sent, read, SENT, null, null);
 
     ObjectId id = new ObjectId();
     when(repository.save(history)).then(inv -> {
       History saving = inv.getArgument(0);
       assertThat("Unexpected ID.", saving.id(), nullValue());
       return new History(id, saving.tisReference(), saving.type(), saving.recipient(),
-          saving.template(), saving.sentAt(), saving.readAt(), SENT, null, null);
+          saving.template(), null, saving.sentAt(), saving.readAt(), SENT, null, null);
     });
 
     History savedHistory = service.save(history);
@@ -155,7 +155,7 @@ class HistoryServiceTest {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
     History foundHistory = new History(notificationId, null, COJ_CONFIRMATION, recipientInfo, null,
-        Instant.MIN, Instant.MAX, null, null, null);
+        null, Instant.MIN, Instant.MAX, null, null, null);
 
     when(repository.findById(notificationId)).thenReturn(Optional.of(foundHistory));
 
@@ -176,7 +176,7 @@ class HistoryServiceTest {
         TEMPLATE_VARIABLES);
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
     History foundHistory = new History(notificationId, tisReferenceInfo, COJ_CONFIRMATION,
-        recipientInfo, templateInfo, Instant.MIN, Instant.MAX, null, null, null);
+        recipientInfo, templateInfo, null, Instant.MIN, Instant.MAX, null, null, null);
 
     when(repository.findById(notificationId)).thenReturn(Optional.of(foundHistory));
     when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -215,7 +215,7 @@ class HistoryServiceTest {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
     History foundHistory = new History(notificationId, null, COJ_CONFIRMATION, recipientInfo, null,
-        Instant.MIN, Instant.MAX, null, null, null);
+        null, Instant.MIN, Instant.MAX, null, null, null);
 
     when(repository.findById(notificationId)).thenReturn(Optional.of(foundHistory));
 
@@ -236,7 +236,7 @@ class HistoryServiceTest {
         TEMPLATE_VARIABLES);
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
     History foundHistory = new History(notificationId, tisReferenceInfo, COJ_CONFIRMATION,
-        recipientInfo, templateInfo, Instant.MIN, Instant.MAX, null, null, null);
+        recipientInfo, templateInfo, null, Instant.MIN, Instant.MAX, null, null, null);
 
     String templatePath = "in-app/test/template/v1.2.3";
     when(templateService.getTemplatePath(IN_APP, TEMPLATE_NAME, TEMPLATE_VERSION)).thenReturn(
@@ -291,7 +291,7 @@ class HistoryServiceTest {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
     History foundHistory = new History(notificationId, null, COJ_CONFIRMATION, recipientInfo, null,
-        Instant.MIN, Instant.MAX, null, null, null);
+        null, Instant.MIN, Instant.MAX, null, null, null);
 
     when(repository.findByIdAndRecipient_Id(notificationId, TRAINEE_ID)).thenReturn(
         Optional.of(foundHistory));
@@ -313,7 +313,7 @@ class HistoryServiceTest {
         TEMPLATE_VARIABLES);
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
     History foundHistory = new History(notificationId, tisReferenceInfo, COJ_CONFIRMATION,
-        recipientInfo, templateInfo, Instant.MIN, Instant.MAX, null, null, null);
+        recipientInfo, templateInfo, null, Instant.MIN, Instant.MAX, null, null, null);
 
     when(repository.findByIdAndRecipient_Id(notificationId, TRAINEE_ID)).thenReturn(
         Optional.of(foundHistory));
@@ -353,7 +353,7 @@ class HistoryServiceTest {
     ObjectId notificationId = new ObjectId(NOTIFICATION_ID);
     RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
     History foundHistory = new History(notificationId, null, COJ_CONFIRMATION, recipientInfo, null,
-        Instant.MIN, Instant.MAX, null, null, null);
+        null, Instant.MIN, Instant.MAX, null, null, null);
 
     when(repository.findByIdAndRecipient_Id(notificationId, TRAINEE_ID)).thenReturn(
         Optional.of(foundHistory));
@@ -375,7 +375,7 @@ class HistoryServiceTest {
         TEMPLATE_VARIABLES);
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
     History foundHistory = new History(notificationId, tisReferenceInfo, COJ_CONFIRMATION,
-        recipientInfo, templateInfo, Instant.MIN, Instant.MAX, null, null, null);
+        recipientInfo, templateInfo, null, Instant.MIN, Instant.MAX, null, null, null);
 
     String templatePath = "in-app/test/template/v1.2.3";
     when(templateService.getTemplatePath(IN_APP, TEMPLATE_NAME, TEMPLATE_VERSION)).thenReturn(
@@ -434,11 +434,11 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
     ObjectId id2 = ObjectId.get();
     History history2 = new History(id2, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MAX, Instant.MIN, SENT, null, null);
+        templateInfo, null, Instant.MAX, Instant.MIN, SENT, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history1, history2));
@@ -487,11 +487,11 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
     ObjectId id2 = ObjectId.get();
     History history2 = new History(id2, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MAX, Instant.MIN, SENT, null, null);
+        templateInfo, null, Instant.MAX, Instant.MIN, SENT, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history1, history2));
@@ -559,16 +559,16 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
     ObjectId id2 = ObjectId.get();
     Instant timeNow = Instant.now();
     History history2 = new History(id2, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, timeNow, Instant.MIN, SENT, null, null);
+        templateInfo, null, timeNow, Instant.MIN, SENT, null, null);
 
     ObjectId id3 = ObjectId.get();
     History history3 = new History(id3, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MAX, Instant.MIN, SENT, null, null);
+        templateInfo, null, Instant.MAX, Instant.MIN, SENT, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history3, history2, history1));
@@ -627,16 +627,16 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
     ObjectId id2 = ObjectId.get();
     Instant timeNow = Instant.now();
     History history2 = new History(id2, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, timeNow, Instant.MIN, SENT, null, null);
+        templateInfo, null, timeNow, Instant.MIN, SENT, null, null);
 
     ObjectId id3 = ObjectId.get();
     History history3 = new History(id3, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MAX, Instant.MIN, SENT, null, null);
+        templateInfo, null, Instant.MAX, Instant.MIN, SENT, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history3, history2, history1));
@@ -678,7 +678,7 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, FAILED, null, Instant.MAX);
+        templateInfo, null, Instant.MIN, Instant.MAX, FAILED, null, Instant.MAX);
 
     when(repository.findAllByRecipient_IdAndStatus(TRAINEE_ID, FAILED.name()))
         .thenReturn(List.of(history1));
@@ -730,7 +730,7 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history1));
@@ -760,7 +760,7 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history1));
@@ -790,7 +790,7 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history1));
@@ -814,7 +814,7 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MAX, null, UNREAD, null, null);
+        templateInfo, null, Instant.MAX, null, UNREAD, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history1));
@@ -844,7 +844,7 @@ class HistoryServiceTest {
 
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.MIN, null, UNREAD, null, null);
+        templateInfo, null, Instant.MIN, null, UNREAD, null, null);
 
     when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
         List.of(history1));
@@ -885,7 +885,7 @@ class HistoryServiceTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(notificationId, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.now(), Instant.now(), SENT, null, null);
+        templateInfo, null, Instant.now(), Instant.now(), SENT, null, null);
     when(repository.findById(any())).thenReturn(Optional.of(history));
 
     String templatePath = "type/test/template/v1.2.3";
@@ -926,7 +926,7 @@ class HistoryServiceTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     History history = new History(notificationId, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, Instant.now(), Instant.now(), SENT, null, null);
+        templateInfo, null, Instant.now(), Instant.now(), SENT, null, null);
     when(repository.findByIdAndRecipient_Id(any(), any())).thenReturn(Optional.of(history));
 
     String templatePath = "type/test/template/v1.2.3";
@@ -954,7 +954,7 @@ class HistoryServiceTest {
     RecipientInfo recipientInfo = new RecipientInfo(null, IN_APP, null);
     TemplateInfo templateInfo = new TemplateInfo(null, null, TEMPLATE_VARIABLES);
     History history = new History(notificationId, null, notificationType, recipientInfo,
-        templateInfo, null, null, null, null, null);
+        templateInfo, null, null, null, null, null, null);
 
     when(repository.findByIdAndRecipient_Id(any(), any())).thenReturn(Optional.of(history));
     when(templateService.process(any(), any(), eq(TEMPLATE_VARIABLES))).thenReturn("");
@@ -972,7 +972,7 @@ class HistoryServiceTest {
     RecipientInfo recipientInfo = new RecipientInfo(null, EMAIL, null);
     TemplateInfo templateInfo = new TemplateInfo(null, null, TEMPLATE_VARIABLES);
     History history = new History(notificationId, null, notificationType, recipientInfo,
-        templateInfo, null, null, null, null, null);
+        templateInfo, null, null, null, null, null, null);
 
     when(repository.findByIdAndRecipient_Id(any(), any())).thenReturn(Optional.of(history));
     when(templateService.process(any(), any(), eq(TEMPLATE_VARIABLES))).thenReturn("");

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/InAppServiceTest.java
@@ -163,6 +163,18 @@ class InAppServiceTest {
 
   @ParameterizedTest
   @EnumSource(NotificationType.class)
+  void shouldNotAttachmentsWhenCreatingNotification(NotificationType notificationType) {
+    service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.captor();
+    verify(historyService).save(historyCaptor.capture());
+
+    History history = historyCaptor.getValue();
+    assertThat("Unexpected attachments.", history.attachments(), nullValue());
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
   void shouldSetSentAtWhenCreatingNotification(NotificationType notificationType) {
     service.createNotifications(TRAINEE_ID, null, notificationType, VERSION, Map.of());
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -618,6 +618,7 @@ class NotificationServiceTest {
     History history = historyCaptor.getValue();
     assertThat("Unexpected notification id.", history.id(), notNullValue());
     assertThat("Unexpected notification type.", history.type(), is(notificationType));
+    assertThat("Unexpected attachments.", history.attachments(), nullValue());
     assertThat("Unexpected sent at.", history.sentAt(), notNullValue());
     assertThat("Unexpected status.", history.status(), is(SCHEDULED));
     assertThat("Unexpected status detail.", history.statusDetail(), nullValue());
@@ -686,6 +687,7 @@ class NotificationServiceTest {
     History history = historyCaptor.getValue();
     assertThat("Unexpected notification id.", history.id(), notNullValue());
     assertThat("Unexpected notification type.", history.type(), is(notificationType));
+    assertThat("Unexpected attachments.", history.attachments(), nullValue());
     assertThat("Unexpected sent at.", history.sentAt(), notNullValue());
     assertThat("Unexpected status.", history.status(), is(SCHEDULED));
     assertThat("Unexpected status detail.", history.statusDetail(), nullValue());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -81,7 +81,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.quartz.JobDataMap;
 import org.quartz.SchedulerException;
-import uk.nhs.tis.trainee.notifications.dto.CojSignedEvent.ConditionsOfJoining;
+import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent.ConditionsOfJoining;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.Curriculum;
 import uk.nhs.tis.trainee.notifications.model.History;
@@ -555,7 +555,8 @@ class ProgrammeMembershipServiceTest {
     RecipientInfo recipientInfo = new RecipientInfo("id", MessageType.IN_APP, null);
     List<History> sentNotifications = List.of(
         new History(ObjectId.get(), new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
-            notificationType, recipientInfo, null, Instant.MIN, Instant.MAX, UNREAD, null, null));
+            notificationType, recipientInfo, null, null, Instant.MIN, Instant.MAX, UNREAD, null,
+            null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
     when(notificationService.meetsCriteria(programmeMembership, true,
@@ -736,12 +737,12 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.MIN, Instant.MAX, SENT, null, null));
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_DAY_ONE, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.MIN, Instant.MAX, SENT, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -763,7 +764,7 @@ class ProgrammeMembershipServiceTest {
       sentNotifications.add(new History(ObjectId.get(),
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
-          templateInfo,
+          templateInfo, null,
           Instant.MIN, Instant.MAX, SENT, null, null));
     }
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -798,13 +799,13 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_DAY_ONE, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
 
@@ -834,7 +835,7 @@ class ProgrammeMembershipServiceTest {
       sentNotifications.add(new History(ObjectId.get(),
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
-          templateInfo,
+          templateInfo, null,
           Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
           SENT, null, null));
     }
@@ -873,13 +874,13 @@ class ProgrammeMembershipServiceTest {
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
         templateInfo,
-        null, null,
+        null, null, null,
         SENT, null, null));
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_DAY_ONE, recipientInfo,
         templateInfo,
-        null, null,
+        null, null, null,
         SENT, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -910,7 +911,7 @@ class ProgrammeMembershipServiceTest {
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
           templateInfo,
-          null, null,
+          null, null, null,
           SENT, null, null));
     }
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -947,7 +948,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
 
@@ -977,7 +978,7 @@ class ProgrammeMembershipServiceTest {
       sentNotifications.add(new History(ObjectId.get(),
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
-          templateInfo,
+          templateInfo, null,
           Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
           SENT, null, null));
     }
@@ -1024,13 +1025,13 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        mostRecentTemplateInfo,
+        mostRecentTemplateInfo, null,
         Instant.from(mostRecentSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        previousTemplateInfo,
+        previousTemplateInfo, null,
         Instant.from(previousSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
 
@@ -1065,13 +1066,13 @@ class ProgrammeMembershipServiceTest {
       sentNotifications.add(new History(ObjectId.get(),
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
-          mostRecentTemplateInfo,
+          mostRecentTemplateInfo, null,
           Instant.from(mostRecentSentAt.atStartOfDay(timezone)), Instant.MAX,
           SENT, null, null));
       sentNotifications.add(new History(ObjectId.get(),
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
-          previousTemplateInfo,
+          previousTemplateInfo, null,
           Instant.from(previousSentAt.atStartOfDay(timezone)), Instant.MAX,
           SENT, null, null));
     }
@@ -1118,25 +1119,25 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        mostRecentTemplateInfo,
+        mostRecentTemplateInfo, null,
         Instant.from(mostRecentSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        previousTemplateInfo,
+        previousTemplateInfo, null,
         Instant.from(previousSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_DAY_ONE, recipientInfo,
-        mostRecentTemplateInfo,
+        mostRecentTemplateInfo, null,
         Instant.from(mostRecentSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_DAY_ONE, recipientInfo,
-        previousTemplateInfo,
+        previousTemplateInfo, null,
         Instant.from(previousSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
 
@@ -1168,13 +1169,13 @@ class ProgrammeMembershipServiceTest {
       sentNotifications.add(new History(ObjectId.get(),
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
-          mostRecentTemplateInfo,
+          mostRecentTemplateInfo, null,
           Instant.from(mostRecentSentAt.atStartOfDay(timezone)), Instant.MAX,
           SENT, null, null));
       sentNotifications.add(new History(ObjectId.get(),
           new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
           inAppType, recipientInfo,
-          previousTemplateInfo,
+          previousTemplateInfo, null,
           Instant.from(previousSentAt.atStartOfDay(timezone)), Instant.MAX,
           SENT, null, null));
     }
@@ -1210,7 +1211,7 @@ class ProgrammeMembershipServiceTest {
     History sentNotification = new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null);
     Map<NotificationType, History> alreadySent = Map.of(PROGRAMME_CREATED, sentNotification);
@@ -1235,7 +1236,7 @@ class ProgrammeMembershipServiceTest {
     History sentNotification = new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null);
     Map<NotificationType, History> alreadySent = Map.of(PROGRAMME_CREATED, sentNotification);
@@ -1257,7 +1258,7 @@ class ProgrammeMembershipServiceTest {
     History sentNotification = new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.from(originalSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null);
     Map<NotificationType, History> alreadySent = Map.of(PROGRAMME_CREATED, sentNotification);
@@ -1276,7 +1277,7 @@ class ProgrammeMembershipServiceTest {
     History sentNotification = new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        null,
+        null, null,
         Instant.MIN, Instant.MAX,
         SENT, null, null);
     Map<NotificationType, History> alreadySent = Map.of(PROGRAMME_CREATED, sentNotification);
@@ -1296,7 +1297,7 @@ class ProgrammeMembershipServiceTest {
     History sentNotification = new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.MIN, Instant.MAX,
         SENT, null, null);
     Map<NotificationType, History> alreadySent = Map.of(PROGRAMME_CREATED, sentNotification);
@@ -1317,7 +1318,7 @@ class ProgrammeMembershipServiceTest {
     History sentNotification = new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_CREATED, recipientInfo,
-        templateInfo,
+        templateInfo, null,
         Instant.MIN, Instant.MAX,
         SENT, null, null);
     Map<NotificationType, History> alreadySent = Map.of(PROGRAMME_CREATED, sentNotification);
@@ -1339,7 +1340,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         notificationType, recipientInfo,
-        null,
+        null, null,
         Instant.MIN, Instant.MAX, SENT, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -1358,7 +1359,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(TisReferenceType.PLACEMENT, TIS_ID), //note: placement type
         PROGRAMME_CREATED, recipientInfo, //to avoid masking the test condition
-        null,
+        null, null,
         Instant.MIN, Instant.MAX, SENT, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -1377,7 +1378,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, "another id"),
         PROGRAMME_CREATED, recipientInfo,
-        null,
+        null, null,
         Instant.MIN, Instant.MAX, SENT, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -1396,7 +1397,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         null,
         PROGRAMME_CREATED, recipientInfo,
-        null,
+        null, null,
         Instant.MIN, Instant.MAX, SENT, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -1414,7 +1415,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         null,
         PROGRAMME_CREATED,
-        recipientInfo, null,
+        recipientInfo, null, null,
         Instant.MIN, Instant.MAX, SENT, null, null));
 
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);
@@ -1433,7 +1434,7 @@ class ProgrammeMembershipServiceTest {
     sentNotifications.add(new History(ObjectId.get(),
         new TisReferenceInfo(PROGRAMME_MEMBERSHIP, TIS_ID),
         PROGRAMME_DAY_ONE, any(),
-        new TemplateInfo(null, null, null),
+        new TemplateInfo(null, null, null), null,
         Instant.from(mostRecentSentAt.atStartOfDay(timezone)), Instant.MAX,
         SENT, null, null));
     when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(sentNotifications);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,7 +5,7 @@ application:
   email:
     sender: dummy-value
   queues:
-    coj-received: dummy-value
+    coj-published: dummy-value
 
 mongock:
   enabled: false


### PR DESCRIPTION
Attach a copy of the signed PDF to COJ notification emails.
The PDF is generated by the forms service and uploaded to S3, when the
COJ publish event is received it contains a reference to S3 bucket and
file to be attached.

Update the next steps section of the COJ confirmation to say that a copy
of the PDF is attached, as well as being able to download it from TIS
Self-Service.

TIS21-6106
TIS21-6122