### PR TITLE
fix: ignore COJ publish if confirmation sent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.33.0"
+version = "1.33.1"
 
 configurations {
   compileOnly {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ConditionsOfJoiningListenerIntegrationTest.java
@@ -154,8 +154,8 @@ class ConditionsOfJoiningListenerIntegrationTest {
     }).when(emailService).sendMessageToExistingUser(any(), any(), any(), any(), any(), any());
 
     // Create a new listener instance to inject the spy.
-    ConditionsOfJoiningListener listener = new ConditionsOfJoiningListener(emailService,
-        templateVersion);
+    ConditionsOfJoiningListener listener = new ConditionsOfJoiningListener(historyService,
+        emailService, templateVersion);
     listener.handleConditionsOfJoiningPublished(event);
 
     ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();


### PR DESCRIPTION
The COJ listener previous used COJ received event, which was only ever sent once. Now that it used a COJ published event, there is a possibility that the event could be sent again if a PDF was regenerated.

Update the listener to ensure that processing is skipped if a COJ confirmation was already sent.

TIS21-6106
TIS21-6122