### PR TITLE
fix: time-sensitive test robustified

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.34.1"
+version = "1.34.2"
 
 configurations {
   compileOnly {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -351,9 +351,12 @@ class PlacementServiceTest {
         is(SITE));
 
     Date when = dateCaptor.getValue();
-    Date minuteHence = Date.from(Instant.now().plus(1, ChronoUnit.MINUTES));
+    Date twoMinutesHence = Date.from(Instant.now().plus(2, ChronoUnit.MINUTES));
     assertThat("Unexpected rollout correction notification start time",
-        when.before(minuteHence), is(true));
+        when.before(twoMinutesHence), is(true));
+    Date now = Date.from(Instant.now());
+    assertThat("Unexpected rollout correction notification start time",
+        when.after(now), is(true));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
The previous PR threw-up when deploying to staging.

NO-TICKET