### PR TITLE
Feat: handle GMC-update rejection

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -45,12 +45,12 @@
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/form/updated"
         },
         {
-          "name": "GMC_UPDATED_QUEUE",
-          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/gmc-details/updated"
-        },
-        {
           "name": "GMC_REJECTED_QUEUE",
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/gmc-details/rejected"
+        },
+        {
+          "name": "GMC_UPDATED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/gmc-details/updated"
         },
         {
           "name": "PLACEMENT_UPDATED_QUEUE",

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -49,6 +49,10 @@
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/gmc-details/updated"
         },
         {
+          "name": "GMC_REJECTED_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/gmc-details/rejected"
+        },
+        {
           "name": "PLACEMENT_UPDATED_QUEUE",
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/placement/updated"
         },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.36.0"
+version = "1.37.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/GmcListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/GmcListener.java
@@ -22,12 +22,16 @@
 package uk.nhs.tis.trainee.notifications.event;
 
 import static uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType.GMC_UPDATE;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.GMC_REJECTED_LO;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.GMC_REJECTED_TRAINEE;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.GMC_UPDATED;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.CC_OF_FIELD;
 
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import jakarta.mail.MessagingException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,22 +58,34 @@ public class GmcListener {
   public static final String FAMILY_NAME_FIELD = "familyName";
   public static final String GMC_NUMBER_FIELD = "gmcNumber";
   public static final String GMC_STATUS_FIELD = "gmcStatus";
+  public static final String TIS_TRIGGER_FIELD = "tisTrigger";
+  public static final String TIS_TRIGGER_DETAIL_FIELD = "tisTriggerDetail";
 
   private final EmailService emailService;
   private final String templateVersion;
+  private final String updateTemplateVersion;
+  private final String rejectLoTemplateVersion;
+  private final String rejectTraineeTemplateVersion;
   private final NotificationService notificationService;
   private final MessagingControllerService messagingControllerService;
 
   /**
    * Construct a listener for GMC events.
    *
-   * @param emailService The service to use for sending emails.
+   * @param notificationService          The service to use for notifications.
+   * @param updateTemplateVersion        The update-GMC template version to use.
+   * @param rejectLoTemplateVersion      The rejected-GMC template version to use for local office.
+   * @param rejectTraineeTemplateVersion The rejected-GMC template version to use for trainee.
    */
-  public GmcListener(EmailService emailService, NotificationService notificationService,
-      MessagingControllerService messagingControllerService,
-      @Value("${application.template-versions.gmc-updated.email}") String templateVersion) {
-    this.emailService = emailService;
-    this.templateVersion = templateVersion;
+  public GmcListener(NotificationService notificationService,
+      @Value("${application.template-versions.gmc-updated.email}") String updateTemplateVersion,
+      @Value("${application.template-versions.gmc-rejected-lo.email}")
+      String rejectLoTemplateVersion,
+      @Value("${application.template-versions.gmc-rejected-trainee.email}")
+      String rejectTraineeTemplateVersion) {
+    this.updateTemplateVersion = updateTemplateVersion;
+    this.rejectLoTemplateVersion = rejectLoTemplateVersion;
+    this.rejectTraineeTemplateVersion = rejectTraineeTemplateVersion;
     this.notificationService = notificationService;
     this.messagingControllerService = messagingControllerService;
   }
@@ -92,31 +108,55 @@ public class GmcListener {
     templateVariables.put(GMC_NUMBER_FIELD, event.gmcDetails().gmcNumber());
     templateVariables.put(GMC_STATUS_FIELD, event.gmcDetails().gmcStatus());
 
+    notificationService.sendLocalOfficeMail(event.traineeId(), GMC_UPDATE, templateVariables,
+        updateTemplateVersion, GMC_UPDATED);
+  }
+
+  /**
+   * Handle GMC rejected events.
+   *
+   * @param event The GMC rejected event message, which contains the reset GMC details.
+   * @throws MessagingException If the message could not be sent.
+   */
+  @SqsListener("${application.queues.gmc-rejected}")
+  public void handleGmcRejected(GmcRejectedEvent event) throws MessagingException {
+    log.info("Handling GMC rejected event {}.", event);
+
+    UserDetails userDetails = notificationService.getTraineeDetails(event.traineeId());
+    Map<String, Object> loTemplateVariables = buildGmcRejectedTemplateVariables(event, userDetails);
+
     String traineeId = event.traineeId();
-    Set<LocalOfficeContact> localOfficeContacts = notificationService
-        .getTraineeLocalOfficeContacts(traineeId, GMC_UPDATE);
+    Set<String> sentTo = notificationService.sendLocalOfficeMail(traineeId, GMC_UPDATE,
+        loTemplateVariables, rejectLoTemplateVersion, GMC_REJECTED_LO);
 
-    if (localOfficeContacts != null && !localOfficeContacts.isEmpty()) {
-      boolean canSendMail = messagingControllerService.isMessagingEnabled(MessageType.EMAIL);
-      //since some LO's share a contact we need to eliminate possible duplicates:
-      Set<String> distinctContacts = localOfficeContacts.stream()
-          .map(LocalOfficeContact::contact).filter(Objects::nonNull).collect(Collectors.toSet());
-
-      for (String loContact : distinctContacts) {
-        if (notificationService.isLocalOfficeContactEmail(loContact)) {
-          emailService.sendMessage(traineeId, loContact, GMC_UPDATED, templateVersion,
-              templateVariables, null, !canSendMail);
-          log.info("GMC updated notification {} for trainee {} to {}.",
-              (canSendMail ? "sent" : "logged"), traineeId, loContact);
-        } else {
-          log.info("GMC updated notification skipped for trainee {} to non-email {}.",
-              traineeId, loContact);
-        }
-      }
-
-    } else {
-      log.warn("GMC updated notification not processed for trainee {}: no local office contacts.",
-          traineeId);
+    Map<String, Object> traineeTemplateVariables
+        = buildGmcRejectedTemplateVariables(event, userDetails);
+    String sentToJoined = String.join("; ", sentTo);
+    if (!sentToJoined.isBlank()) {
+      traineeTemplateVariables.put(CC_OF_FIELD, sentToJoined);
     }
+    String traineeEmail = userDetails != null ? userDetails.email() : null;
+    notificationService.sendTraineeMail(traineeId, traineeEmail, traineeTemplateVariables,
+        rejectTraineeTemplateVersion, GMC_REJECTED_TRAINEE);
+  }
+
+  /**
+   * Build baseline template variables for a GMC-rejected template.
+   *
+   * @param event       The GMC rejected event message, which contains the reset GMC details.
+   * @param userDetails The user details of the trainee.
+   * @return The template variable map.
+   */
+  private Map<String, Object> buildGmcRejectedTemplateVariables(GmcRejectedEvent event,
+      UserDetails userDetails) {
+    Map<String, Object> templateVariables = new HashMap<>();
+    templateVariables.put(TRAINEE_ID_FIELD, event.traineeId());
+    templateVariables.put(TIS_TRIGGER_FIELD, event.tisTrigger());
+    templateVariables.put(TIS_TRIGGER_DETAIL_FIELD, event.tisTriggerDetail());
+    templateVariables.put(GIVEN_NAME_FIELD, userDetails != null ? userDetails.givenName() : null);
+    templateVariables.put(FAMILY_NAME_FIELD, userDetails != null ? userDetails.familyName() : null);
+    templateVariables.put(GMC_NUMBER_FIELD, event.update().gmcDetails().gmcNumber());
+    templateVariables.put(GMC_STATUS_FIELD, event.update().gmcDetails().gmcStatus());
+    return templateVariables;
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/GmcListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/GmcListener.java
@@ -32,18 +32,12 @@ import jakarta.mail.MessagingException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
+import uk.nhs.tis.trainee.notifications.model.GmcRejectedEvent;
 import uk.nhs.tis.trainee.notifications.model.GmcUpdateEvent;
-import uk.nhs.tis.trainee.notifications.model.LocalOfficeContact;
-import uk.nhs.tis.trainee.notifications.model.MessageType;
-import uk.nhs.tis.trainee.notifications.service.EmailService;
-import uk.nhs.tis.trainee.notifications.service.MessagingControllerService;
 import uk.nhs.tis.trainee.notifications.service.NotificationService;
 
 /**
@@ -61,13 +55,10 @@ public class GmcListener {
   public static final String TIS_TRIGGER_FIELD = "tisTrigger";
   public static final String TIS_TRIGGER_DETAIL_FIELD = "tisTriggerDetail";
 
-  private final EmailService emailService;
-  private final String templateVersion;
   private final String updateTemplateVersion;
   private final String rejectLoTemplateVersion;
   private final String rejectTraineeTemplateVersion;
   private final NotificationService notificationService;
-  private final MessagingControllerService messagingControllerService;
 
   /**
    * Construct a listener for GMC events.
@@ -87,7 +78,6 @@ public class GmcListener {
     this.rejectLoTemplateVersion = rejectLoTemplateVersion;
     this.rejectTraineeTemplateVersion = rejectTraineeTemplateVersion;
     this.notificationService = notificationService;
-    this.messagingControllerService = messagingControllerService;
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/GmcRejectedEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/GmcRejectedEvent.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package uk.nhs.tis.trainee.notifications.model;
+import com.fasterxml.jackson.annotation.JsonProperty;
+/**
+ * An event to receive details of a rejected trainee GMC update.
+ *
+ * @param traineeId        The trainee ID.
+ * @param tisTrigger       The TIS trigger for the rejection.
+ * @param tisTriggerDetail The details of the reason for rejection.
+ * @param update           The reverted GMC details.
+ */
+public record GmcRejectedEvent(
+    @JsonProperty("tisId") String traineeId,
+    String tisTrigger,
+    String tisTriggerDetail,
+    @JsonProperty("record")
+    Update update) {
+  /**
+   * A wrapper around the update data, used so the record structure matches the incoming message.
+   *
+   * @param gmcDetails The updated GMC details.
+   */
+  public record Update(
+      @JsonProperty("data")
+      GmcDetails gmcDetails) {
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/GmcRejectedEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/GmcRejectedEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2024 Crown Copyright (Health Education England)
+ * Copyright 2025 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -18,8 +18,11 @@
  * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 package uk.nhs.tis.trainee.notifications.model;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * An event to receive details of a rejected trainee GMC update.
  *
@@ -34,6 +37,7 @@ public record GmcRejectedEvent(
     String tisTriggerDetail,
     @JsonProperty("record")
     Update update) {
+
   /**
    * A wrapper around the update data, used so the record structure matches the incoming message.
    *
@@ -42,5 +46,6 @@ public record GmcRejectedEvent(
   public record Update(
       @JsonProperty("data")
       GmcDetails gmcDetails) {
+
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/NotificationType.java
@@ -42,6 +42,8 @@ public enum NotificationType {
   EMAIL_UPDATED_NEW("email-updated-new"),
   EMAIL_UPDATED_OLD("email-updated-old"),
   FORM_UPDATED("form-updated"),
+  GMC_REJECTED_LO("gmc-rejected-lo"),
+  GMC_REJECTED_TRAINEE("gmc-rejected-trainee"),
   GMC_UPDATED("gmc-updated"),
   INDEMNITY_INSURANCE("indemnity-insurance"),
   LTFT("less-than-full-time"),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ application:
     contact-details-updated: ${CONTACT_DETAILS_UPDATED_QUEUE}
     email-failure: ${EMAIL_FAILURE_QUEUE}
     form-updated: ${FORM_UPDATED_QUEUE}
+    gmc-rejected: ${GMC_REJECTED_QUEUE}
     gmc-updated: ${GMC_UPDATED_QUEUE}
     placement-updated: ${PLACEMENT_UPDATED_QUEUE}
     placement-deleted: ${PLACEMENT_DELETED_QUEUE}
@@ -50,6 +51,10 @@ application:
     email-updated-old:
       email: v1.0.0
     form-updated:
+      email: v1.0.0
+    gmc-rejected-localoffice:
+      email: v1.0.0
+    gmc-rejected-trainee:
       email: v1.0.0
     gmc-updated:
       email: v1.0.0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ application:
       email: v1.0.0
     form-updated:
       email: v1.0.0
-    gmc-rejected-localoffice:
+    gmc-rejected-lo:
       email: v1.0.0
     gmc-rejected-trainee:
       email: v1.0.0

--- a/src/main/resources/templates/email/gmc-rejected-lo/v1.0.0.html
+++ b/src/main/resources/templates/email/gmc-rejected-lo/v1.0.0.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title>Form Updated</title>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">GMC Number update rejected</th:block>
+<h2>Content</h2>
+<th:block th:fragment="content">
+  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+  <p>Dear Local Office,</p>
+  <p id="doctorName">Doctor <span th:text="${not #strings.isEmpty(givenName)} ? |${givenName}| : _"></span
+  > <span th:text="${not #strings.isEmpty(familyName)} ? |${familyName}| : _">(family name missing)</span
+  > GMC number <span th:text="${not #strings.isEmpty(gmcNumber)} ? |${gmcNumber}| : _">(GMC number missing)</span
+  ></p>
+  <p>The recent update to GMC details was rejected by TIS, and the GMC number has been reset to that shown above. <a id="tisTraineeLink"
+      th:href="${'https://apps.tis.nhs.uk/admin/people/person/' + {traineeId} + '/edit-personal-details'}">Review</a> their details to confirm.</p>
+  <p>This may be caused by a variety of factors. For example, duplicate GMC numbers are not allowed. Please review the TIS profile and/or liaise with the doctor as required.</p>
+  <p>Kind Regards,</p>
+  <p>TIS Self-Service</p>
+  <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/email/gmc-rejected-trainee/v1.0.0.html
+++ b/src/main/resources/templates/email/gmc-rejected-trainee/v1.0.0.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <title>Form Updated</title>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">GMC Number update rejected</th:block>
+<h2>Content</h2>
+<th:block th:fragment="content">
+  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+  <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+  <p>GMC number <span th:text="${not #strings.isEmpty(gmcNumber)} ? |${gmcNumber}| : _">(GMC number missing)</span
+  ></p>
+  <p>Your recent update to GMC details was rejected by TIS, and the GMC number has been reset to that shown above. Please correct your GMC number on TIS Self-Service if it is still incorrect, or liaise with your local office if you have further concerns.</p>
+  <p><span id="ccOf" th:text="${ccOfSentTo} ? |This notification was also sent to local office contact(s): ${ccOfSentTo}.| : _"></span></p>
+  <p>Kind Regards,</p>
+  <p>TIS Self-Service</p>
+  <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+</th:block>
+</body>
+</html>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/GmcListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/GmcListenerTest.java
@@ -23,67 +23,61 @@ package uk.nhs.tis.trainee.notifications.event;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.FAMILY_NAME_FIELD;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.GIVEN_NAME_FIELD;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.GMC_NUMBER_FIELD;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.GMC_STATUS_FIELD;
+import static uk.nhs.tis.trainee.notifications.event.GmcListener.TIS_TRIGGER_DETAIL_FIELD;
+import static uk.nhs.tis.trainee.notifications.event.GmcListener.TIS_TRIGGER_FIELD;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.TRAINEE_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType.GMC_UPDATE;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.GMC_REJECTED_LO;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.CC_OF_FIELD;
 
 import jakarta.mail.MessagingException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.model.GmcDetails;
+import uk.nhs.tis.trainee.notifications.model.GmcRejectedEvent;
+import uk.nhs.tis.trainee.notifications.model.GmcRejectedEvent.Update;
 import uk.nhs.tis.trainee.notifications.model.GmcUpdateEvent;
-import uk.nhs.tis.trainee.notifications.model.LocalOfficeContact;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
-import uk.nhs.tis.trainee.notifications.service.EmailService;
-import uk.nhs.tis.trainee.notifications.service.MessagingControllerService;
 import uk.nhs.tis.trainee.notifications.service.NotificationService;
 
 class GmcListenerTest {
 
-  private static final String VERSION = "v1.2.3";
+  private static final String UPDATE_VERSION = "v1.2.3";
+  private static final String REJECT_LO_VERSION = "v3.2.1";
+  private static final String REJECT_TRAINEE_VERSION = "v3.2.4";
+  private static final String TRAINEE_ID = "traineeId";
+  private static final String TIS_TRIGGER = "TIS trigger";
+  private static final String TIS_TRIGGER_DETAIL = "TIS trigger detail";
+  private static final String GMC_NO = "1234567";
+  private static final String GMC_STATUS = "CONFIRMED";
 
   private GmcListener listener;
-  private EmailService emailService;
   private NotificationService notificationService;
-  private MessagingControllerService messagingControllerService;
 
   @BeforeEach
   void setUp() {
-    emailService = mock(EmailService.class);
     notificationService = mock(NotificationService.class);
-    messagingControllerService = mock(MessagingControllerService.class);
-    listener = new GmcListener(emailService, notificationService, messagingControllerService,
-        VERSION);
+    listener = new GmcListener(notificationService, UPDATE_VERSION, REJECT_LO_VERSION,
+        REJECT_TRAINEE_VERSION);
   }
 
   @Test
   void shouldThrowExceptionWhenGmcUpdatedAndSendingFails() throws MessagingException {
-    doThrow(MessagingException.class).when(emailService)
-        .sendMessage(any(), any(), any(), any(), any(), any(), anyBoolean());
-
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact("contact", "local office"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(true);
+    doThrow(MessagingException.class).when(notificationService)
+        .sendLocalOfficeMail(any(), any(), any(), any(), any());
 
     GmcUpdateEvent event
         = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
@@ -92,133 +86,22 @@ class GmcListenerTest {
   }
 
   @Test
-  void shouldNotSendEmailIfNullLocalOffice() throws MessagingException {
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(null);
+  void shouldThrowExceptionWhenGmcRejectedAndSendingFails() throws MessagingException {
+    doThrow(MessagingException.class).when(notificationService)
+        .sendLocalOfficeMail(any(), any(), any(), any(), any());
 
-    GmcUpdateEvent event
-        = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
+    GmcRejectedEvent event
+        = new GmcRejectedEvent(TRAINEE_ID, TIS_TRIGGER, TIS_TRIGGER_DETAIL,
+            new Update(new GmcDetails(GMC_NO, GMC_STATUS)));
 
-    listener.handleGmcUpdate(event);
-
-    verify(messagingControllerService, never()).isMessagingEnabled(any());
+    assertThrows(MessagingException.class, () -> listener.handleGmcRejected(event));
   }
 
   @Test
-  void shouldNotSendEmailIfNoLocalOffice() throws MessagingException {
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(new HashSet<>());
-
-    GmcUpdateEvent event
-        = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
-
-    listener.handleGmcUpdate(event);
-
-    verify(messagingControllerService, never()).isMessagingEnabled(any());
-  }
-
-  @Test
-  void shouldNotSendEmailIfLocalOfficeHasNoEmail() throws MessagingException {
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact(null, "local office"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(true);
-
-    GmcUpdateEvent event
-        = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
-
-    listener.handleGmcUpdate(event);
-
-    verify(emailService, never())
-        .sendMessage(any(), any(), any(), any(), any(), any(), anyBoolean());
-  }
-
-  @Test
-  void shouldNotSendEmailIfLocalOfficeContactNotEmail() throws MessagingException {
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact("https://url.com", "local office"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(false);
-
-    GmcUpdateEvent event
-        = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
-
-    listener.handleGmcUpdate(event);
-
-    verify(emailService, never())
-        .sendMessage(any(), any(), any(), any(), any(), any(), anyBoolean());
-  }
-
-  @Test
-  void shouldSendOneEmailIfLocalOfficesHaveSameEmail() throws MessagingException {
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact("contact", "local office"));
-    localOfficeContacts.add(new LocalOfficeContact("contact", "name2"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(true);
-
-    GmcUpdateEvent event
-        = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
-
-    listener.handleGmcUpdate(event);
-
-    verify(emailService)
-        .sendMessage(any(), eq("contact"), any(), any(), any(), any(), anyBoolean());
-  }
-
-  @Test
-  void shouldSendMultipleEmailIfLocalOfficesHaveDifferentEmail() throws MessagingException {
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact("contact", "local office"));
-    localOfficeContacts.add(new LocalOfficeContact("contact2", "name2"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(true);
-
-    GmcUpdateEvent event
-        = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
-
-    listener.handleGmcUpdate(event);
-
-    verify(emailService)
-        .sendMessage(any(), eq("contact"), any(), any(), any(), any(), anyBoolean());
-    verify(emailService)
-        .sendMessage(any(), eq("contact2"), any(), any(), any(), any(), anyBoolean());
-    verifyNoMoreInteractions(emailService);
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void shouldLogEmailIfMessagingNotEnabled(boolean isMessagingEnabled) throws MessagingException {
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact("contact", "local office"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
-    when(messagingControllerService.isMessagingEnabled(any())).thenReturn(isMessagingEnabled);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(true);
-
-    GmcUpdateEvent event
-        = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
-
-    listener.handleGmcUpdate(event);
-
-    verify(emailService)
-        .sendMessage(any(), eq("contact"), any(), any(), any(), any(), eq(!isMessagingEnabled));
-  }
-
-  @Test
-  void shouldIncludeUserDetailsInTemplateIfAvailable() throws MessagingException {
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact("contact", "local office"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
+  void shouldIncludeUserDetailsInUpdateTemplateIfAvailable() throws MessagingException {
     UserDetails userDetails
         = new UserDetails(true, "traineeemail", "title", "family", "given", "1111111");
     when(notificationService.getTraineeDetails(any())).thenReturn(userDetails);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(true);
 
     GmcUpdateEvent event
         = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
@@ -226,41 +109,113 @@ class GmcListenerTest {
     listener.handleGmcUpdate(event);
 
     Map<String, Object> expectedTemplateVariables = new HashMap<>();
-    expectedTemplateVariables.put(TRAINEE_ID_FIELD, "traineeId");
+    expectedTemplateVariables.put(TRAINEE_ID_FIELD, TRAINEE_ID);
     expectedTemplateVariables.put(GIVEN_NAME_FIELD, "given");
     expectedTemplateVariables.put(FAMILY_NAME_FIELD, "family");
-    expectedTemplateVariables.put(GMC_NUMBER_FIELD, "1234567");
-    expectedTemplateVariables.put(GMC_STATUS_FIELD, "CONFIRMED");
+    expectedTemplateVariables.put(GMC_NUMBER_FIELD, GMC_NO);
+    expectedTemplateVariables.put(GMC_STATUS_FIELD, GMC_STATUS);
 
-    verify(emailService)
-        .sendMessage(eq("traineeId"), eq("contact"), eq(NotificationType.GMC_UPDATED), any(),
-            eq(expectedTemplateVariables), eq(null), anyBoolean());
+    verify(notificationService).sendLocalOfficeMail(eq("traineeId"), eq(GMC_UPDATE),
+        eq(expectedTemplateVariables), any(), eq(NotificationType.GMC_UPDATED));
   }
 
   @Test
-  void shouldNotIncludeUserDetailsInTemplateIfNotAvailable() throws MessagingException {
-    Set<LocalOfficeContact> localOfficeContacts = new HashSet<>();
-    localOfficeContacts.add(new LocalOfficeContact("email@contact.com", "local office"));
-    when(notificationService.getTraineeLocalOfficeContacts(any(), eq(GMC_UPDATE)))
-        .thenReturn(localOfficeContacts);
-    when(notificationService.getTraineeDetails(any())).thenReturn(null);
-    when(notificationService.isLocalOfficeContactEmail(any())).thenReturn(true);
+  void shouldIncludeUserDetailsInRejectTemplateIfAvailable() throws MessagingException {
+    UserDetails userDetails
+        = new UserDetails(true, "traineeemail", "title", "family", "given", "1111111");
+    when(notificationService.getTraineeDetails(any())).thenReturn(userDetails);
 
+    GmcRejectedEvent event
+        = new GmcRejectedEvent(TRAINEE_ID, TIS_TRIGGER, TIS_TRIGGER_DETAIL,
+            new Update(new GmcDetails(GMC_NO, GMC_STATUS)));
+
+    listener.handleGmcRejected(event);
+
+    Map<String, Object> expectedTemplateVariables = new HashMap<>();
+    expectedTemplateVariables.put(TRAINEE_ID_FIELD, TRAINEE_ID);
+    expectedTemplateVariables.put(GIVEN_NAME_FIELD, "given");
+    expectedTemplateVariables.put(FAMILY_NAME_FIELD, "family");
+    expectedTemplateVariables.put(GMC_NUMBER_FIELD, GMC_NO);
+    expectedTemplateVariables.put(GMC_STATUS_FIELD, GMC_STATUS);
+    expectedTemplateVariables.put(TIS_TRIGGER_FIELD, TIS_TRIGGER);
+    expectedTemplateVariables.put(TIS_TRIGGER_DETAIL_FIELD, TIS_TRIGGER_DETAIL);
+
+    verify(notificationService).sendLocalOfficeMail(eq(TRAINEE_ID), eq(GMC_UPDATE),
+        eq(expectedTemplateVariables), any(), eq(GMC_REJECTED_LO));
+  }
+
+  @Test
+  void shouldNotIncludeUserDetailsInUpdateTemplateIfNotAvailable() throws MessagingException {
     GmcUpdateEvent event
         = new GmcUpdateEvent("traineeId", new GmcDetails("1234567", "CONFIRMED"));
 
     listener.handleGmcUpdate(event);
 
     Map<String, Object> expectedTemplateVariables = new HashMap<>();
-    expectedTemplateVariables.put(TRAINEE_ID_FIELD, "traineeId");
+    expectedTemplateVariables.put(TRAINEE_ID_FIELD, TRAINEE_ID);
     expectedTemplateVariables.put(GIVEN_NAME_FIELD, null);
     expectedTemplateVariables.put(FAMILY_NAME_FIELD, null);
-    expectedTemplateVariables.put(GMC_NUMBER_FIELD, "1234567");
-    expectedTemplateVariables.put(GMC_STATUS_FIELD, "CONFIRMED");
+    expectedTemplateVariables.put(GMC_NUMBER_FIELD, GMC_NO);
+    expectedTemplateVariables.put(GMC_STATUS_FIELD, GMC_STATUS);
 
-    verify(emailService)
-        .sendMessage(eq("traineeId"), eq("email@contact.com"), eq(NotificationType.GMC_UPDATED),
-            any(), eq(expectedTemplateVariables), eq(null), anyBoolean());
+    verify(notificationService).sendLocalOfficeMail(eq("traineeId"), eq(GMC_UPDATE),
+        eq(expectedTemplateVariables), any(), eq(NotificationType.GMC_UPDATED));
   }
 
+  @Test
+  void shouldNotIncludeUserDetailsInRejectTemplateIfNotAvailable() throws MessagingException {
+    GmcRejectedEvent event
+        = new GmcRejectedEvent(TRAINEE_ID, TIS_TRIGGER, TIS_TRIGGER_DETAIL,
+            new Update(new GmcDetails("1234567", "CONFIRMED")));
+
+    listener.handleGmcRejected(event);
+
+    Map<String, Object> expectedTemplateVariables = new HashMap<>();
+    expectedTemplateVariables.put(TRAINEE_ID_FIELD, TRAINEE_ID);
+    expectedTemplateVariables.put(GIVEN_NAME_FIELD, null);
+    expectedTemplateVariables.put(FAMILY_NAME_FIELD, null);
+    expectedTemplateVariables.put(GMC_NUMBER_FIELD, GMC_NO);
+    expectedTemplateVariables.put(GMC_STATUS_FIELD, GMC_STATUS);
+    expectedTemplateVariables.put(TIS_TRIGGER_FIELD, TIS_TRIGGER);
+    expectedTemplateVariables.put(TIS_TRIGGER_DETAIL_FIELD, TIS_TRIGGER_DETAIL);
+
+    verify(notificationService).sendLocalOfficeMail(eq(TRAINEE_ID), eq(GMC_UPDATE),
+        eq(expectedTemplateVariables), any(), eq(GMC_REJECTED_LO));
+  }
+
+  @Test
+  void shouldIncludeCcedToInRejectTraineeTemplate() throws MessagingException {
+    UserDetails userDetails
+        = new UserDetails(true, "traineeemail", "title", "family", "given", "1111111");
+    when(notificationService.getTraineeDetails(any())).thenReturn(userDetails);
+
+    Map<String, Object> expectedLoTemplateVariables = new HashMap<>();
+    expectedLoTemplateVariables.put(TRAINEE_ID_FIELD, TRAINEE_ID);
+    expectedLoTemplateVariables.put(GIVEN_NAME_FIELD, "given");
+    expectedLoTemplateVariables.put(FAMILY_NAME_FIELD, "family");
+    expectedLoTemplateVariables.put(GMC_NUMBER_FIELD, GMC_NO);
+    expectedLoTemplateVariables.put(GMC_STATUS_FIELD, GMC_STATUS);
+    expectedLoTemplateVariables.put(TIS_TRIGGER_FIELD, TIS_TRIGGER);
+    expectedLoTemplateVariables.put(TIS_TRIGGER_DETAIL_FIELD, TIS_TRIGGER_DETAIL);
+
+    Set<String> losContacted = Set.of("lo@1.com", "lo@2.com");
+    when(notificationService.sendLocalOfficeMail(eq(TRAINEE_ID), eq(GMC_UPDATE), any(),
+        eq(REJECT_LO_VERSION), eq(GMC_REJECTED_LO))).thenReturn(losContacted);
+
+    GmcRejectedEvent event
+        = new GmcRejectedEvent(TRAINEE_ID, TIS_TRIGGER, TIS_TRIGGER_DETAIL,
+        new Update(new GmcDetails(GMC_NO, GMC_STATUS)));
+
+    listener.handleGmcRejected(event);
+
+    verify(notificationService).sendLocalOfficeMail(TRAINEE_ID, GMC_UPDATE,
+        expectedLoTemplateVariables, REJECT_LO_VERSION, GMC_REJECTED_LO);
+
+    Map<String, Object> expectedTraineeTemplateVariables = new HashMap<>(
+        Map.copyOf(expectedLoTemplateVariables));
+    expectedTraineeTemplateVariables.put(CC_OF_FIELD, "lo@1.com; lo@2.com");
+    verify(notificationService).sendTraineeMail(TRAINEE_ID, "traineeemail",
+        expectedTraineeTemplateVariables, REJECT_TRAINEE_VERSION,
+        NotificationType.GMC_REJECTED_TRAINEE);
+  }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/GmcListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/GmcListenerTest.java
@@ -204,7 +204,7 @@ class GmcListenerTest {
 
     GmcRejectedEvent event
         = new GmcRejectedEvent(TRAINEE_ID, TIS_TRIGGER, TIS_TRIGGER_DETAIL,
-        new Update(new GmcDetails(GMC_NO, GMC_STATUS)));
+            new Update(new GmcDetails(GMC_NO, GMC_STATUS)));
 
     listener.handleGmcRejected(event);
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -623,7 +623,8 @@ class EmailServiceIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
     Element body = content.body();
 
-    assertNull(body.getElementById("ccOf"), "Unexpected cc details.");
+    String ccOfText = Objects.requireNonNull(body.getElementById("ccOf")).wholeText();
+    assertThat("Unexpected cc details.", ccOfText.isEmpty(), is(true));
   }
 
   int getGreetingElementIndex(NotificationType notificationType) {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -25,17 +25,21 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.FAMILY_NAME_FIELD;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.GIVEN_NAME_FIELD;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.GMC_STATUS_FIELD;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.TRAINEE_ID_FIELD;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.GMC_REJECTED_LO;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.GMC_REJECTED_TRAINEE;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.GMC_UPDATED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_ROLLOUT_2024_CORRECTION;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_DAY_ONE;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.CC_OF_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_CONTACT_HREF_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.PlacementService.START_DATE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.GMC_NUMBER_FIELD;
@@ -157,7 +161,7 @@ class EmailServiceIntegrationTest {
     Document content = Jsoup.parse((String) message.getContent());
     Element body = content.body();
 
-    if (notificationType.equals(GMC_UPDATED)) {
+    if (notificationType.equals(GMC_UPDATED) || notificationType.equals(GMC_REJECTED_LO)) {
       Element greeting = body.children().get(getGreetingElementIndex(notificationType));
       assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
       assertThat("Unexpected greeting.", greeting.text(), is("Dear Local Office,"));
@@ -191,7 +195,7 @@ class EmailServiceIntegrationTest {
       Element greeting = body.children().get(getGreetingElementIndex(notificationType));
       assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
       assertThat("Unexpected greeting.", greeting.text(), is("Dear Dr Anthony Gilliam,"));
-    } else if (notificationType.equals(GMC_UPDATED)) {
+    } else if (notificationType.equals(GMC_UPDATED) || notificationType.equals(GMC_REJECTED_LO)) {
       Element greeting = body.children().get(getGreetingElementIndex(notificationType));
       assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
       assertThat("Unexpected greeting.", greeting.text(), is("Dear Local Office,"));
@@ -226,7 +230,7 @@ class EmailServiceIntegrationTest {
       Element greeting = body.children().get(getGreetingElementIndex(notificationType));
       assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
       assertThat("Unexpected greeting.", greeting.text(), is("Dear Dr Anthony Maillig,"));
-    } else if (notificationType.equals(GMC_UPDATED)) {
+    } else if (notificationType.equals(GMC_UPDATED) || notificationType.equals(GMC_REJECTED_LO)) {
       Element greeting = body.children().get(getGreetingElementIndex(notificationType));
       assertThat("Unexpected element tag.", greeting.tagName(), is("p"));
       assertThat("Unexpected greeting.", greeting.text(), is("Dear Local Office,"));
@@ -556,11 +560,78 @@ class EmailServiceIntegrationTest {
     assertThat("Unexpected doctor name.", docName.contains("Maillig"), is(true));
   }
 
+  @Test
+  void shouldIncludeLinkToReviewTraineeOnTis() throws Exception {
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, GMC));
+
+    Map<String, Object> templateVariables = new HashMap<>();
+    templateVariables.put("traineeId", "12345");
+    service.sendMessage(PERSON_ID, RECIPIENT, GMC_REJECTED_LO, TEMPLATE_VERSION,
+        templateVariables, null, false);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    assertThat("Unexpected missing TIS link.",
+        Objects.requireNonNull(body.getElementById("tisTraineeLink")).hasAttr("href"), is(true));
+    String tisLinkText = Objects.requireNonNull(body.getElementById("tisTraineeLink"))
+        .attributes().get("href");
+    assertThat("Unexpected TIS link content.", tisLinkText.contains(
+        "https://apps.tis.nhs.uk/admin/people/person/12345/edit-personal-details"), is(true));
+  }
+
+  @Test
+  void shouldIncludeCcDetailsWhenAvailable() throws Exception {
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, GMC));
+
+    Map<String, Object> templateVariables = new HashMap<>();
+    templateVariables.put(CC_OF_FIELD, "some@email.com");
+    service.sendMessage(PERSON_ID, RECIPIENT, GMC_REJECTED_TRAINEE, TEMPLATE_VERSION,
+        templateVariables, null, false);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    String ccOfText = Objects.requireNonNull(body.getElementById("ccOf")).wholeText();
+    assertThat("Unexpected cc details.", ccOfText.contains(
+        "This notification was also sent to local office contact(s): some@email.com"), is(true));
+  }
+
+  @Test
+  void shouldIgnoreMissingCcDetails() throws Exception {
+    when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
+        new UserDetails(true, RECIPIENT, null, null, null, GMC));
+
+    Map<String, Object> templateVariables = new HashMap<>();
+    service.sendMessage(PERSON_ID, RECIPIENT, GMC_REJECTED_TRAINEE, TEMPLATE_VERSION,
+        templateVariables, null, false);
+
+    ArgumentCaptor<MimeMessage> messageCaptor = ArgumentCaptor.captor();
+    verify(mailSender).send(messageCaptor.capture());
+
+    MimeMessage message = messageCaptor.getValue();
+    Document content = Jsoup.parse((String) message.getContent());
+    Element body = content.body();
+
+    assertNull(body.getElementById("ccOf"), "Unexpected cc details.");
+  }
+
   int getGreetingElementIndex(NotificationType notificationType) {
     return switch (notificationType) {
       case PLACEMENT_UPDATED_WEEK_12, PLACEMENT_ROLLOUT_2024_CORRECTION, PROGRAMME_CREATED,
            PROGRAMME_DAY_ONE, EMAIL_UPDATED_NEW, EMAIL_UPDATED_OLD, COJ_CONFIRMATION,
-           CREDENTIAL_REVOKED, FORM_UPDATED, GMC_UPDATED -> 1;
+           CREDENTIAL_REVOKED, FORM_UPDATED, GMC_UPDATED, GMC_REJECTED_LO,
+           GMC_REJECTED_TRAINEE -> 1;
       default -> 0;
     };
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.nhs.tis.trainee.notifications.event.GmcListener.FAMILY_NAME_FIELD;


### PR DESCRIPTION
This is slight rework of the reverted https://github.com/Health-Education-England/tis-trainee-notifications/pull/235 . In particular, the trainee- and LO- emails have been separated into distinct templates instead of using the same template with a 'cc' fragment included in the trainee copy. This necessitated a slight rework of GmcListener and NotificationService code.

Updated email contents:

To trainee:
![image](https://github.com/user-attachments/assets/e50b4806-481c-437b-8878-62743a8f370b)

To LO:
![image](https://github.com/user-attachments/assets/e303bee5-c556-4c64-83a5-d883a84f34a6)


TIS21-6638