### PR TITLE
fix: actually delete scheduled PM notifications on PM delete

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.1.0"
+version = "2.1.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListener.java
@@ -78,8 +78,8 @@ public class ProgrammeMembershipListener {
       throws SchedulerException {
     log.info("Handling programme membership delete event {}.", event);
     if (event.recrd() != null && event.recrd().getData() != null) {
-      ProgrammeMembership programmeMembership = new ProgrammeMembership();
-      programmeMembership.setTisId(event.tisId()); //delete messages have empty recrd data
+      ProgrammeMembership programmeMembership = mapper.toEntity(event.recrd().getData());
+      programmeMembership.setTisId(event.tisId());
       programmeMembershipService.deleteNotificationsFromScheduler(programmeMembership);
       programmeMembershipService.deleteScheduledNotificationsFromDb(programmeMembership);
     } else {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -463,6 +463,8 @@ public class ProgrammeMembershipService {
             programmeMembership.getTisId());
 
     for (History history : scheduledHistories) {
+      log.info("Deleting scheduled programme membership notification {} (person {}, PM {}).",
+          history.id(), programmeMembership.getPersonId(), programmeMembership.getTisId());
       historyService.deleteHistoryForTrainee(history.id(), programmeMembership.getPersonId());
     }
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -41,6 +42,7 @@ import uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService;
 class ProgrammeMembershipListenerTest {
 
   private static final String TIS_ID = "123";
+  private static final String PERSON_ID = "47165";
   private static final LocalDate START_DATE = LocalDate.now();
 
   private ProgrammeMembershipListener listener;
@@ -85,12 +87,16 @@ class ProgrammeMembershipListenerTest {
   @Test
   void shouldDeleteNotifications() throws SchedulerException {
     Map<String, String> dataMap = new HashMap<>();
+    dataMap.put("personId", PERSON_ID);
     RecordDto data = new RecordDto();
     data.setData(dataMap);
     ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, data);
 
     ProgrammeMembership expectedProgrammeMembership = new ProgrammeMembership();
     expectedProgrammeMembership.setTisId(TIS_ID);
+    expectedProgrammeMembership.setPersonId(PERSON_ID);
+
+    when(mapper.toEntity(dataMap)).thenReturn(expectedProgrammeMembership);
 
     listener.handleProgrammeMembershipDelete(event);
 


### PR DESCRIPTION
Events arrive like
```
2025-04-03T07:56:33.083Z  INFO 1 --- [ntContainer#9-1] u.n.t.t.n.e.ProgrammeMembershipListener  : Handling programme membership delete event ProgrammeMembershipEvent[tisId=c73fbd6c-62a8-405e-9092-0fd245f4e1df, recrd=RecordDto(data={uuid=c73fbd6c-62a8-405e-9092-0fd245f4e1df, programmeMembershipType=SUBSTANTIVE, programmeStartDate=2025-08-06, programmeEndDate=2027-08-03, programmeId=18500, personId=334298, trainingPathway=N/A, amendedDate=2025-03-11T14:30:17.249Z}, metadata={timestamp=2025-04-03T07:56:27.659948Z, record-type=data, operation=delete, partition-key-type=schema-table, schema-name=tcs, table-name=ProgrammeMembership, transaction-id=30700426879410})].
```
but the existing code would not have deleted them from the DB because the personId was not set correctly.

NO-TICKET