### PR TITLE
refactor(ltft): LTFT update event DTO

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.2.0"
+version = "2.2.1"
 
 configurations {
   compileOnly {
@@ -71,9 +71,11 @@ dependencies {
   testImplementation("com.h2database:h2")
 
   testImplementation("org.springframework.boot:spring-boot-testcontainers")
+  testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("org.testcontainers:localstack")
   testImplementation("org.testcontainers:mongodb")
   testImplementation("org.testcontainers:mysql")
-  testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("org.awaitility:awaitility")
 
   testImplementation(libs.jsoup)
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/LtftListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/LtftListener.java
@@ -25,7 +25,6 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.LTFT_UPDAT
 
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import jakarta.mail.MessagingException;
-import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -63,15 +62,9 @@ public class LtftListener {
   public void handleLtftUpdate(LtftUpdateEvent event) throws MessagingException {
     log.info("Handling LTFT update event {}.", event);
 
-    Map<String, Object> templateVariables = new HashMap<>();
-    templateVariables.put("ltftName", event.content().name());
-    templateVariables.put("status", event.status().current().state());
-    templateVariables.put("eventDate", event.status().current().timestamp());
-    templateVariables.put("formRef", event.formRef());
-
-    String traineeTisId = event.traineeTisId();
+    String traineeTisId = event.getTraineeId();
     emailService.sendMessageToExistingUser(traineeTisId, LTFT_UPDATED, templateVersion,
-        templateVariables, null);
+        Map.of("var", event), null);
     log.info("LTFT updated notification sent for trainee {}.", traineeTisId);
   }
 }

--- a/src/main/resources/templates/email/coj-confirmation/v1.0.0.html
+++ b/src/main/resources/templates/email/coj-confirmation/v1.0.0.html
@@ -10,9 +10,9 @@
     <th:block th:fragment="subject">We've received your Conditions of Joining</th:block>
     <h2>Content</h2>
     <th:block th:fragment="content">
-      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
       <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-      <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+      <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
       <p>
         We want to inform you that your local NHS England office has received your signed Conditions of Joining<span
           th:text="${syncedAt} ? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"

--- a/src/main/resources/templates/email/coj-confirmation/v1.1.0.html
+++ b/src/main/resources/templates/email/coj-confirmation/v1.1.0.html
@@ -10,9 +10,9 @@
     <th:block th:fragment="subject">We've received your Conditions of Joining</th:block>
     <h2>Content</h2>
     <th:block th:fragment="content">
-      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
       <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-      <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+      <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
       <p>
         We want to inform you that your local NHS England office has received your signed Conditions of Joining<span
           th:text="${syncedAt} ? | on ${#temporals.format(syncedAt, 'dd MMMM yyyy')}| : _"

--- a/src/main/resources/templates/email/credential-revoked/v1.0.0.html
+++ b/src/main/resources/templates/email/credential-revoked/v1.0.0.html
@@ -10,9 +10,9 @@
     <th:block th:fragment="subject">Your <th:block th:text="${not #strings.isEmpty(credentialType)} ? ${credentialType} : _">DSP</th:block> credential was revoked</th:block>
     <h2>Content</h2>
     <th:block th:fragment="content">
-      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
       <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-      <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+      <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
       <p>
         You previously issued a <span th:text="${not #strings.isEmpty(credentialType)} ? ${credentialType} : _"></span> DSP credential<span
           th:text="${issuedAt}? | on ${#temporals.format(issuedAt, 'dd MMMM yyyy')}| : _"></span>, this credential has been revoked due to a change made by your local NHS England office.

--- a/src/main/resources/templates/email/email-updated-new/v1.0.0.html
+++ b/src/main/resources/templates/email/email-updated-new/v1.0.0.html
@@ -10,9 +10,9 @@
     <th:block th:fragment="subject">TIS Self-Service Email Updated</th:block>
     <h2>Content</h2>
     <th:block th:fragment="content">
-      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
       <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-      <p th:replace="fragments/greeting/v1.0.0 :: p"></p>
+      <p th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></p>
 
       <p>
         Your contact details have been updated by your local NHS England office, as a result

--- a/src/main/resources/templates/email/email-updated-old/v1.0.0.html
+++ b/src/main/resources/templates/email/email-updated-old/v1.0.0.html
@@ -10,9 +10,9 @@
     <th:block th:fragment="subject">TIS Self-Service Email Updated</th:block>
     <h2>Content</h2>
     <th:block th:fragment="content">
-      <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+      <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
       <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-      <p th:replace="fragments/greeting/v1.0.0 :: p"></p>
+      <p th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></p>
 
       <p>
         Your contact details have been updated by your local NHS England office, as a result

--- a/src/main/resources/templates/email/form-updated/v1.0.0.html
+++ b/src/main/resources/templates/email/form-updated/v1.0.0.html
@@ -10,9 +10,9 @@
 <th:block th:fragment="subject">Your FormR has been updated</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-  <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+  <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
 <span th:switch="${lifecycleState}">
 
   <span th:case="'SUBMITTED'" id="SUBMITTED">

--- a/src/main/resources/templates/email/gmc-rejected-lo/v1.0.0.html
+++ b/src/main/resources/templates/email/gmc-rejected-lo/v1.0.0.html
@@ -10,7 +10,7 @@
 <th:block th:fragment="subject">GMC Number update rejected</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p>Dear Local Office,</p>
   <p id="doctorName">Doctor <span th:text="${not #strings.isEmpty(givenName)} ? |${givenName}| : _"></span

--- a/src/main/resources/templates/email/gmc-rejected-trainee/v1.0.0.html
+++ b/src/main/resources/templates/email/gmc-rejected-trainee/v1.0.0.html
@@ -10,9 +10,9 @@
 <th:block th:fragment="subject">GMC Number update rejected</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-  <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+  <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
   <p>GMC number <span th:text="${not #strings.isEmpty(gmcNumber)} ? |${gmcNumber}| : _">(GMC number missing)</span
   ></p>
   <p>Your recent update to GMC details was rejected by TIS, and the GMC number has been reset to that shown above. Please correct your GMC number on TIS Self-Service if it is still incorrect, or liaise with your local office if you have further concerns.</p>

--- a/src/main/resources/templates/email/gmc-updated/v1.0.0.html
+++ b/src/main/resources/templates/email/gmc-updated/v1.0.0.html
@@ -10,7 +10,7 @@
 <th:block th:fragment="subject">A trainee doctor has updated their GMC Number</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p>Dear Local Office,</p>
   <p id="doctorName">Doctor <span th:text="${not #strings.isEmpty(givenName)} ? |${givenName}| : _"></span

--- a/src/main/resources/templates/email/ltft-updated/v1.0.0.html
+++ b/src/main/resources/templates/email/ltft-updated/v1.0.0.html
@@ -15,14 +15,14 @@
   <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
   <p>
     The status of your LTFT application<span
-      th:text="${not #strings.isEmpty(formRef)}? | (ref: ${formRef})| : _"></span> has changed<span
-      th:text="${not #strings.isEmpty(status)}? | to ${status}| : _"></span><span
-      th:text="${eventDate}? | on ${#temporals.format(eventDate, 'dd MMMM yyyy')}| : _"></span>.
+      th:text="${not #strings.isEmpty(var?.formRef)}? | (ref: ${var.formRef})| : _"></span> has changed<span
+      th:text="${not #strings.isEmpty(var?.state)}? | to ${var.state}| : _"></span><span
+      th:text="${var?.timestamp}? | on ${#temporals.format(var.timestamp, 'dd MMMM yyyy')}| : _"></span>.
   </p>
   <p>Kind Regards,</p>
   <p>TIS Self-Service</p>
   <p><strong>Application Reference:</strong> <span
-      th:text="${not #strings.isEmpty(ltftName)}? |${ltftName}| : _">(not set)</span></p>
+      th:text="${not #strings.isEmpty(var?.formName)}? |${var.formName}| : _">(not set)</span></p>
   <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
 </th:block>
 </body>

--- a/src/main/resources/templates/email/ltft-updated/v1.0.0.html
+++ b/src/main/resources/templates/email/ltft-updated/v1.0.0.html
@@ -10,9 +10,9 @@
 <th:block th:fragment="subject">Your LTFT Application Status Update</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-  <p th:replace="~{fragments/greeting/v1.0.0 :: p}"></p>
+  <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
   <p>
     The status of your LTFT application<span
       th:text="${not #strings.isEmpty(formRef)}? | (ref: ${formRef})| : _"></span> has changed<span

--- a/src/main/resources/templates/email/placement-rollout-2024-correction/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-rollout-2024-correction/v1.0.0.html
@@ -9,7 +9,7 @@
 <th:block th:fragment="subject">NHS England - <th:block th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local office'"></th:block> - Notification sent in error</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
   <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span>,</p>

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.0.0.html
@@ -9,7 +9,7 @@
 <th:block th:fragment="subject">NHS England - <th:block th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local office'"></th:block> - Notification of Placement</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
   <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span>,</p>

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.1.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.1.0.html
@@ -9,7 +9,7 @@
 <th:block th:fragment="subject">NHS England - <th:block th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local office'"></th:block> - Notification of Placement</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
   <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span>,</p>

--- a/src/main/resources/templates/email/placement-updated-week-12/v1.2.0.html
+++ b/src/main/resources/templates/email/placement-updated-week-12/v1.2.0.html
@@ -30,7 +30,7 @@
 <th:block th:fragment="subject">NHS England Notification of Placement</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
   <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span>,</p>

--- a/src/main/resources/templates/email/programme-created/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-created/v1.0.0.html
@@ -11,9 +11,9 @@
   > - Onboarding to your Training Programme</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-  <div th:replace="fragments/greeting/v1.0.0 :: body"></div>
+  <div th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></div>
   <p>Congratulations on your appointment to the <span
       th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : 'programme'"></span> Programme in <span
       th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local office'"></span

--- a/src/main/resources/templates/email/programme-created/v1.1.0.html
+++ b/src/main/resources/templates/email/programme-created/v1.1.0.html
@@ -11,9 +11,9 @@
 > - Onboarding to your Training Programme</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-  <div th:replace="fragments/greeting/v1.0.0 :: body"></div>
+  <div th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></div>
   <p>Congratulations on your appointment to the <span
     th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : 'programme'"></span> Programme in <span
     th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local office'"></span

--- a/src/main/resources/templates/email/programme-created/v1.2.0.html
+++ b/src/main/resources/templates/email/programme-created/v1.2.0.html
@@ -11,9 +11,9 @@
 > - Onboarding to your Training Programme</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
-  <div th:replace="fragments/greeting/v1.0.0 :: body"></div>
+  <div th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></div>
   <p>Congratulations on your appointment to the <span
       th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : 'programme'"></span> Programme in <span
       th:text="${not #strings.isEmpty(localOfficeName)} ? ${localOfficeName} : 'your local office'"></span

--- a/src/main/resources/templates/email/programme-day-one/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-day-one/v1.0.0.html
@@ -11,7 +11,7 @@
   > - Onboarding to your Training Programme</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
   <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span

--- a/src/main/resources/templates/email/programme-day-one/v1.1.0.html
+++ b/src/main/resources/templates/email/programme-day-one/v1.1.0.html
@@ -11,7 +11,7 @@
 > - Onboarding to your Training Programme</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/retry/v1.0.0 :: body"></div>
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
   <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
   <p th:if="${#strings.isEmpty(givenName) AND #strings.isEmpty(familyName)}">Dear Doctor,</p>
   <p th:if="${not (#strings.isEmpty(givenName) OR #strings.isEmpty(familyName))}">Dear <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span

--- a/src/main/resources/templates/email/programme-updated-week-0/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-updated-week-0/v1.0.0.html
@@ -9,7 +9,7 @@
 <th:block th:fragment="subject">Programme checklist: programme has started</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/greeting/v1.0.0 :: body"></div>
+  <div th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></div>
   <p>
     We welcome you as you start <b><span
     th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : 'your programme'"></span></b

--- a/src/main/resources/templates/email/programme-updated-week-1/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-updated-week-1/v1.0.0.html
@@ -9,7 +9,7 @@
 <th:block th:fragment="subject">Programme checklist: 1 week to go</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/greeting/v1.0.0 :: body"></div>
+  <div th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></div>
   <p>
     We look forward to welcoming you as you start <b><span
     th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : 'your programme'"></span></b> in <b

--- a/src/main/resources/templates/email/programme-updated-week-4/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-updated-week-4/v1.0.0.html
@@ -9,7 +9,7 @@
 <th:block th:fragment="subject">Programme checklist: 4 weeks to go</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/greeting/v1.0.0 :: body"></div>
+  <div th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></div>
   <p>
     We look forward to welcoming you as you start <b><span
     th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : 'your programme'"></span></b> in <b

--- a/src/main/resources/templates/email/programme-updated-week-8/v1.0.0.html
+++ b/src/main/resources/templates/email/programme-updated-week-8/v1.0.0.html
@@ -9,7 +9,7 @@
 <th:block th:fragment="subject">Programme checklist: 8 weeks to go</th:block>
 <h2>Content</h2>
 <th:block th:fragment="content">
-  <div th:replace="fragments/greeting/v1.0.0 :: body"></div>
+  <div th:replace="fragments/greeting/v1.0.0 :: greeting(${familyName})"></div>
   <p>
     We look forward to welcoming you as you start <b><span
     th:text="${not #strings.isEmpty(programmeName)} ? ${programmeName} : 'your programme'"></span></b> in <b

--- a/src/main/resources/templates/fragments/greeting/v1.0.0.html
+++ b/src/main/resources/templates/fragments/greeting/v1.0.0.html
@@ -5,6 +5,6 @@
     <title>Greeting</title>
   </head>
   <body>
-    <p>Dear <span th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</span>,</p>
+    <p th:fragment="greeting(familyName)">Dear <span th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</span>,</p>
   </body>
 </html>

--- a/src/main/resources/templates/fragments/retry/v1.0.0.html
+++ b/src/main/resources/templates/fragments/retry/v1.0.0.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>Retry</title>
 </head>
-<body>
+<body th:fragment="retry(originallySentOn)">
 <span th:if="${!#strings.isEmpty(originallySentOn)}"><hr
 ><i>This is a copy of an email sent<span
     th:text="${originallySentOn} ? | on ${#temporals.format(originallySentOn, 'dd MMMM yyyy')}| : _"

--- a/src/test/java/uk/nhs/tis/trainee/notifications/DockerImageNames.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/DockerImageNames.java
@@ -19,40 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.notifications.dto;
+package uk.nhs.tis.trainee.notifications;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import java.util.Map;
-import lombok.Builder;
-import lombok.Data;
+import org.testcontainers.utility.DockerImageName;
 
 /**
- * A LTFT update event.
+ * Constants for {@link DockerImageName} values used in tests to ensure consistency.
  */
-@Data
-@Builder
-public class LtftUpdateEvent {
+public class DockerImageNames {
 
-  @JsonAlias("traineeTisId")
-  private String traineeId;
-  private String formRef;
-  private String formName;
-  private String state;
-  private Instant timestamp;
-
-  /**
-   * Unpack the current status to set the state and timestamp.
-   *
-   * @param status The value of the status property.
-   */
-  @JsonProperty("status")
-  private void unpackCurrentStatus(Map<String, Object> status) {
-    Map<String, String> current = (Map<String, String>) status.get("current");
-    state = current.get("state");
-    String timestampString = current.get("timestamp");
-    timestamp = timestampString == null || timestampString.isBlank() ? null
-        : Instant.parse(timestampString);
-  }
+  public static final DockerImageName LOCALSTACK = DockerImageName.parse("localstack/localstack:3");
+  public static final DockerImageName MONGO = DockerImageName.parse("mongo:5");
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/ProgrammeMembershipListenerTest.java
@@ -90,13 +90,14 @@ class ProgrammeMembershipListenerTest {
     dataMap.put("personId", PERSON_ID);
     RecordDto data = new RecordDto();
     data.setData(dataMap);
-    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, data);
 
     ProgrammeMembership expectedProgrammeMembership = new ProgrammeMembership();
     expectedProgrammeMembership.setTisId(TIS_ID);
     expectedProgrammeMembership.setPersonId(PERSON_ID);
 
     when(mapper.toEntity(dataMap)).thenReturn(expectedProgrammeMembership);
+
+    ProgrammeMembershipEvent event = new ProgrammeMembershipEvent(TIS_ID, data);
 
     listener.handleProgrammeMembershipDelete(event);
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -451,9 +451,9 @@ class EmailServiceIntegrationTest {
     Element body = content.body();
 
     String bodyText = body.wholeText();
-    assertThat("Unexpected Horus text.",
-        bodyText.contains("If you are a Foundation doctor, please continue using Horus as previously instructed."),
-        is(true));
+    assertThat("Unexpected Horus text.", bodyText.contains(
+        "If you are a Foundation doctor, please continue using Horus as previously instructed."
+    ), is(true));
   }
 
   @Test
@@ -683,8 +683,8 @@ class EmailServiceIntegrationTest {
   int getGreetingElementIndex(NotificationType notificationType) {
     return switch (notificationType) {
       case PLACEMENT_UPDATED_WEEK_12, PLACEMENT_ROLLOUT_2024_CORRECTION, PROGRAMME_CREATED,
-           PROGRAMME_DAY_ONE, EMAIL_UPDATED_NEW, EMAIL_UPDATED_OLD, COJ_CONFIRMATION,
-           CREDENTIAL_REVOKED, FORM_UPDATED, GMC_UPDATED, GMC_REJECTED_LO,
+          PROGRAMME_DAY_ONE, EMAIL_UPDATED_NEW, EMAIL_UPDATED_OLD, COJ_CONFIRMATION,
+          CREDENTIAL_REVOKED, FORM_UPDATED, GMC_UPDATED, GMC_REJECTED_LO,
           GMC_REJECTED_TRAINEE, LTFT_UPDATED -> 1;
       default -> 0;
     };

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,7 +5,19 @@ application:
   email:
     sender: dummy-value
   queues:
+    account-confirmed: dummy-value
+    account-updated: dummy-value
     coj-published: dummy-value
+    contact-details-updated: dummy-value
+    email-event: dummy-value
+    form-updated: dummy-value
+    gmc-rejected: dummy-value
+    gmc-updated: dummy-value
+    ltft-updated: dummy-value
+    placement-updated: dummy-value
+    placement-deleted: dummy-value
+    programme-membership-updated: dummy-value
+    programme-membership-deleted: dummy-value
 
 mongock:
   enabled: false


### PR DESCRIPTION
# refactor(ltft): LTFT update event DTO

Refactor the update event DTO to flatten the properties to a simpler
structure.
The whole event DTO should be passed in the template variables and the
template updated to pull from the event DTO, rather than manually set
fields with inconsistent naming.

Rewrite LtftListenerIntegrationTest to be trigger by SQS publishing
instead of calling the listener method directly.
This allows proper verification of the incoming event structure and the
conversion to the newly simplified flatter event structure.
This change also accounts for the structural changes to the published
event, which removed the `content` wrapper around several properties.

TIS21-7178
TIS21-7183

---

# refactor: parameterize fragments

Refactor the retry and greeting template fragments to parameterise the
variables.
This allows more flexibility in each template rather than enforcing a
strict variable naming based on the used fragments.

TIS21-6596
TIS21-6594