### PR TITLE
fix: standardise LTFT summary in email templates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.6.0"
+version = "2.6.1"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,15 +60,15 @@ application:
     gmc-updated:
       email: v1.0.0
     ltft-approved:
-      email: v1.0.0
+      email: v1.0.1
     ltft-approved-tpd:
-      email: v1.0.0
+      email: v1.0.1
     ltft-updated:
       email: v1.0.0
     ltft-submitted:
       email: v1.0.0
     ltft-submitted-tpd:
-      email: v1.0.0
+      email: v1.0.1
     indemnity-insurance:
       in-app: v1.0.0
     less-than-full-time:

--- a/src/main/resources/templates/email/ltft-approved-tpd/v1.0.1.html
+++ b/src/main/resources/templates/email/ltft-approved-tpd/v1.0.1.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>LTFT Approved</title>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">Notification for Changing hours (LTFT) Application Approval for <th:block th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</th:block> (<th:block th:text="${not #strings.isEmpty(var?.formRef)} ? ${var.formRef} : 'unknown form reference'"></th:block>)
+</th:block><h2>Content</h2>
+<th:block th:fragment="content" th:with="subjectRefs = |GMC: ${not #strings.isEmpty(var?.personalDetails?.gmcNumber) ? var.personalDetails.gmcNumber : 'unknown'}, LTFT Ref No: ${not #strings.isEmpty(var?.formRef) ? var.formRef : 'unknown'}|">
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
+  <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+  <p>Dear <span th:text="${not #strings.isEmpty(var?.discussions?.tpdName)} ? |${var.discussions.tpdName}| : _">Training Programme Director</span>,</p>
+  <p>We would like to inform you that we have approved Changing hours (LTFT) application for <th:block th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</th:block>, <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block> on <th:block th:text="${not #strings.isEmpty(var?.timestamp)} ? ${#temporals.format(var.timestamp, 'dd MMMM yyyy')}   : 'unknown'"
+  ></th:block>. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the approved application:</p>
+  <table th:replace="~{fragments/ltft-summary/v1.0.0 :: ltftSummary(${var?.programmeMembership?.name}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.programmeMembership?.wte}, ${var?.change?.wte})}"></table>
+  <p>If you have any queries regarding this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
+    <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Approved - Enquiries - ${subjectRefs}|)}"></th:block>
+  </th:block>
+  </p>
+  <p>
+    Kind Regards,
+  </p>
+  <p>
+    <th:block th:text="${not #strings.isEmpty(var?.programmeMembership?.managingDeanery)} ? |NHS England - ${var.programmeMembership.managingDeanery}| : 'Your Local Office'"></th:block>
+  </p>
+  <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/email/ltft-approved/v1.0.1.html
+++ b/src/main/resources/templates/email/ltft-approved/v1.0.1.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>LTFT Approved</title>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">Notification of Your Less Than Full Time (LTFT) Application Status (<th:block th:text="${not #strings.isEmpty(var?.formRef)} ? ${var.formRef} : 'unknown'"></th:block>)</th:block>
+<h2>Content</h2>
+<th:block th:fragment="content" th:with="subjectRefs = |GMC: ${not #strings.isEmpty(var?.personalDetails?.gmcNumber) ? var.personalDetails.gmcNumber : 'unknown'}, LTFT Ref No: ${not #strings.isEmpty(var?.formRef) ? var.formRef : 'unknown'}|">
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
+  <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+  <p th:replace="~{fragments/greeting/v1.0.0 :: greeting(${familyName})}"></p>
+  <p>We are pleased to inform you that your application for Less Than Full Time (LTFT) training has been approved. Below are the details of your updated working arrangements:</p>
+  <table th:replace="~{fragments/ltft-summary/v1.0.0 :: ltftSummary(${var?.programmeMembership?.name}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.programmeMembership?.wte}, ${var?.change?.wte})}"></table>
+  <p>Your estimated completion date will be extended as a result of your change in working hours and will be confirmed at your next Annual Review of Competence Progression (ARCP).</p>
+  <p><strong>Important Information for Skilled Worker (Tier 2) Visa Holders</strong></p>
+  <p>If you are an NHSE-sponsored Skilled Worker (Tier 2) visa holder, you are required to complete the reporting form within 5 working days to notify the <strong>National Overseas Sponsorship team</strong> of any change in your working hours.</p>
+  <p>For more details, please refer to the <a href="https://medical.hee.nhs.uk/medical-training-recruitment/medical-specialty-training/overseas-applicants">Overseas Sponsorship FAQ</a>.</p>
+  <p><strong>Additional Support & Resources</strong></p>
+  <ul>
+    <li><strong>Frequently Asked Questions: <a href="https://tis-support.hee.nhs.uk/trainees/">TSS Support FAQs</a></strong></li>
+    <li><strong>Supported Return to Training (SuppoRTT):</strong> If you are returning after a period of absence, resources are available through your local SuppoRTT team. Find more details
+      <th:block th:with="contact = ${contacts?.get('SUPPORTED_RETURN_TO_TRAINING')}">
+        <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'by clicking on the following link for Supported Return to Training. ', ${contact?.contact}, '', 'from your <strong>Local Office Support team.</strong>', |Ltft Approved - Supported Return to Training - ${subjectRefs}|)}"></th:block>
+      </th:block>
+    </li>
+    <li><strong>LTFT Working Policy:</strong>
+      <th:block th:with="contact = ${contacts?.get('LTFT')}">
+        <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'Please click on the following link for LTFT Working Policy. ', ${contact?.contact}, '', 'Please contact your <strong>Local Office Support team.</strong>', |Ltft Approved - Working Policy - ${subjectRefs}|)}"></th:block>
+      </th:block>
+    </li>
+  </ul>
+  <p><strong>Future Changes to Your Working Hours</strong></p>
+  <p>Any future changes to your working arrangements, including an increase or further decrease in hours, must be prospectively approved via the submission of a new application form.</p>
+  <p><strong>Your Employer and Pay</strong></p>
+  <p>Please note that NHSE is not an employer. Any issues you have with how your pay is calculated as a LTFT Resident Doctor should be submitted to the medical staffing department of your Employing Trust.</p>
+  <p>For any queries,
+    <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
+      <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Approved - Enquiries - ${subjectRefs}|)}"></th:block>
+    </th:block>
+  </p>
+  <p>
+    Kind Regards,
+  </p>
+  <p>
+    <th:block th:text="${not #strings.isEmpty(var?.programmeMembership?.managingDeanery)} ? |NHS England - ${var.programmeMembership.managingDeanery}| : 'Your Local Office'"></th:block>
+  </p>
+  <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.1.html
+++ b/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.1.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>LTFT Submitted</title>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">
+  Notification for Changing hours (LTFT) Application Submission received from <th:block th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</th:block> (<th:block th:text="${not #strings.isEmpty(var?.formRef)} ? ${var.formRef} : 'unknown form reference'"></th:block>)
+</th:block><h2>Content</h2>
+<th:block th:fragment="content" th:with="subjectRefs = |GMC: ${not #strings.isEmpty(var?.personalDetails?.gmcNumber) ? var.personalDetails.gmcNumber : 'unknown'}, LTFT Ref No: ${not #strings.isEmpty(var?.formRef) ? var.formRef : 'unknown'}|">
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
+  <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+  <p>Dear <span th:text="${not #strings.isEmpty(var?.discussions?.tpdName)} ? |${var.discussions.tpdName}| : _">Training Programme Director</span>,</p>
+  <p>
+    We would like to inform you that we have received Changing hours (LTFT) application for <th:block th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</th:block>, <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block> on
+    <th:block th:text="${not #strings.isEmpty(var?.timestamp)} ? ${#temporals.format(var.timestamp, 'dd MMMM yyyy')}   : 'unknown'"
+    ></th:block>. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
+  <table th:replace="~{fragments/ltft-summary/v1.0.0 :: ltftSummary(${var?.programmeMembership?.name}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.programmeMembership?.wte}, ${var?.change?.wte})}"></table>
+  <p>If you have any queries regarding this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
+    <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Submitted - Enquiries - ${subjectRefs}|)}"></th:block>
+  </th:block>
+  </p>
+  <p>
+    Kind Regards,
+  </p>
+  <p>
+    <th:block th:text="${not #strings.isEmpty(var?.programmeMembership?.managingDeanery)} ? |NHS England - ${var.programmeMembership.managingDeanery}| : 'Your Local Office'"></th:block>
+  </p>
+  <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/ltft-summary/v1.0.0.html
+++ b/src/main/resources/templates/fragments/ltft-summary/v1.0.0.html
@@ -7,23 +7,23 @@
 <body>
 <table style="width:100%" border="1" th:fragment="ltftSummary(programme, startDate, cctDate, currentWte, newWte)">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td><th:block th:text="${not #strings.isEmpty(programme)} ? ${programme} : 'unknown'"></th:block></td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td><th:block th:text="${not #strings.isEmpty(startDate)} ? ${startDate} : 'unknown'"></th:block></td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td><th:block th:text="${not #strings.isEmpty(cctDate)} ? ${cctDate} : 'unknown'"></th:block></td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td><th:block th:text="${not #strings.isEmpty(currentWte)} ? ${currentWte} : 'unknown'"></th:block></td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td><th:block th:text="${not #strings.isEmpty(newWte)} ? ${newWte} : 'unknown'"></th:block></td>
   </tr>
 </table>

--- a/src/main/resources/templates/fragments/ltft-summary/v1.0.0.html
+++ b/src/main/resources/templates/fragments/ltft-summary/v1.0.0.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>LTFT summary</title>
+</head>
+<body>
+<table style="width:100%" border="1" th:fragment="ltftSummary(programme, startDate, cctDate, currentWte, newWte)">
+  <tr>
+    <th>Programme</th>
+    <th>Start Date</th>
+    <th>Anticipated End Date</th>
+    <th>Current WTE %</th>
+    <th>New WTE %</th>
+  </tr>
+  <tr>
+    <td><th:block th:text="${not #strings.isEmpty(programme)} ? ${programme} : 'unknown'"></th:block></td>
+    <td><th:block th:text="${not #strings.isEmpty(startDate)} ? ${startDate} : 'unknown'"></th:block></td>
+    <td><th:block th:text="${not #strings.isEmpty(cctDate)} ? ${cctDate} : 'unknown'"></th:block></td>
+    <td><th:block th:text="${not #strings.isEmpty(currentWte)} ? ${currentWte} : 'unknown'"></th:block></td>
+    <td><th:block th:text="${not #strings.isEmpty(newWte)} ? ${newWte} : 'unknown'"></th:block></td>
+  </tr>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/ltft-summary/v1.0.0.html
+++ b/src/main/resources/templates/fragments/ltft-summary/v1.0.0.html
@@ -7,17 +7,23 @@
 <body>
 <table style="width:100%" border="1" th:fragment="ltftSummary(programme, startDate, cctDate, currentWte, newWte)">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td><th:block th:text="${not #strings.isEmpty(programme)} ? ${programme} : 'unknown'"></th:block></td>
   </tr>
   <tr>
-    <td><th:block th:text="${not #strings.isEmpty(programme)} ? ${programme} : 'unknown'"></th:block></td>
+    <td>Start Date</td>
     <td><th:block th:text="${not #strings.isEmpty(startDate)} ? ${startDate} : 'unknown'"></th:block></td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td><th:block th:text="${not #strings.isEmpty(cctDate)} ? ${cctDate} : 'unknown'"></th:block></td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td><th:block th:text="${not #strings.isEmpty(currentWte)} ? ${currentWte} : 'unknown'"></th:block></td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td><th:block th:text="${not #strings.isEmpty(newWte)} ? ${newWte} : 'unknown'"></th:block></td>
   </tr>
 </table>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerIntegrationTest.java
@@ -63,7 +63,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
@@ -170,9 +169,6 @@ class LtftListenerIntegrationTest {
 
   @Autowired
   private MongoTemplate mongoTemplate;
-
-  @Value("${application.template-versions.ltft-updated.email}")
-  private String templateVersion;
 
   private String traineeId;
 
@@ -499,11 +495,12 @@ class LtftListenerIntegrationTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
-      APPROVED     | LTFT_APPROVED
-      SUBMITTED    | LTFT_SUBMITTED
-      Other-Status | LTFT_UPDATED
+      APPROVED     | LTFT_APPROVED  | v1.0.1
+      SUBMITTED    | LTFT_SUBMITTED | v1.0.0
+      Other-Status | LTFT_UPDATED   | v1.0.0
       """)
-  void shouldStoreNotificationHistoryWhenMessageSent(String state, NotificationType type)
+  void shouldStoreNotificationHistoryWhenMessageSent(String state, NotificationType type,
+      String expectedVersion)
       throws JsonProcessingException {
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
@@ -568,7 +565,7 @@ class LtftListenerIntegrationTest {
 
     TemplateInfo templateInfo = history.template();
     assertThat("Unexpected template name.", templateInfo.name(), is(type.getTemplateName()));
-    assertThat("Unexpected template version.", templateInfo.version(), is(templateVersion));
+    assertThat("Unexpected template version.", templateInfo.version(), is(expectedVersion));
 
     Map<String, Object> storedVariables = templateInfo.variables();
     assertThat("Unexpected template variable count.", storedVariables.size(), is(6));
@@ -747,10 +744,11 @@ class LtftListenerIntegrationTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
-      APPROVED  | LTFT_APPROVED_TPD
-      SUBMITTED | LTFT_SUBMITTED_TPD
+      APPROVED  | LTFT_APPROVED_TPD  | v1.0.1
+      SUBMITTED | LTFT_SUBMITTED_TPD | v1.0.1
       """)
-  void shouldStoreTpdNotificationHistoryWhenMessageSent(String state, NotificationType type)
+  void shouldStoreTpdNotificationHistoryWhenMessageSent(String state, NotificationType type,
+      String expectedVersion)
       throws JsonProcessingException {
     when(userAccountService.getUserDetailsById(USER_ID)).thenReturn(
         new UserDetails(true, EMAIL, TITLE, FAMILY_NAME, GIVEN_NAME, GMC));
@@ -819,7 +817,7 @@ class LtftListenerIntegrationTest {
 
     TemplateInfo templateInfo = history.template();
     assertThat("Unexpected template name.", templateInfo.name(), is(type.getTemplateName()));
-    assertThat("Unexpected template version.", templateInfo.version(), is(templateVersion));
+    assertThat("Unexpected template version.", templateInfo.version(), is(expectedVersion));
 
     Map<String, Object> storedVariables = templateInfo.variables();
     assertThat("Unexpected template variable count.", storedVariables.size(), is(6));

--- a/src/test/resources/email/ltft-approved-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-full-email-contacts.html
@@ -8,17 +8,23 @@
 <p>We are pleased to inform you that your application for Less Than Full Time (LTFT) training has been approved. Below are the details of your updated working arrangements:</p>
 <table style="width:100%" border="1">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td>General Practice</td>
   </tr>
   <tr>
-    <td>General Practice</td>
+    <td>Start Date</td>
     <td>2025-04-03</td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td>2027-06-05</td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td>1.0</td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-approved-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-full-email-contacts.html
@@ -12,7 +12,7 @@
     <th>Start Date</th>
     <th>Anticipated End Date</th>
     <th>Current WTE %</th>
-    <th>Agreed New WTE %</th>
+    <th>New WTE %</th>
   </tr>
   <tr>
     <td>General Practice</td>

--- a/src/test/resources/email/ltft-approved-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-full-email-contacts.html
@@ -8,23 +8,23 @@
 <p>We are pleased to inform you that your application for Less Than Full Time (LTFT) training has been approved. Below are the details of your updated working arrangements:</p>
 <table style="width:100%" border="1">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td>General Practice</td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td>2025-04-03</td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td>2027-06-05</td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td>1.0</td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-approved-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-full-url-contacts.html
@@ -8,17 +8,23 @@
 <p>We are pleased to inform you that your application for Less Than Full Time (LTFT) training has been approved. Below are the details of your updated working arrangements:</p>
 <table style="width:100%" border="1">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td>General Practice</td>
   </tr>
   <tr>
-    <td>General Practice</td>
+    <td>Start Date</td>
     <td>2025-04-03</td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td>2027-06-05</td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td>1.0</td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-approved-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-full-url-contacts.html
@@ -12,7 +12,7 @@
     <th>Start Date</th>
     <th>Anticipated End Date</th>
     <th>Current WTE %</th>
-    <th>Agreed New WTE %</th>
+    <th>New WTE %</th>
   </tr>
   <tr>
     <td>General Practice</td>

--- a/src/test/resources/email/ltft-approved-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-full-url-contacts.html
@@ -8,23 +8,23 @@
 <p>We are pleased to inform you that your application for Less Than Full Time (LTFT) training has been approved. Below are the details of your updated working arrangements:</p>
 <table style="width:100%" border="1">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td>General Practice</td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td>2025-04-03</td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td>2027-06-05</td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td>1.0</td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-approved-minimal.html
+++ b/src/test/resources/email/ltft-approved-minimal.html
@@ -12,7 +12,7 @@
       <th>Start Date</th>
       <th>Anticipated End Date</th>
       <th>Current WTE %</th>
-      <th>Agreed New WTE %</th>
+      <th>New WTE %</th>
     </tr>
     <tr>
       <td>unknown</td>

--- a/src/test/resources/email/ltft-approved-minimal.html
+++ b/src/test/resources/email/ltft-approved-minimal.html
@@ -8,23 +8,23 @@
   <p>We are pleased to inform you that your application for Less Than Full Time (LTFT) training has been approved. Below are the details of your updated working arrangements:</p>
   <table style="width:100%" border="1">
     <tr>
-      <td>Programme</td>
+      <th>Programme</th>
       <td>unknown</td>
     </tr>
     <tr>
-      <td>Start Date</td>
+      <th>Start Date</th>
       <td>unknown</td>
     </tr>
     <tr>
-      <td>Anticipated End Date</td>
+      <th>Anticipated End Date</th>
       <td>unknown</td>
     </tr>
     <tr>
-      <td>Current WTE %</td>
+      <th>Current WTE %</th>
       <td>unknown</td>
     </tr>
     <tr>
-      <td>New WTE %</td>
+      <th>New WTE %</th>
       <td>unknown</td>
     </tr>
   </table>

--- a/src/test/resources/email/ltft-approved-minimal.html
+++ b/src/test/resources/email/ltft-approved-minimal.html
@@ -8,17 +8,23 @@
   <p>We are pleased to inform you that your application for Less Than Full Time (LTFT) training has been approved. Below are the details of your updated working arrangements:</p>
   <table style="width:100%" border="1">
     <tr>
-      <th>Programme</th>
-      <th>Start Date</th>
-      <th>Anticipated End Date</th>
-      <th>Current WTE %</th>
-      <th>New WTE %</th>
+      <td>Programme</td>
+      <td>unknown</td>
     </tr>
     <tr>
+      <td>Start Date</td>
       <td>unknown</td>
+    </tr>
+    <tr>
+      <td>Anticipated End Date</td>
       <td>unknown</td>
+    </tr>
+    <tr>
+      <td>Current WTE %</td>
       <td>unknown</td>
-      <td>unknown</td>
+    </tr>
+    <tr>
+      <td>New WTE %</td>
       <td>unknown</td>
     </tr>
   </table>

--- a/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
@@ -8,23 +8,23 @@
 <p>We would like to inform you that we have approved Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the approved application:
 <table style="width:100%" border="1">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td>General Practice</td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td>2025-04-03</td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td>2027-06-05</td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td>1.0</td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
@@ -10,12 +10,14 @@
   <tr>
     <th>Programme</th>
     <th>Start Date</th>
+    <th>Anticipated End Date</th>
     <th>Current WTE %</th>
-    <th>Agreed New WTE %</th>
+    <th>New WTE %</th>
   </tr>
   <tr>
-    <td>General Practice</th:block></td>
+    <td>General Practice</td>
     <td>2025-04-03</td>
+    <td>2027-06-05</td>
     <td>1.0</td>
     <td>0.5</td>
   </tr>

--- a/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
@@ -8,17 +8,23 @@
 <p>We would like to inform you that we have approved Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the approved application:
 <table style="width:100%" border="1">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td>General Practice</td>
   </tr>
   <tr>
-    <td>General Practice</td>
+    <td>Start Date</td>
     <td>2025-04-03</td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td>2027-06-05</td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td>1.0</td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
@@ -8,23 +8,23 @@
 <p>We would like to inform you that we have approved Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the approved application:
 <table style="width:100%" border="1">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td>General Practice</td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td>2025-04-03</td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td>2027-06-05</td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td>1.0</td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
@@ -10,12 +10,14 @@
   <tr>
     <th>Programme</th>
     <th>Start Date</th>
+    <th>Anticipated End Date</th>
     <th>Current WTE %</th>
-    <th>Agreed New WTE %</th>
+    <th>New WTE %</th>
   </tr>
   <tr>
-    <td>General Practice</th:block></td>
+    <td>General Practice</td>
     <td>2025-04-03</td>
+    <td>2027-06-05</td>
     <td>1.0</td>
     <td>0.5</td>
   </tr>

--- a/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
@@ -8,17 +8,23 @@
 <p>We would like to inform you that we have approved Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the approved application:
 <table style="width:100%" border="1">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td>General Practice</td>
   </tr>
   <tr>
-    <td>General Practice</td>
+    <td>Start Date</td>
     <td>2025-04-03</td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td>2027-06-05</td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td>1.0</td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
@@ -8,17 +8,23 @@
 <p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
 <table style="width:100%" border="1">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td>General Practice</td>
   </tr>
   <tr>
-    <td>General Practice</td>
+    <td>Start Date</td>
     <td>2025-04-03</td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td>2027-06-05</td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td>1.0</td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
@@ -5,18 +5,23 @@
   <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Mr TPD</span>,</p>
-<p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p><strong>Linked programme</strong>
-<ul>
-  <li>Name General Practice</li>
-  <li>Start date 2025-01-03</li>
-  <li>Current WTE 1.0</li>
-</ul>
-<br><strong>Proposed changes</strong>
-<ul>
-  <li>Change type Changing hours LTFT</li>
-  <li>From 2025-04-03</li>
-  <li>WTE change 0.5</li>
-</ul>
+<p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
+<table style="width:100%" border="1">
+  <tr>
+    <th>Programme</th>
+    <th>Start Date</th>
+    <th>Anticipated End Date</th>
+    <th>Current WTE %</th>
+    <th>New WTE %</th>
+  </tr>
+  <tr>
+    <td>General Practice</td>
+    <td>2025-04-03</td>
+    <td>2027-06-05</td>
+    <td>1.0</td>
+    <td>0.5</td>
+  </tr>
+</table>
 <p>If you have any queries regarding this application, please click on the following link for Local Office Support. <a href="mailto:LTFT_SUPPORT@example.com?subject=Ltft Submitted - Enquiries - GMC: 1234567, LTFT Ref No: ltft_47165_001" target="_blank">LTFT_SUPPORT@example.com</a></p>
 <p>Kind Regards,</p>
 <p>NHS England - North West</p>

--- a/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
@@ -8,23 +8,23 @@
 <p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
 <table style="width:100%" border="1">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td>General Practice</td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td>2025-04-03</td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td>2027-06-05</td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td>1.0</td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
@@ -8,17 +8,23 @@
 <p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
 <table style="width:100%" border="1">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td>General Practice</td>
   </tr>
   <tr>
-    <td>General Practice</td>
+    <td>Start Date</td>
     <td>2025-04-03</td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td>2027-06-05</td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td>1.0</td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
@@ -5,18 +5,23 @@
   <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Mr TPD</span>,</p>
-<p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p><strong>Linked programme</strong>
-<ul>
-  <li>Name General Practice</li>
-  <li>Start date 2025-01-03</li>
-  <li>Current WTE 1.0</li>
-</ul>
-<br><strong>Proposed changes</strong>
-<ul>
-  <li>Change type Changing hours LTFT</li>
-  <li>From 2025-04-03</li>
-  <li>WTE change 0.5</li>
-</ul>
+<p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
+<table style="width:100%" border="1">
+  <tr>
+    <th>Programme</th>
+    <th>Start Date</th>
+    <th>Anticipated End Date</th>
+    <th>Current WTE %</th>
+    <th>New WTE %</th>
+  </tr>
+  <tr>
+    <td>General Practice</td>
+    <td>2025-04-03</td>
+    <td>2027-06-05</td>
+    <td>1.0</td>
+    <td>0.5</td>
+  </tr>
+</table>
 <p>If you have any queries regarding this application, please click on the following link for Local Office Support. <a href="https://test/LTFT_SUPPORT" target="_blank">https://test/LTFT_SUPPORT</a></p>
 <p>Kind Regards,</p>
 <p>NHS England - North West</p>

--- a/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
@@ -8,23 +8,23 @@
 <p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 04 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
 <table style="width:100%" border="1">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td>General Practice</td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td>2025-04-03</td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td>2027-06-05</td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td>1.0</td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td>0.5</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-submitted-tpd-minimal.html
+++ b/src/test/resources/email/ltft-submitted-tpd-minimal.html
@@ -8,17 +8,23 @@
 <p>We would like to inform you that we have received Changing hours (LTFT) application for Doctor, unknown on unknown. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
 <table style="width:100%" border="1">
   <tr>
-    <th>Programme</th>
-    <th>Start Date</th>
-    <th>Anticipated End Date</th>
-    <th>Current WTE %</th>
-    <th>New WTE %</th>
+    <td>Programme</td>
+    <td>unknown</td>
   </tr>
   <tr>
+    <td>Start Date</td>
     <td>unknown</td>
+  </tr>
+  <tr>
+    <td>Anticipated End Date</td>
     <td>unknown</td>
+  </tr>
+  <tr>
+    <td>Current WTE %</td>
     <td>unknown</td>
-    <td>unknown</td>
+  </tr>
+  <tr>
+    <td>New WTE %</td>
     <td>unknown</td>
   </tr>
 </table>

--- a/src/test/resources/email/ltft-submitted-tpd-minimal.html
+++ b/src/test/resources/email/ltft-submitted-tpd-minimal.html
@@ -5,18 +5,23 @@
   <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Training Programme Director</span>,</p>
-<p>We would like to inform you that we have received Changing hours (LTFT) application for Doctor, unknown on unknown. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p><strong>Linked programme</strong>
-<ul>
-  <li>Name unknown</li>
-  <li>Start date unknown</li>
-  <li>Current WTE unknown</li>
-</ul>
-<br><strong>Proposed changes</strong>
-<ul>
-  <li>Change type Changing hours LTFT</li>
-  <li>From unknown</li>
-  <li>WTE change unknown</li>
-</ul>
+<p>We would like to inform you that we have received Changing hours (LTFT) application for Doctor, unknown on unknown. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
+<table style="width:100%" border="1">
+  <tr>
+    <th>Programme</th>
+    <th>Start Date</th>
+    <th>Anticipated End Date</th>
+    <th>Current WTE %</th>
+    <th>New WTE %</th>
+  </tr>
+  <tr>
+    <td>unknown</td>
+    <td>unknown</td>
+    <td>unknown</td>
+    <td>unknown</td>
+    <td>unknown</td>
+  </tr>
+</table>
 <p>If you have any queries regarding this application, please contact your <strong>Local Office Support team.</strong></p>
 <p>Kind Regards,</p>
 <p>Your Local Office</p>

--- a/src/test/resources/email/ltft-submitted-tpd-minimal.html
+++ b/src/test/resources/email/ltft-submitted-tpd-minimal.html
@@ -8,23 +8,23 @@
 <p>We would like to inform you that we have received Changing hours (LTFT) application for Doctor, unknown on unknown. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
 <table style="width:100%" border="1">
   <tr>
-    <td>Programme</td>
+    <th>Programme</th>
     <td>unknown</td>
   </tr>
   <tr>
-    <td>Start Date</td>
+    <th>Start Date</th>
     <td>unknown</td>
   </tr>
   <tr>
-    <td>Anticipated End Date</td>
+    <th>Anticipated End Date</th>
     <td>unknown</td>
   </tr>
   <tr>
-    <td>Current WTE %</td>
+    <th>Current WTE %</th>
     <td>unknown</td>
   </tr>
   <tr>
-    <td>New WTE %</td>
+    <th>New WTE %</th>
     <td>unknown</td>
   </tr>
 </table>


### PR DESCRIPTION
the 
1. LTFT approved, 
2. LTFT approved TPD and 
3. LTFT submitted TPD 

emails all include a summary of the LTFT application. These are in tabular form, except for (3).

Fields included:
Programme name, CCT start date, anticipated end date (CCT date), current WTE, new WTE

(2) omits the anticipated end date, and 
(3) omits the anticipated end date and includes the programme start date


I would suggest 
* making them all tabular
* adding anticipated end date to (2)
* adding anticipated end date to (3) <--- is it ok to remove programme start date here?

This is what is implemented in this PR.

How does that sound?


TIS21-7246