### PR TITLE
refactor: improve account != 1 errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.6.0"
+version = "2.6.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/EmailService.java
@@ -352,10 +352,12 @@ public class EmailService {
     Set<String> userAccountIds = userAccountService.getUserAccountIds(traineeId);
 
     return switch (userAccountIds.size()) {
-      case 0 -> throw new IllegalArgumentException("No user account found for the given ID.");
+      case 0 -> throw new IllegalArgumentException(
+          "No account found for trainee %s.".formatted(traineeId));
       case 1 -> userAccountService.getUserDetailsById(userAccountIds.iterator().next());
-      default ->
-          throw new IllegalArgumentException("Multiple user accounts found for the given ID.");
+      default -> throw new IllegalArgumentException(
+          "%s accounts found for trainee %s. Found: [%s]".formatted(userAccountIds.size(),
+              traineeId, String.join(", ", userAccountIds)));
     };
   }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,7 @@ application:
     ltft-updated: ${local.sqs-path}/tis-trainee-notifications-local-ltft-updated
     ltft-updated-tpd: ${local.sqs-path}/tis-trainee-notifications-local-ltft-updated-tpd
     form-updated: ${local.sqs-path}/tis-trainee-notifications-local-form-updated
+    gmc-rejected: ${local.sqs-path}/tis-trainee-notifications-local-gmc-rejected
     gmc-updated: ${local.sqs-path}/tis-trainee-notifications-local-gmc-updated
     placement-deleted: ${local.sqs-path}/tis-trainee-notifications-local-placement-deleted
     placement-updated: ${local.sqs-path}/tis-trainee-notifications-local-placement-updated


### PR DESCRIPTION
The exceptions throw when looking for a user account and getting zero or multiple results are generic and static.
Update EmailService to throw a more dynamic exception message, including the trainee ID, found account IDs and found account count, so that diagnosing is easier without trawling through logs for context from earlier log messages.

NO-TICKET