### PR TITLE
fix: bump notifications window to 24 hours

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.9.1"
+version = "2.9.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/NotificationService.java
@@ -97,7 +97,7 @@ public class NotificationService implements Job {
   public static final String API_TRAINEE_LOCAL_OFFICE_CONTACTS
       = "/api/trainee-profile/local-office-contacts/{tisId}/{contactTypeName}";
   private static final String TRIGGER_ID_PREFIX = "trigger-";
-  public static final long NINE_HOURS_IN_SECONDS = 9 * 60 * 60L;
+  public static final long ONE_DAY_IN_SECONDS = 24 * 60 * 60L;
 
   public static final String TEMPLATE_NOTIFICATION_TYPE_FIELD = "notificationType";
   public static final String TEMPLATE_OWNER_CONTACT_FIELD = "localOfficeContact";

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/PlacementService.java
@@ -28,7 +28,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.USEFUL_INFORMATION;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
-import static uk.nhs.tis.trainee.notifications.service.NotificationService.NINE_HOURS_IN_SECONDS;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.ONE_DAY_IN_SECONDS;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_NOTIFICATION_TYPE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_OWNER_FIELD;
@@ -268,7 +268,7 @@ public class PlacementService {
 
       String jobId = PLACEMENT_UPDATED_WEEK_12 + "-" + placement.getTisId();
       try {
-        notificationService.scheduleNotification(jobId, jobDataMap, when, NINE_HOURS_IN_SECONDS);
+        notificationService.scheduleNotification(jobId, jobDataMap, when, ONE_DAY_IN_SECONDS);
       } catch (SchedulerException e) {
         log.error("Failed to schedule notification {}: {}", jobId, e.toString());
         throw (e); //to allow message to be requeue-ed

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -31,7 +31,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_DAY_ONE;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.SPONSORSHIP;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
-import static uk.nhs.tis.trainee.notifications.service.NotificationService.NINE_HOURS_IN_SECONDS;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.ONE_DAY_IN_SECONDS;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_NOTIFICATION_TYPE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_OWNER_FIELD;
@@ -278,7 +278,7 @@ public class ProgrammeMembershipService {
         notificationService.executeNow(jobId, pmCreatedJobDataMap);
       } else {
         notificationService.scheduleNotification(jobId, pmCreatedJobDataMap, scheduleWhen,
-            NINE_HOURS_IN_SECONDS);
+            ONE_DAY_IN_SECONDS);
       }
     }
 
@@ -305,7 +305,7 @@ public class ProgrammeMembershipService {
         notificationService.executeNow(jobId, pmDayOneJobDataMap);
       } else {
         notificationService.scheduleNotification(jobId, pmDayOneJobDataMap,
-            Date.from(startDate.atStartOfDay(timezone).toInstant()), NINE_HOURS_IN_SECONDS);
+            Date.from(startDate.atStartOfDay(timezone).toInstant()), ONE_DAY_IN_SECONDS);
       }
     }
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/NotificationServiceTest.java
@@ -61,7 +61,7 @@ import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTA
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTACT_TYPE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.DEFAULT_NO_CONTACT_MESSAGE;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.DUMMY_USER_ROLES;
-import static uk.nhs.tis.trainee.notifications.service.NotificationService.NINE_HOURS_IN_SECONDS;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.ONE_DAY_IN_SECONDS;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_CONTACT_HREF_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_NOTIFICATION_TYPE_FIELD;
@@ -1237,9 +1237,9 @@ class NotificationServiceTest {
     when(restTemplate.getForObject(ACCOUNT_DETAILS_URL, UserDetails.class,
         Map.of(TIS_ID_FIELD, PERSON_ID))).thenReturn(userAccountDetails);
 
-    service.scheduleNotification("id1", jobDataMap, scheduledDate, NINE_HOURS_IN_SECONDS);
-    service.scheduleNotification("id2", jobDataMap, scheduledDate, NINE_HOURS_IN_SECONDS);
-    service.scheduleNotification("id3", jobDataMap, scheduledDate, NINE_HOURS_IN_SECONDS);
+    service.scheduleNotification("id1", jobDataMap, scheduledDate, ONE_DAY_IN_SECONDS);
+    service.scheduleNotification("id2", jobDataMap, scheduledDate, ONE_DAY_IN_SECONDS);
+    service.scheduleNotification("id3", jobDataMap, scheduledDate, ONE_DAY_IN_SECONDS);
 
     ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
     verify(scheduler, times(3)).scheduleJob(any(), triggerCaptor.capture());

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/PlacementServiceTest.java
@@ -48,7 +48,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.USEFUL_INF
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTACT_TYPE_FIELD;
-import static uk.nhs.tis.trainee.notifications.service.NotificationService.NINE_HOURS_IN_SECONDS;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.ONE_DAY_IN_SECONDS;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_OWNER_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.PlacementService.GMC_NUMBER_FIELD;
@@ -282,7 +282,7 @@ class PlacementServiceTest {
         stringCaptor.capture(),
         jobDataMapCaptor.capture(),
         dateCaptor.capture(),
-        eq(NINE_HOURS_IN_SECONDS)
+        eq(ONE_DAY_IN_SECONDS)
     );
 
     //verify the details of the last notification added
@@ -577,7 +577,7 @@ class PlacementServiceTest {
         any(),
         any(),
         dateCaptor.capture(),
-        eq(NINE_HOURS_IN_SECONDS)
+        eq(ONE_DAY_IN_SECONDS)
     );
 
     Date when = dateCaptor.getValue();

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -49,7 +49,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.SPONSORSHIP;
 import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PROGRAMME_MEMBERSHIP;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.CONTACT_TYPE_FIELD;
-import static uk.nhs.tis.trainee.notifications.service.NotificationService.NINE_HOURS_IN_SECONDS;
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.ONE_DAY_IN_SECONDS;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.PlacementService.GMC_NUMBER_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.BLOCK_INDEMNITY_FIELD;
@@ -700,7 +700,7 @@ class ProgrammeMembershipServiceTest {
         dayOneStringCaptor.capture(),
         dayOneJobDataMapCaptor.capture(),
         eq(Date.from(START_DATE.atStartOfDay(timezone).toInstant())),
-        eq(NINE_HOURS_IN_SECONDS));
+        eq(ONE_DAY_IN_SECONDS));
 
     String dayOneJobId = dayOneStringCaptor.getValue();
     String dayOneExpectedJobId = PROGRAMME_DAY_ONE + "-" + TIS_ID;
@@ -822,7 +822,7 @@ class ProgrammeMembershipServiceTest {
 
     String dayOneExpectedJobId = PROGRAMME_DAY_ONE + "-" + TIS_ID;
     verify(notificationService)
-        .scheduleNotification(eq(dayOneExpectedJobId), any(), any(), eq(NINE_HOURS_IN_SECONDS));
+        .scheduleNotification(eq(dayOneExpectedJobId), any(), any(), eq(ONE_DAY_IN_SECONDS));
   }
 
   @Test
@@ -897,7 +897,7 @@ class ProgrammeMembershipServiceTest {
 
     String dayOneExpectedJobId = PROGRAMME_DAY_ONE + "-" + TIS_ID;
     verify(notificationService)
-        .scheduleNotification(eq(dayOneExpectedJobId), any(), any(), eq(NINE_HOURS_IN_SECONDS));
+        .scheduleNotification(eq(dayOneExpectedJobId), any(), any(), eq(ONE_DAY_IN_SECONDS));
   }
 
   @Test
@@ -966,7 +966,7 @@ class ProgrammeMembershipServiceTest {
     Date expectedWhenDate = Date.from(
         expectedWhen.atStartOfDay(timezone).toInstant());
     verify(notificationService)
-        .scheduleNotification(any(), any(), eq(expectedWhenDate), eq(NINE_HOURS_IN_SECONDS));
+        .scheduleNotification(any(), any(), eq(expectedWhenDate), eq(ONE_DAY_IN_SECONDS));
     verify(notificationService, never()).executeNow(any(), any());
   }
 
@@ -1050,7 +1050,7 @@ class ProgrammeMembershipServiceTest {
     Date expectedWhenDate = Date.from(
         expectedWhen.atStartOfDay(timezone).toInstant());
     verify(notificationService)
-        .scheduleNotification(any(), any(), eq(expectedWhenDate), eq(NINE_HOURS_IN_SECONDS));
+        .scheduleNotification(any(), any(), eq(expectedWhenDate), eq(ONE_DAY_IN_SECONDS));
     verify(notificationService, never()).executeNow(any(), any());
   }
 


### PR DESCRIPTION
A notification window exists which spreads notification scheduling out over 9 hours to try and avoid rate limits accessing the Cognito API. However, we are now seeing delivery failures to gmail accounts as a result of Google blocking our sudden surge in emails sent to them.

Increase the notification window to 24 hours in an attempt to smooth the surges and avoid the automated blocking.
A longer term fix remains to buffer scheduled emails in to a queue, which can then be dynamically delayed/retried more easily based on these sorts of bounces.

TIS21-7290