### PR TITLE
fix: retry blocked email notifications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.9.2"
+version = "2.9.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures.java
@@ -1,0 +1,177 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.EMAIL_UPDATED_NEW;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.LTFT_SUBMITTED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_DAY_ONE;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import jakarta.mail.MessagingException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobDataMap;
+import org.quartz.SchedulerException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.service.EmailService;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+import uk.nhs.tis.trainee.notifications.service.NotificationService;
+
+/**
+ * Resend email notifications that failed on the 14th and 15th May due to Google blocking us.
+ */
+@Slf4j
+@ChangeUnit(id = "resendGoogleMailFailures", order = "9")
+public class ResendGoogleMailFailures {
+
+  private static final long WINDOW = Duration.ofDays(1).getSeconds();
+
+  private static final Set<NotificationType> INSTANT_NOTIFICATIONS = Set.of(
+      COJ_CONFIRMATION,
+      EMAIL_UPDATED_NEW,
+      FORM_UPDATED,
+      LTFT_SUBMITTED
+  );
+
+  private static final Set<NotificationType> SCHEDULE_NOTIFICATIONS = Set.of(
+      PLACEMENT_UPDATED_WEEK_12,
+      PROGRAMME_CREATED,
+      PROGRAMME_DAY_ONE
+  );
+
+  private final MongoTemplate mongoTemplate;
+  private final EmailService emailService;
+  private final HistoryService historyService;
+  private final NotificationService notificationService;
+
+  /**
+   * Construct the migrator.
+   *
+   * @param mongoTemplate The mongo template to use for accessing failed records.
+   */
+  public ResendGoogleMailFailures(MongoTemplate mongoTemplate, EmailService emailService,
+      HistoryService historyService,
+      NotificationService notificationService) {
+    this.mongoTemplate = mongoTemplate;
+    this.emailService = emailService;
+    this.historyService = historyService;
+    this.notificationService = notificationService;
+  }
+
+  /**
+   * Resend the failed Google email notifications.
+   */
+  @Execution
+  public void migrate() {
+    Query query = new Query()
+        .addCriteria(Criteria.where("recipient.type").is(EMAIL))
+        .addCriteria(Criteria.where("recipient.contact")
+            .regex(Pattern.compile("^.+@(gmail|googlemail)\\.com$", CASE_INSENSITIVE)))
+        .addCriteria(Criteria.where("status").is(FAILED))
+        .addCriteria(Criteria.where("statusDetail").is("Bounce: Transient - General"))
+        .addCriteria(Criteria.where("sentAt")
+            .gte(LocalDate.of(2025, 5, 14))
+            .lt(LocalDate.of(2025, 5, 16))
+        );
+
+    List<History> failures = mongoTemplate.find(query, History.class);
+    int total = failures.size();
+    log.info("Found {} qualifying failure(s).", total);
+    int current = 1;
+
+    for (History failure : failures) {
+      log.info("Progress: {}/{}.", current++, total);
+
+      NotificationType type = failure.type();
+      if (INSTANT_NOTIFICATIONS.contains(type)) {
+        sendEmail(failure);
+      } else if (SCHEDULE_NOTIFICATIONS.contains(type)) {
+        scheduleEmail(failure);
+      } else {
+        log.warn("Skipping unexpected failed notification type {}.", type);
+        continue;
+      }
+
+      historyService.deleteHistoryForTrainee(failure.id(), failure.recipient().id());
+    }
+  }
+
+  /**
+   * Retry sending the failed email.
+   *
+   * @param failure The failed notification history.
+   */
+  private void sendEmail(History failure) {
+    try {
+      emailService.resendMessage(failure, failure.recipient().contact());
+    } catch (MessagingException e) {
+      log.error("Failed to send notification retry.", e);
+    }
+  }
+
+  /**
+   * Schedule retrying to send the failed email.
+   *
+   * @param failure The failed notification history.
+   */
+  private void scheduleEmail(History failure) {
+    Map<String, Object> templateVariables = failure.template().variables();
+    JobDataMap jobData = new JobDataMap(templateVariables);
+    String jobId = "%s-%s".formatted(failure.type(), failure.tisReference().id());
+
+    try {
+      notificationService.removeNotification(jobId);
+      notificationService.scheduleNotification(jobId, jobData, Date.from(Instant.now()), WINDOW);
+    } catch (SchedulerException e) {
+      log.error("Failed to schedule notification retry.", e);
+    }
+  }
+
+  /**
+   * Do not attempt rollback, the collection should be left as-is.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn(
+        "Rollback requested but not available for 'ResendGoogleMailFailures' migration.");
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailuresIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailuresIntegrationTest.java
@@ -1,0 +1,179 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MONGODB;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.WELCOME;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers(disabledWithoutDocker = true)
+class ResendGoogleMailFailuresIntegrationTest {
+
+  private static final String LOG_MESSAGE = "Found 2 qualifying failure(s).";
+
+  private static final Logger log = (Logger) LoggerFactory.getLogger(
+      ResendGoogleMailFailures.class);
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer MONGODB_CONTAINER = new MongoDBContainer(MONGODB);
+
+  @SpyBean
+  private MongoTemplate mongoTemplate;
+
+  private ResendGoogleMailFailures migrator;
+  private List<ILoggingEvent> logsList;
+
+  @BeforeEach
+  void setUp() {
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    log.addAppender(listAppender);
+    logsList = listAppender.list;
+
+    mongoTemplate.dropCollection(History.class);
+    migrator = new ResendGoogleMailFailures(mongoTemplate, null, null, null);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = MessageType.class, mode = EXCLUDE, names = "EMAIL")
+  void shouldFindByRecipientType(MessageType type) {
+    createFailure(null, null, null, null, null);
+    createFailure(EMAIL, null, null, null, null);
+    createFailure(type, null, null, null, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @Test
+  void shouldFindByRecipientContact() {
+    createFailure(null, null, null, null, null);
+    createFailure(null, ".@gmail.com", null, null, null);
+    createFailure(null, ".@GMAIL.COM", null, null, null);
+    createFailure(null, ".@googlemail.com", null, null, null);
+    createFailure(null, ".@GOOGLEMAIL.COM", null, null, null);
+    createFailure(null, ".@example.com", null, null, null);
+    createFailure(null, ".@EXAMPLE.COM", null, null, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is("Found 5 qualifying failure(s)."));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationStatus.class, mode = EXCLUDE, names = "FAILED")
+  void shouldFindByStatus(NotificationStatus status) {
+    createFailure(null, null, null, null, null);
+    createFailure(null, null, FAILED, null, null);
+    createFailure(null, null, status, null, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @Test
+  void shouldFindByStatusDetail() {
+    createFailure(null, null, null, null, null);
+    createFailure(null, null, null, "Bounce: Transient - General", null);
+    createFailure(null, null, null, "Some other status detail", null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @Test
+  void shouldFindBySentAt() {
+    createFailure(null, null, null, null, Instant.parse("2025-05-13T23:59:59Z"));
+    createFailure(null, null, null, null, Instant.parse("2025-05-14T00:00:00Z"));
+    createFailure(null, null, null, null, Instant.parse("2025-05-15T23:59:59Z"));
+    createFailure(null, null, null, null, Instant.parse("2025-05-16T00:00:00Z"));
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  /**
+   * Create and persist a failure, uses valid defaults for null parameters.
+   *
+   * @param type         The message type.
+   * @param contact      The contact email address.
+   * @param status       The history status.
+   * @param statusDetail The status detail text.
+   * @param sentAt       The sent-at timestamp.
+   */
+  private void createFailure(@Nullable MessageType type, @Nullable String contact,
+      @Nullable NotificationStatus status, @Nullable String statusDetail,
+      @Nullable Instant sentAt) {
+    History history = History.builder()
+        .id(ObjectId.get())
+        .type(WELCOME)
+        .recipient(new RecipientInfo(UUID.randomUUID().toString(), type != null ? type : EMAIL,
+            contact != null ? contact : "_@gmail.com"))
+        .status(status != null ? status : FAILED)
+        .statusDetail(statusDetail != null ? statusDetail : "Bounce: Transient - General")
+        .sentAt(sentAt != null ? sentAt : Instant.parse("2025-05-14T12:00:00Z"))
+        .build();
+    mongoTemplate.save(history);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailuresTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailuresTest.java
@@ -1,0 +1,242 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
+
+import jakarta.mail.MessagingException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.number.IsCloseTo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.quartz.JobDataMap;
+import org.quartz.SchedulerException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.service.EmailService;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+import uk.nhs.tis.trainee.notifications.service.NotificationService;
+
+class ResendGoogleMailFailuresTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_EMAIL = "trainee@example.com";
+  private static final String REFERENCE_ID = UUID.randomUUID().toString();
+
+  private MongoTemplate mongoTemplate;
+
+  private EmailService emailService;
+
+  private HistoryService historyService;
+
+  private NotificationService notificationService;
+
+  private ResendGoogleMailFailures migrator;
+
+  @BeforeEach
+  void setUp() {
+    mongoTemplate = mock(MongoTemplate.class);
+    emailService = mock(EmailService.class);
+    historyService = mock(HistoryService.class);
+    notificationService = mock(NotificationService.class);
+    migrator = new ResendGoogleMailFailures(mongoTemplate, emailService, historyService,
+        notificationService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(NotificationType.class)
+  void shouldNotInterruptMigrationForExceptions(NotificationType type)
+      throws MessagingException, SchedulerException {
+    ObjectId historyId = ObjectId.get();
+    History failure = History.builder()
+        .id(historyId)
+        .type(type)
+        .tisReference(new TisReferenceInfo(PLACEMENT, REFERENCE_ID))
+        .recipient(new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_EMAIL))
+        .template(new TemplateInfo("template-name", "v1.2.3", Map.of()))
+        .build();
+    when(mongoTemplate.find(any(), eq(History.class))).thenReturn(List.of(failure));
+
+    doThrow(MessagingException.class).when(emailService).resendMessage(any(), any());
+    doThrow(SchedulerException.class).when(notificationService)
+        .scheduleNotification(any(), any(), any(), anyLong());
+
+    assertDoesNotThrow(() -> migrator.migrate());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationType.class, names = {
+      "COJ_CONFIRMATION", "EMAIL_UPDATED_NEW", "FORM_UPDATED", "LTFT_SUBMITTED"})
+  void shouldMigrateInstantEmails(NotificationType type) throws MessagingException {
+    ObjectId historyId = ObjectId.get();
+    History failure = History.builder()
+        .id(historyId)
+        .type(type)
+        .recipient(new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_EMAIL))
+        .build();
+    when(mongoTemplate.find(any(), eq(History.class))).thenReturn(List.of(failure));
+
+    migrator.migrate();
+
+    verify(emailService).resendMessage(failure, TRAINEE_EMAIL);
+    verify(historyService).deleteHistoryForTrainee(historyId, TRAINEE_ID);
+    verifyNoInteractions(notificationService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationType.class, names = {
+      "PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED", "PROGRAMME_DAY_ONE"})
+  void shouldMigrateScheduledEmails(NotificationType type) throws SchedulerException {
+    ObjectId historyId = ObjectId.get();
+    History failure = History.builder()
+        .id(historyId)
+        .type(type)
+        .tisReference(new TisReferenceInfo(PLACEMENT, REFERENCE_ID))
+        .recipient(new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_EMAIL))
+        .template(new TemplateInfo("template-name", "v1.2.3", Map.of(
+            "key1", "value1",
+            "key2", "value2"
+        )))
+        .build();
+    when(mongoTemplate.find(any(), eq(History.class))).thenReturn(List.of(failure));
+
+    migrator.migrate();
+
+    String jobId = type + "-" + REFERENCE_ID;
+    verify(notificationService).removeNotification(jobId);
+
+    ArgumentCaptor<JobDataMap> jobDataCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Date> whenCaptor = ArgumentCaptor.captor();
+    verify(notificationService).scheduleNotification(eq(jobId), jobDataCaptor.capture(),
+        whenCaptor.capture(), eq(86400L));
+
+    JobDataMap jobData = jobDataCaptor.getValue();
+    assertThat("Unexpected job data count.", jobData.keySet(), hasSize(2));
+    assertThat("Unexpected job data.", jobData.get("key1"), is("value1"));
+    assertThat("Unexpected job data.", jobData.get("key2"), is("value2"));
+
+    assertThat("Unexpected send date.", whenCaptor.getValue(),
+        DateCloseTo.closeTo(Instant.now().getEpochSecond(), 1));
+
+    verify(historyService).deleteHistoryForTrainee(historyId, TRAINEE_ID);
+    verifyNoInteractions(emailService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationType.class, mode = EXCLUDE, names = {
+      "COJ_CONFIRMATION", "EMAIL_UPDATED_NEW", "FORM_UPDATED", "LTFT_SUBMITTED",
+      "PLACEMENT_UPDATED_WEEK_12", "PROGRAMME_CREATED", "PROGRAMME_DAY_ONE"})
+  void shouldNotMigrateUnsupportedTypes(NotificationType type) {
+    History failure = History.builder()
+        .id(ObjectId.get())
+        .type(type)
+        .build();
+    when(mongoTemplate.find(any(), eq(History.class))).thenReturn(List.of(failure));
+
+    Mockito.clearInvocations(mongoTemplate);
+    migrator.migrate();
+
+    verifyNoInteractions(emailService);
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(historyService);
+  }
+
+  @Test
+  void rollback() {
+    Mockito.clearInvocations(mongoTemplate);
+    migrator.rollback();
+
+    verifyNoInteractions(mongoTemplate);
+    verifyNoInteractions(emailService);
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(historyService);
+  }
+
+  /**
+   * A custom matcher which wraps {@link IsCloseTo} to allow easier use with Java Dates.
+   */
+  private static class DateCloseTo extends TypeSafeMatcher<Date> {
+
+    private final IsCloseTo isCloseTo;
+
+    /**
+     * Construct a matcher that matches when a date value is equal, within the error range.
+     *
+     * @param value The expected value of matching doubles after conversion.
+     * @param error The delta (+/-) within which matches will be allowed.
+     */
+    DateCloseTo(double value, double error) {
+      isCloseTo = new IsCloseTo(value, error);
+    }
+
+    @Override
+    protected boolean matchesSafely(Date date) {
+      return isCloseTo.matchesSafely((double) date.toInstant().getEpochSecond());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      isCloseTo.describeTo(description);
+    }
+
+    /**
+     * Get an instance of the closeTo matcher.
+     *
+     * @param operand The expected value of matching doubles after conversion.
+     * @param error   The delta (+/-) within which matches will be allowed.
+     * @return the matcher instance.
+     */
+    public static Matcher<Date> closeTo(double operand, double error) {
+      return new DateCloseTo(operand, error);
+    }
+  }
+}


### PR DESCRIPTION
Google Mail blocked the majority of our emails sent to gmail and googlemail addresses due to a sudden spike in sends. This has left 3734 failed emails which need to be retried.

Create a migrator to re-schedule the failed emails, spread over a 24 hour period to hopefully avoid any automated blocks.

TIS21-7290