### PR TITLE
fix: keep notifications when resend fails

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.9.3"
+version = "2.9.4"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
The resend migration is deleting notifications when it could not be rescheduled, update the migrator to skip the deletion step so the original failure is retained and no notifications are lost.

TIS21-7290