### PR TITLE
feat: add TisReferenceInfo to LTFT history

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.9.4"
+version = "2.10.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/LtftUpdateEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/LtftUpdateEvent.java
@@ -38,6 +38,8 @@ public class LtftUpdateEvent {
 
   @JsonAlias("traineeTisId")
   private String traineeId;
+  @JsonAlias("id")
+  private String formId;
   private String formRef;
   private String formName;
   private PersonalDetails personalDetails;

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/LtftListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/LtftListener.java
@@ -49,9 +49,10 @@ import uk.nhs.tis.trainee.notifications.config.TemplateVersionsProperties;
 import uk.nhs.tis.trainee.notifications.dto.LtftUpdateEvent;
 import uk.nhs.tis.trainee.notifications.dto.UserDetails;
 import uk.nhs.tis.trainee.notifications.mapper.LtftEventMapper;
-import uk.nhs.tis.trainee.notifications.model.HrefType;
+import uk.nhs.tis.trainee.notifications.model.History;
 import uk.nhs.tis.trainee.notifications.model.LocalOfficeContactType;
 import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
 import uk.nhs.tis.trainee.notifications.service.EmailService;
 import uk.nhs.tis.trainee.notifications.service.NotificationService;
 
@@ -124,8 +125,10 @@ public class LtftListener {
         "var", event,
         "contacts", getContacts(managingDeanery)
     );
+    History.TisReferenceInfo tisReferenceInfo
+        = new History.TisReferenceInfo(TisReferenceType.LTFT, event.getFormId());
     emailService.sendMessageToExistingUser(traineeTisId, notificationType, templateVersion,
-        templateVariables, null);
+        templateVariables, tisReferenceInfo);
     log.info("LTFT updated notification sent for trainee {}.", traineeTisId);
   }
 
@@ -162,9 +165,11 @@ public class LtftListener {
           : event.getProgrammeMembership().managingDeanery();
       templateVariables.put("contacts", getContacts(managingDeanery));
 
+      History.TisReferenceInfo tisReferenceInfo
+          = new History.TisReferenceInfo(TisReferenceType.LTFT, event.getFormId());
       String tpdEmail = event.getDiscussions() == null ? null : event.getDiscussions().tpdEmail();
       emailService.sendMessage(traineeTisId, tpdEmail, notificationType,
-          templateVersion, templateVariables, null, !emailNotificationsEnabled);
+          templateVersion, templateVariables, tisReferenceInfo, !emailNotificationsEnabled);
       log.info("LTFT {} notification sent to TPD at email '{}' for trainee {}.", event.getState(),
           tpdEmail, traineeTisId);
     } else {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/TisReferenceType.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/TisReferenceType.java
@@ -29,6 +29,7 @@ public enum TisReferenceType {
   PLACEMENT,
   PROGRAMME_MEMBERSHIP,
   FORMR_PARTA,
-  FORMR_PARTB
+  FORMR_PARTB,
+  LTFT
 
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerTest.java
@@ -172,7 +172,8 @@ class LtftListenerTest {
     ArgumentCaptor<History.TisReferenceInfo> captor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(), any(), captor.capture());
 
-    assertThat("Unexpected TIS reference type.", captor.getValue().type(), is(TisReferenceType.LTFT));
+    assertThat("Unexpected TIS reference type.", captor.getValue().type(),
+        is(TisReferenceType.LTFT));
     assertThat("Unexpected TIS reference id.", captor.getValue().id(), is("123"));
   }
 
@@ -388,7 +389,8 @@ class LtftListenerTest {
     ArgumentCaptor<History.TisReferenceInfo> captor = ArgumentCaptor.captor();
     verify(emailService).sendMessageToExistingUser(any(), any(), any(), any(), captor.capture());
 
-    assertThat("Unexpected TIS reference type.", captor.getValue().type(), is(TisReferenceType.LTFT));
+    assertThat("Unexpected TIS reference type.", captor.getValue().type(),
+        is(TisReferenceType.LTFT));
     assertThat("Unexpected TIS reference id.", captor.getValue().id(), is("123"));
   }
 


### PR DESCRIPTION
 tis-trainee-forms includes the id in the published DTO when the form is e.g. submitted (here: https://github.com/Health-Education-England/tis-trainee-forms/blob/91e7fdbb4bccd0c6f5a54acff520db9ed3a8a5fe/src/main/java/uk/nhs/hee/tis/trainee/forms/dto/LtftFormDto.java#L59) 

With this PR, the History that the notification service broadcasts when the email status changes from PENDING->SENT/FAILED will include TisReferenceInfo with this form ID, so that the forms service can in turn find the correct form to update with the new email status.

TIS21-7025