### PR TITLE
feat: queue emails in an outbox queue before send

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -57,6 +57,10 @@
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/ltft/status-update-tpd"
         },
         {
+          "name": "OUTBOX_QUEUE",
+          "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/outbox"
+        },
+        {
           "name": "PLACEMENT_UPDATED_QUEUE",
           "valueFrom": "/tis/trainee/notifications/${environment}/queue-url/placement/updated"
         },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.10.0"
+version = "2.11.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/event/EmailListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/event/EmailListener.java
@@ -22,13 +22,11 @@
 package uk.nhs.tis.trainee.notifications.event;
 
 import io.awspring.cloud.sqs.annotation.SqsListener;
-import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.tis.trainee.notifications.dto.EmailEvent;
 import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Bounce;
 import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Complaint;
-import uk.nhs.tis.trainee.notifications.dto.EmailEvent.Mail.MailHeader;
 import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
 import uk.nhs.tis.trainee.notifications.service.HistoryService;
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/migration/ResendAugust2025RotationScheduleFailures.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/migration/ResendAugust2025RotationScheduleFailures.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SCHEDULED;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobDataMap;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+import uk.nhs.tis.trainee.notifications.service.NotificationService;
+
+/**
+ * Resend email notifications which failed and got stuck in SCHEDULED.
+ */
+@Slf4j
+@ChangeUnit(id = "resendAugust2025RotationScheduleFailures", order = "10")
+public class ResendAugust2025RotationScheduleFailures {
+
+  private static final long WINDOW = Duration.ofDays(1).getSeconds();
+
+  private final MongoTemplate mongoTemplate;
+  private final HistoryService historyService;
+  private final NotificationService notificationService;
+
+  /**
+   * Construct the migrator.
+   *
+   * @param mongoTemplate The mongo template to use for accessing failed records.
+   */
+  public ResendAugust2025RotationScheduleFailures(MongoTemplate mongoTemplate,
+      HistoryService historyService, NotificationService notificationService) {
+    this.mongoTemplate = mongoTemplate;
+    this.historyService = historyService;
+    this.notificationService = notificationService;
+  }
+
+  /**
+   * Resend the failed Google email notifications.
+   */
+  @Execution
+  public void migrate() {
+    Query query = new Query()
+        .addCriteria(Criteria.where("recipient.type").is(EMAIL))
+        .addCriteria(Criteria.where("status").is(SCHEDULED))
+        .addCriteria(Criteria.where("sentAt")
+            .gte(LocalDate.of(2025, 5, 1))
+            .lt(LocalDate.now(ZoneOffset.UTC))
+        );
+
+    List<History> missedSchedules = mongoTemplate.find(query, History.class);
+    int total = missedSchedules.size();
+    log.info("Found {} qualifying missed schedules.", total);
+    int current = 1;
+
+    for (History missedSchedule : missedSchedules) {
+      log.info("Progress: {}/{}.", current++, total);
+      boolean success = scheduleEmail(missedSchedule);
+
+      if (success) {
+        historyService.deleteHistoryForTrainee(missedSchedule.id(),
+            missedSchedule.recipient().id());
+      }
+    }
+  }
+
+  /**
+   * Schedule retrying to send the missed email.
+   *
+   * @param missedSchedule The missed schedule notification history.
+   * @return Whether the notification was successfully scheduled.
+   */
+  private boolean scheduleEmail(History missedSchedule) {
+    Map<String, Object> templateVariables = missedSchedule.template().variables();
+    JobDataMap jobData = new JobDataMap(templateVariables);
+    String jobId = "%s-%s".formatted(missedSchedule.type(), missedSchedule.tisReference().id());
+
+    try {
+      notificationService.removeNotification(jobId);
+      notificationService.scheduleNotification(jobId, jobData, Date.from(Instant.now()), WINDOW);
+      return true;
+    } catch (Exception e) {
+      log.error("Failed to schedule notification retry.", e);
+      return false;
+    }
+  }
+
+  /**
+   * Do not attempt rollback, the collection should be left as-is.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn("Rollback requested but not available for 'ResendAugust2025RotationScheduleFailures'"
+        + " migration.");
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/MessageSendingService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/MessageSendingService.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static uk.nhs.tis.trainee.notifications.service.NotificationService.PERSON_ID_FIELD;
+
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.JobDataMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * A service for sending messages to a queue.
+ */
+@Slf4j
+@Service
+public class MessageSendingService {
+
+  private final SqsTemplate template;
+  private final String outboxQueue;
+
+  /**
+   * Construct an instance of the message sending service.
+   *
+   * @param template    The SQS template to use for sending messages.
+   * @param outboxQueue The name of the outbox queue.
+   */
+  public MessageSendingService(SqsTemplate template,
+      @Value("${application.queues.outbox}") String outboxQueue) {
+    this.template = template;
+    this.outboxQueue = outboxQueue;
+  }
+
+  /**
+   * Queue a job for execution.
+   *
+   * @param jobKey     The descriptive job identifier.
+   * @param jobDetails The job details.
+   * @return the result map with status details if successful.
+   */
+  public Map<String, String> sendJobToOutbox(String jobKey, JobDataMap jobDetails) {
+    log.info("Sending job {} to the outbox.", jobKey);
+    SendResult<Object> result = template.send(to -> to.queue(outboxQueue)
+        .payload(jobDetails)
+        .messageDeduplicationId(jobKey)
+        .messageGroupId(jobDetails.getString(PERSON_ID_FIELD))
+    );
+
+    return Map.of("status", "queued " + result.messageId());
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,7 @@ application:
     email-event: ${local.sqs-path}/tis-trainee-notifications-local-email-failure
     ltft-updated: ${local.sqs-path}/tis-trainee-notifications-local-ltft-updated
     ltft-updated-tpd: ${local.sqs-path}/tis-trainee-notifications-local-ltft-updated-tpd
+    outbox: ${local.sqs-path}/tis-trainee-notifications-local-outbox
     form-updated: ${local.sqs-path}/tis-trainee-notifications-local-form-updated
     gmc-rejected: ${local.sqs-path}/tis-trainee-notifications-local-gmc-rejected
     gmc-updated: ${local.sqs-path}/tis-trainee-notifications-local-gmc-updated

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ application:
     gmc-updated: ${GMC_UPDATED_QUEUE}
     ltft-updated: ${LTFT_UPDATED_QUEUE}
     ltft-updated-tpd: ${LTFT_UPDATED_TPD_QUEUE}
+    outbox: ${OUTBOX_QUEUE}
     placement-updated: ${PLACEMENT_UPDATED_QUEUE}
     placement-deleted: ${PLACEMENT_DELETED_QUEUE}
     programme-membership-updated: ${PROGRAMME_MEMBERSHIP_UPDATED_QUEUE}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/TisTraineeNotificationsApplicationTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.awspring.cloud.s3.S3Template;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.junit.jupiter.api.Test;
 import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +51,9 @@ class TisTraineeNotificationsApplicationTest {
 
   @MockBean
   private S3Template s3Template;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   @Autowired
   ApplicationContext context;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/config/MongoConfigurationIntegrationTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MONGODB;
 
 import io.awspring.cloud.s3.S3Template;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -55,6 +56,9 @@ class MongoConfigurationIntegrationTest {
 
   @MockBean
   private S3Template s3Template;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   @Container
   @ServiceConnection

--- a/src/test/java/uk/nhs/tis/trainee/notifications/matcher/DateCloseTo.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/matcher/DateCloseTo.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.matcher;
+
+import java.util.Date;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.number.IsCloseTo;
+
+/**
+ * A custom matcher which wraps {@link IsCloseTo} to allow easier use with Java Dates.
+ */
+public class DateCloseTo extends TypeSafeMatcher<Date> {
+
+  private final IsCloseTo isCloseTo;
+
+  /**
+   * Construct a matcher that matches when a date value is equal, within the error range.
+   *
+   * @param value The expected value of matching doubles after conversion.
+   * @param error The delta (+/-) within which matches will be allowed.
+   */
+  DateCloseTo(double value, double error) {
+    isCloseTo = new IsCloseTo(value, error);
+  }
+
+  @Override
+  protected boolean matchesSafely(Date date) {
+    return isCloseTo.matchesSafely((double) date.toInstant().getEpochSecond());
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    isCloseTo.describeTo(description);
+  }
+
+  /**
+   * Get an instance of the closeTo matcher.
+   *
+   * @param operand The expected value of matching doubles after conversion.
+   * @param error   The delta (+/-) within which matches will be allowed.
+   * @return the matcher instance.
+   */
+  public static Matcher<Date> closeTo(double operand, double error) {
+    return new DateCloseTo(operand, error);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/DeleteOrphanScheduledHistoryTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/DeleteOrphanScheduledHistoryTest.java
@@ -34,6 +34,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SCHEDULE
 import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 
 import com.mongodb.MongoException;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -62,6 +64,9 @@ class DeleteOrphanScheduledHistoryTest {
 
   @SpyBean
   private MongoTemplate mongoTemplate;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   private DeleteOrphanScheduledHistory migrator;
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/PopulateNotificationHistoryStatusIntegrationTest.java
@@ -31,6 +31,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SENT;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
 
 import io.awspring.cloud.s3.S3Template;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +62,9 @@ class PopulateNotificationHistoryStatusIntegrationTest {
 
   @MockBean
   private S3Template s3Template;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   private PopulateNotificationHistoryStatus migrator;
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendAugust2025RotationScheduleFailuresIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendAugust2025RotationScheduleFailuresIntegrationTest.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.Mockito.mock;
+import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MONGODB;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.SCHEDULED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.WELCOME;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
+import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
+import uk.nhs.tis.trainee.notifications.model.TisReferenceType;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+import uk.nhs.tis.trainee.notifications.service.NotificationService;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers(disabledWithoutDocker = true)
+class ResendAugust2025RotationScheduleFailuresIntegrationTest {
+
+  private static final String LOG_MESSAGE = "Found 2 qualifying missed schedules.";
+
+  private static final Logger log = (Logger) LoggerFactory.getLogger(
+      ResendAugust2025RotationScheduleFailures.class);
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer MONGODB_CONTAINER = new MongoDBContainer(MONGODB);
+
+  @SpyBean
+  private MongoTemplate mongoTemplate;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
+
+  private ResendAugust2025RotationScheduleFailures migrator;
+  private List<ILoggingEvent> logsList;
+
+  @BeforeEach
+  void setUp() {
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    log.addAppender(listAppender);
+    logsList = listAppender.list;
+
+    mongoTemplate.dropCollection(History.class);
+    migrator = new ResendAugust2025RotationScheduleFailures(mongoTemplate,
+        mock(HistoryService.class), mock(NotificationService.class));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = MessageType.class, mode = EXCLUDE, names = "EMAIL")
+  void shouldFindByRecipientType(MessageType type) {
+    createMissedSchedule(null, null, null);
+    createMissedSchedule(EMAIL, null, null);
+    createMissedSchedule(type, null, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationStatus.class, mode = EXCLUDE, names = "SCHEDULED")
+  void shouldFindByStatus(NotificationStatus status) {
+    createMissedSchedule(null, null, null);
+    createMissedSchedule(null, SCHEDULED, null);
+    createMissedSchedule(null, status, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @Test
+  void shouldFindBySentAt() {
+    createMissedSchedule(null, null, Instant.parse("2025-04-30T23:59:59Z"));
+    createMissedSchedule(null, null, Instant.parse("2025-05-01T00:00:00Z"));
+    createMissedSchedule(null, null, Instant.now()
+        .truncatedTo(ChronoUnit.DAYS).minusMillis(1));
+    createMissedSchedule(null, null, Instant.now().truncatedTo(ChronoUnit.DAYS));
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  /**
+   * Create and persist a missed schedule, uses valid defaults for null parameters.
+   *
+   * @param type   The message type.
+   * @param status The history status.
+   * @param sentAt The sent-at timestamp.
+   */
+  private void createMissedSchedule(@Nullable MessageType type, @Nullable NotificationStatus status,
+      @Nullable Instant sentAt) {
+    History history = History.builder()
+        .id(ObjectId.get())
+        .type(WELCOME)
+        .recipient(new RecipientInfo(UUID.randomUUID().toString(), type != null ? type : EMAIL,
+            "trainee@example.com"))
+        .status(status != null ? status : SCHEDULED)
+        .sentAt(sentAt != null ? sentAt : Instant.parse("2025-05-01T12:00:00Z"))
+        .template(new TemplateInfo("template", "v1.2.3", Map.of()))
+        .tisReference(new TisReferenceInfo(TisReferenceType.PLACEMENT, "123"))
+        .build();
+    mongoTemplate.save(history);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailuresIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailuresIntegrationTest.java
@@ -32,6 +32,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.WELCOME;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.util.List;
@@ -43,6 +44,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -71,6 +73,9 @@ class ResendGoogleMailFailuresIntegrationTest {
 
   @SpyBean
   private MongoTemplate mongoTemplate;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   private ResendGoogleMailFailures migrator;
   private List<ILoggingEvent> logsList;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResetLtftSubmittedTraineeHistoryTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResetLtftSubmittedTraineeHistoryTest.java
@@ -32,12 +32,14 @@ import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MONGOD
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.LTFT_SUBMITTED;
 
 import com.mongodb.MongoException;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -61,6 +63,9 @@ class ResetLtftSubmittedTraineeHistoryTest {
 
   @SpyBean
   private MongoTemplate mongoTemplate;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   private ResetLtftSubmittedTraineeHistory migrator;
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/UpdateInAppTvTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/UpdateInAppTvTest.java
@@ -40,6 +40,7 @@ import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipServic
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.LOCAL_OFFICE_CONTACT_TYPE_FIELD;
 
 import com.mongodb.MongoException;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +85,9 @@ class UpdateInAppTvTest {
 
   @MockBean
   private NotificationService notificationService;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   private UpdateInAppTvContact migrator;
 

--- a/src/test/java/uk/nhs/tis/trainee/notifications/repository/FlywayMigrationsTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/repository/FlywayMigrationsTest.java
@@ -24,6 +24,7 @@ package uk.nhs.tis.trainee.notifications.repository;
 import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MYSQL;
 
 import io.awspring.cloud.s3.S3Template;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,6 +64,9 @@ class FlywayMigrationsTest implements TestExecutionListener {
 
   @MockBean
   private S3Template s3Template;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   @Autowired
   Flyway flyway;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -39,6 +39,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_DAY_ONE;
 
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -101,6 +102,9 @@ class HistoryServiceIntegrationTest {
 
   @MockBean
   EventBroadcastService eventBroadcastService;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   @Autowired
   private HistoryService service;

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/MessageSendingServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/MessageSendingServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.awspring.cloud.sqs.operations.SendResult;
+import io.awspring.cloud.sqs.operations.SqsSendOptions;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.internal.stubbing.defaultanswers.TriesToReturnSelf;
+import org.quartz.JobDataMap;
+import org.springframework.messaging.support.GenericMessage;
+
+class MessageSendingServiceTest {
+
+  private static final String OUTBOX_QUEUE = "outbox.fifo";
+  private static final UUID MESSAGE_ID = UUID.randomUUID();
+
+  private MessageSendingService service;
+
+  private SqsTemplate sqsTemplate;
+
+  @BeforeEach
+  void setUp() {
+    sqsTemplate = mock(SqsTemplate.class);
+    service = new MessageSendingService(sqsTemplate, OUTBOX_QUEUE);
+  }
+
+  @Test
+  void shouldSetSendOptionsWhenSendingJobToOutbox() {
+    ArgumentCaptor<Consumer<SqsSendOptions<JobDataMap>>> consumerCaptor = ArgumentCaptor.captor();
+    SendResult<JobDataMap> sendResult = new SendResult<>(MESSAGE_ID, OUTBOX_QUEUE,
+        new GenericMessage<>(new JobDataMap()), Map.of());
+    when(sqsTemplate.send(consumerCaptor.capture())).thenReturn(sendResult);
+
+    JobDataMap jobData = new JobDataMap(Map.of(
+        "key1", "value1",
+        "key2", "value2",
+        "personId", "person123"
+    ));
+
+    service.sendJobToOutbox("job123", jobData);
+
+    Consumer<SqsSendOptions<JobDataMap>> consumer = consumerCaptor.getValue();
+    SqsSendOptions<JobDataMap> sendOptions = mock(SqsSendOptions.class, new TriesToReturnSelf());
+    consumer.accept(sendOptions);
+
+    verify(sendOptions).queue(OUTBOX_QUEUE);
+    verify(sendOptions).payload(jobData);
+    verify(sendOptions).messageDeduplicationId("job123");
+    verify(sendOptions).messageGroupId("person123");
+    verifyNoMoreInteractions(sendOptions);
+  }
+
+  @Test
+  void shouldReturnQueuedResultWhenSentJobToOutbox() {
+    SendResult<Object> sendResult = new SendResult<>(MESSAGE_ID, OUTBOX_QUEUE,
+        new GenericMessage<>(new Object()), Map.of());
+    when(sqsTemplate.send(any())).thenReturn(sendResult);
+
+    Map<String, String> result = service.sendJobToOutbox("job123", new JobDataMap());
+
+    assertThat("Unexpected result count.", result.keySet(), hasSize(1));
+    assertThat("Unexpected result status.", result.get("status"), is("queued " + MESSAGE_ID));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/UserAccountServiceIntegrationTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -72,6 +73,9 @@ class UserAccountServiceIntegrationTest {
 
   @MockBean
   private CognitoIdentityProviderClient cognitoClient;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
 
   @Mock
   private ListUsersIterable responses;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,6 +15,7 @@ application:
     gmc-updated: dummy-value
     ltft-updated: dummy-value
     ltft-updated-tpd: dummy-value
+    outbox: dummy-value
     placement-updated: dummy-value
     placement-deleted: dummy-value
     programme-membership-updated: dummy-value


### PR DESCRIPTION
# feat: queue emails in an outbox queue before send
Currently messages are sent instantly if either they qualify for non-scheduled sending (e.g. form confirmations) or a schedule was triggered.

Non-scheduled messages are generally sourced from a queue, so have retry available. But scheduled messages are not rescheduled on failure, so if the message is not sent the trigger is removed and never fires again. This results in "lost" messages which remain as "scheduled" in the database but are not scheduled in Quartz for sending.

Scheduled messages should be buffered in an "outbox" consisting of a message queue, which is read back in by this service. This allows the rate of sending to be throttled, retries to be applied more consistently and generally better monitoring and alerting to issues.

Existing failures will still need a separate migrator to replay their schedules.

TIS21-7421

---

# feat: create migrator for missed May emails

Several scheduled emails failed since May 2025 and were not retried or
rescheduled.
Query for the missed scheduled emails and re-schedule them over the
following 24 hours.

TIS21-7421