### PR TITLE
fix: handle null PM record fields

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.12.0"
+version = "2.12.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapper.java
@@ -62,6 +62,9 @@ public interface ProgrammeMembershipMapper {
    * @throws JsonProcessingException if curricula are malformed.
    */
   default List<Curriculum> toCurricula(String curriculumString) throws JsonProcessingException {
+    if (curriculumString == null) {
+      return List.of();
+    }
     ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -79,6 +82,9 @@ public interface ProgrammeMembershipMapper {
    */
   default ConditionsOfJoining toConditionsOfJoining(String cojString)
       throws JsonProcessingException {
+    if (cojString == null) {
+      return null;
+    }
     ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -96,6 +102,9 @@ public interface ProgrammeMembershipMapper {
    */
   default ResponsibleOfficer toResponsibleOfficer(String roString)
       throws JsonProcessingException {
+    if (roString == null) {
+      return null;
+    }
     ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/mapper/ProgrammeMembershipMapperTest.java
@@ -23,6 +23,7 @@ package uk.nhs.tis.trainee.notifications.mapper;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -31,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.nhs.tis.trainee.notifications.dto.CojPublishedEvent.ConditionsOfJoining;
 import uk.nhs.tis.trainee.notifications.dto.ProgrammeMembershipEvent;
 import uk.nhs.tis.trainee.notifications.dto.RecordDto;
@@ -75,6 +78,23 @@ class ProgrammeMembershipMapperTest {
     assertThat("Unexpected Conditions of joining.", returnedPm.getConditionsOfJoining(),
         is(new ConditionsOfJoining(COJ_SYNCED_AT)));
     assertThat("Unexpected Responsible Officer.", returnedPm.getResponsibleOfficer(), is(ro));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"curricula", "conditionsOfJoining", "responsibleOfficer"})
+  void shouldHandleNullOrMissingFieldsInMappingEntity(String fieldToNull)  {
+    Map<String, String> recordData = new HashMap<>();
+    recordData.put("tisId", TIS_ID);
+    recordData.put("startDate", START_DATE.toString());
+    recordData.put(fieldToNull, null);
+
+    ProgrammeMembership pm = mapper.toEntity(recordData);
+
+    assertThat("Unexpected Tis Id.", pm.getTisId(), is(TIS_ID));
+    assertThat("Unexpected start date.", pm.getStartDate(), is(START_DATE));
+    assertThat("Unexpected curricula.", pm.getCurricula(), is(List.of()));
+    assertThat("Unexpected Conditions of joining.", pm.getConditionsOfJoining(), is(nullValue()));
+    assertThat("Unexpected Responsible Officer.", pm.getResponsibleOfficer(), is(nullValue()));
   }
 
   /**


### PR DESCRIPTION
Consequent to https://github.com/Health-Education-England/tis-trainee-sync/pull/504

NO-TICKET