### PR TITLE
feat: endpoint to move history to new trainee

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.15.0"
+version = "2.16.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/api/HistoryResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/api/HistoryResource.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -79,5 +80,22 @@ public class HistoryResource {
 
     return message.map(msg -> ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(msg))
         .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  /**
+   * Move all notifications from one trainee to another.
+   *
+   * @param fromTraineeId The TIS ID of the trainee to move notifications from.
+   * @param toTraineeId   The TIS ID of the trainee to move notifications to.
+   * @return True if the notifications were moved.
+   */
+  @PatchMapping("/move/{fromTraineeId}/to/{toTraineeId}")
+  public ResponseEntity<Boolean> moveNotifications(@PathVariable String fromTraineeId,
+      @PathVariable String toTraineeId) {
+    log.info("Request to move notifications from trainee {} to trainee {}",
+        fromTraineeId, toTraineeId);
+
+    service.moveNotifications(fromTraineeId, toTraineeId);
+    return ResponseEntity.ok(true);
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
+import lombok.With;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -52,6 +53,7 @@ public record History(
     ObjectId id,
     TisReferenceInfo tisReference,
     NotificationType type,
+    @With
     RecipientInfo recipient,
     TemplateInfo template,
     List<StoredFile> attachments,

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -141,9 +141,9 @@ public class HistoryService {
   /**
    * Update the status of a notification, ensuring no retrograde event-driven changes.
    *
-   * @param history The notification history to update.
-   * @param status  The new status.
-   * @param detail  The detail of the status.
+   * @param history   The notification history to update.
+   * @param status    The new status.
+   * @param detail    The detail of the status.
    * @param timestamp The timestamp of the status update, if it is event-driven.
    * @return The updated notification history, or empty if not found.
    */
@@ -273,9 +273,9 @@ public class HistoryService {
   /**
    * Find all scheduled notifications for the given Trainee from DB.
    *
-   * @param traineeId The ID of the trainee to get notifications for.
+   * @param traineeId        The ID of the trainee to get notifications for.
    * @param tisReferenceType The reference type of the object.
-   * @param refId The reference ID of the TisReferenceType.
+   * @param refId            The reference ID of the TisReferenceType.
    * @return The found notifications, empty if none found.
    */
   public List<History> findAllScheduledForTrainee(
@@ -294,9 +294,9 @@ public class HistoryService {
   /**
    * Find scheduled email notification for the given Trainee by reference and type from DB.
    *
-   * @param traineeId The ID of the trainee to get notifications for.
+   * @param traineeId        The ID of the trainee to get notifications for.
    * @param tisReferenceType The reference type of the object.
-   * @param refId The reference ID of the TisReferenceType.
+   * @param refId            The reference ID of the TisReferenceType.
    * @param notificationType The notification Type of the notification.
    * @return The found notifications, empty if none found.
    */
@@ -316,9 +316,9 @@ public class HistoryService {
   /**
    * Find latest scheduled email notification for the given Trainee by reference and type from DB.
    *
-   * @param traineeId The ID of the trainee to get notifications for.
+   * @param traineeId        The ID of the trainee to get notifications for.
    * @param tisReferenceType The reference type of the object.
-   * @param refId The reference ID of the TisReferenceType.
+   * @param refId            The reference ID of the TisReferenceType.
    * @param notificationType The notification Type of the notification.
    * @return The found notifications, empty if none found.
    */
@@ -335,7 +335,7 @@ public class HistoryService {
   /**
    * Delete notification history by history ID and trainee ID.
    *
-   * @param id The object ID of the history to delete.
+   * @param id        The object ID of the history to delete.
    * @param traineeId The ID of the trainee to get notifications for.
    */
   public void deleteHistoryForTrainee(ObjectId id, String traineeId) {
@@ -445,6 +445,6 @@ public class HistoryService {
       this.save(h.withRecipient(newRecipient));
     });
     log.info("Moved {} notification histories from trainee [{}] to trainee [{}]",
-       histories.size(), fromTraineeId, toTraineeId);
+        histories.size(), fromTraineeId, toTraineeId);
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/api/HistoryResourceTest.java
@@ -22,8 +22,10 @@
 package uk.nhs.tis.trainee.notifications.api;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -157,5 +159,19 @@ class HistoryResourceTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.TEXT_HTML))
         .andExpect(content().string(message));
+  }
+
+  @Test
+  void shouldMoveNotificationsFromOneTraineeToAnother() throws Exception {
+    String fromTraineeId = "123";
+    String toTraineeId = "456";
+
+    mockMvc.perform(patch("/api/history/move/{fromTraineeId}/to/{toTraineeId}",
+            fromTraineeId, toTraineeId))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").value(true));
+
+    verify(service).moveNotifications(fromTraineeId, toTraineeId);
   }
 }


### PR DESCRIPTION
(assumed 'yes'):

```
Do we update the following Notification History field:

recipient.id

And leave these unchanged?

recipient.contact (email address)

template.variables.personId

template.variables.email

template.variables.hashedEmail

```
(assumed 'update all'):

`If the status != SENT or FAILED do we update them, or delete them (since presumably they are obsolete?)`

Downstream service effects: 
Published to tis-trainee_env}-notification-event SNS and picked up by 
* tis-trainee-forms-{env}-notification-event, but ignored as no change to the tpdEmailValidity
* tis-trainee-ndw-{env}-notification-event and updated data published to NDW

TIS21-7635