### PR TITLE
fix: foundation identification rule

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "3.8.0"
+version = "3.8.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -83,9 +83,9 @@ public class ProgrammeMembershipService {
   public static final Integer POG_ALL_NOTIFICATION_CUTOFF_WEEKS = 16;
 
   public static final List<String> INCLUDE_CURRICULUM_SUBTYPES
-      = List.of("MEDICAL_CURRICULUM", "MEDICAL_SPR");
+      = List.of("MEDICAL_CURRICULUM", "MEDICAL_SPR", "AFT");
 
-  public static final String ACADEMIC_FOUNDATION_CURRICULUM_NAME = "ACADEMIC FOUNDATION TRAINING";
+  public static final String FOUNDATION_CURRICULUM_SUBTYPE = "AFT";
   public static final String FOUNDATION_SPECIALTY = "FOUNDATION";
   public static final String PUBLIC_HEALTH_SPECIALTY = "Public Health Medicine";
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
@@ -26,11 +26,11 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_POG_MONTH_12;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_POG_MONTH_6;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_OWNER_FIELD;
-import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.FOUNDATION_CURRICULUM_SUBTYPE;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.CCT_DATE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.COJ_SYNCED_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.DEFERRAL_IF_MORE_THAN_DAYS;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.DESIGNATED_BODY_FIELD;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.FOUNDATION_CURRICULUM_SUBTYPE;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.FOUNDATION_SPECIALTY;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.INCLUDE_CURRICULUM_SUBTYPES;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.PERSON_ID_FIELD;

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
@@ -26,7 +26,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_POG_MONTH_12;
 import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_POG_MONTH_6;
 import static uk.nhs.tis.trainee.notifications.service.NotificationService.TEMPLATE_OWNER_FIELD;
-import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.ACADEMIC_FOUNDATION_CURRICULUM_NAME;
+import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.FOUNDATION_CURRICULUM_SUBTYPE;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.CCT_DATE_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.COJ_SYNCED_FIELD;
 import static uk.nhs.tis.trainee.notifications.service.ProgrammeMembershipService.DEFERRAL_IF_MORE_THAN_DAYS;
@@ -246,7 +246,7 @@ public class ProgrammeMembershipUtils {
    * programme membership.
    *
    * <p>This will be TRUE if none of the curricula have curriculumSubType = MEDICAL_CURRICULUM or
-   * MEDICAL_SPR.
+   * MEDICAL_SPR or AFT.
    * Note that specialtyName = 'Public health medicine' or 'Foundation' are no longer excluded.
    *
    * @param programmeMembership the Programme membership.
@@ -412,7 +412,7 @@ public class ProgrammeMembershipUtils {
 
   /**
    * Identify if a programme membership is a foundation programme, by checking if any of the
-   * curricula have a name or specialty indicating it's a foundation programme.
+   * curricula have a subtype or specialty indicating it's a foundation programme.
    *
    * @param programmeMembership The programme membership to check.
    * @return true if the programme membership is a foundation programme, otherwise false.
@@ -420,9 +420,9 @@ public class ProgrammeMembershipUtils {
   public static boolean isFoundationProgramme(ProgrammeMembership programmeMembership) {
     return programmeMembership.getCurricula().stream()
         .anyMatch(curriculum -> {
-          String name = curriculum.curriculumName();
+          String subtype = curriculum.curriculumSubType();
           String specialty = curriculum.curriculumSpecialty();
-          return (name != null && (name.equalsIgnoreCase(ACADEMIC_FOUNDATION_CURRICULUM_NAME))
+          return (subtype != null && (subtype.equalsIgnoreCase(FOUNDATION_CURRICULUM_SUBTYPE))
               || (specialty != null && specialty.equalsIgnoreCase(FOUNDATION_SPECIALTY)));
         });
   }

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtilsTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtilsTest.java
@@ -88,6 +88,7 @@ class ProgrammeMembershipUtilsTest {
 
   private static final String MEDICAL_CURRICULUM_1 = "Medical_curriculum";
   private static final String MEDICAL_CURRICULUM_2 = "Medical_spr";
+  private static final String MEDICAL_CURRICULUM_3 = "AFT";
   private static final String INCLUDED_SPECIALTY_1 = "some-specialty";
   private static final String INCLUDED_SPECIALTY_2 = "Public Health Medicine";
   private static final LocalDate START_DATE = LocalDate.now().plusYears(1);
@@ -129,7 +130,7 @@ class ProgrammeMembershipUtilsTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {MEDICAL_CURRICULUM_1, MEDICAL_CURRICULUM_2})
+  @ValueSource(strings = {MEDICAL_CURRICULUM_1, MEDICAL_CURRICULUM_2, MEDICAL_CURRICULUM_3})
   void shouldNotExcludePmWithMedicalSubtypeAndNoExcludedSpecialties(String subtype) {
     Curriculum theCurriculum = new Curriculum(CURRICULUM_NAME, subtype, "INCLUDED_SPECIALTY_1",
         false, CURRICULUM_END_DATE, null);
@@ -1194,14 +1195,14 @@ class ProgrammeMembershipUtilsTest {
   }
 
   @Test
-  void shouldNotBeFoundationProgrammeWhenBothCurriculumNameAndSpecialtyIsNull() {
+  void shouldNotBeFoundationProgrammeWhenBothCurriculumSpecialtyAndSubtypeIsNull() {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setCurricula(List.of(
-        new Curriculum(null, MEDICAL_CURRICULUM_1, null, false, CURRICULUM_END_DATE,
+        new Curriculum(CURRICULUM_NAME, null, null, false, CURRICULUM_END_DATE,
             null)));
 
     assertThat("Unexpected foundation programme flag.",
-        service.isFoundationProgramme(programmeMembership), is(false));
+        isFoundationProgramme(programmeMembership), is(false));
   }
 
   @ParameterizedTest
@@ -1221,13 +1222,13 @@ class ProgrammeMembershipUtilsTest {
 
   @ParameterizedTest
   @CsvSource(textBlock = """
-      academic foundation training
-      ACADEMIC FOUNDATION TRAINING
-      Academic Foundation Training""")
-  void shouldBeFoundationProgrammeWhenCurriculumNameIsAcademicFoundationTraining(String name) {
+      aft
+      AFT
+      """)
+  void shouldBeFoundationProgrammeWhenCurriculumSubtypeIsAft(String subtype) {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setCurricula(List.of(
-        new Curriculum(name, MEDICAL_CURRICULUM_1, null, false, CURRICULUM_END_DATE,
+        new Curriculum(null, subtype, null, false, CURRICULUM_END_DATE,
             null)));
 
     assertThat("Unexpected foundation programme flag.",


### PR DESCRIPTION
Ensure foundation programmes receive notifications if 'AFT' subtype.

Related: https://github.com/Health-Education-England/tis-trainee-details/pull/576 

TIS21-8503