### PR TITLE
fix: tweaks to LTFT TPD notifications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "3.8.2"
+version = "3.8.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/dto/LtftUpdateEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/dto/LtftUpdateEvent.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
@@ -46,6 +47,7 @@ public class LtftUpdateEvent {
   private ProgrammeMembershipDto programmeMembership;
   private DiscussionsDto discussions;
   private ChangeDto change;
+  private ReasonsDto reasons;
   private String state;
   private Instant timestamp;
   private LftfStatusInfoDetailDto stateDetail;
@@ -65,9 +67,23 @@ public class LtftUpdateEvent {
    *
    * @param startDate The start date of the LTFT change.
    * @param wte       The whole time equivalent being requested.
-   * @param cctDate   The CCT/end of programme date..
+   * @param cctDate   The CCT/end of programme date.
    */
   public record ChangeDto(LocalDate startDate, Double wte, LocalDate cctDate) {
+
+  }
+
+  /**
+   * Reasons for the LTFT change.
+   *
+   * @param selected              A list of the selected reasons for the LTFT change.
+   * @param otherDetail           Details of the "other" reason, if "other" is selected.
+   * @param supportingInformation Any supporting information provided by the trainee.
+   */
+  public record ReasonsDto(
+      List<String> selected,
+      String otherDetail,
+      String supportingInformation) {
 
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,7 +75,7 @@ application:
     ltft-approved:
       email: v1.0.2
     ltft-approved-tpd:
-      email: v1.0.1
+      email: v1.0.2
     ltft-rejected:
       email: v1.0.0
     ltft-rejected-tpd:
@@ -83,7 +83,7 @@ application:
     ltft-submitted:
       email: v1.1.0
     ltft-submitted-tpd:
-      email: v1.0.1
+      email: v1.0.2
     ltft-unsubmitted:
       email: v1.0.0
     ltft-updated:

--- a/src/main/resources/templates/email/ltft-approved-tpd/v1.0.2.html
+++ b/src/main/resources/templates/email/ltft-approved-tpd/v1.0.2.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>LTFT Approved</title>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">Notification for Changing hours (LTFT) Application Approval for <th:block th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</th:block> (<th:block th:text="${not #strings.isEmpty(var?.formRef)} ? ${var.formRef} : 'unknown form reference'"></th:block>)
+</th:block><h2>Content</h2>
+<th:block th:fragment="content" th:with="subjectRefs = |GMC: ${not #strings.isEmpty(var?.personalDetails?.gmcNumber) ? var.personalDetails.gmcNumber : 'unknown'}, LTFT Ref No: ${not #strings.isEmpty(var?.formRef) ? var.formRef : 'unknown'}|">
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
+  <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+  <p>Dear <span th:text="${not #strings.isEmpty(var?.discussions?.tpdName)} ? |${var.discussions.tpdName}| : _">Training Programme Director</span>,</p>
+  <p>
+    An application to change working hours (LTFT) has been approved for the Resident Doctor below.
+  </p>
+  <p>
+    You are receiving this notification because your details were included in the application as part of the discussion about the proposed change.
+  </p>
+  <p>
+    <b>Summary:</b> <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span
+  > applied to change their working hours from <b><span th:text="${not #strings.isEmpty(var?.programmeMembership?.wte)} ? ${var.programmeMembership.wte} : 'unknown'"></span
+  > WTE to <span th:text="${not #strings.isEmpty(var?.change?.wte)} ? ${var.change.wte} : 'unknown'"></span
+  > WTE starting <span th:text="${not #strings.isEmpty(var?.change?.startDate)} ? ${#temporals.format(var.change.startDate, 'd MMMM yyyy')} : 'unknown'"></span
+  ></b>. This has been approved.
+  </p>
+  <p>
+    <b>Resident Doctor</b>
+  </p>
+  <ul>
+    <li>Name: <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span></li>
+    <li>GMC registration no: <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block></li>
+  </ul>
+  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte})}"></div>
+  <p>If you have any questions about this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
+    <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Submitted - Enquiries - ${subjectRefs}|)}"></th:block>
+  </th:block>
+  </p>
+  <p>
+    Kind Regards,
+  </p>
+  <p>
+    <th:block th:text="${not #strings.isEmpty(var?.programmeMembership?.managingDeanery)} ? |NHS England - ${var.programmeMembership.managingDeanery}| : 'Your Local Office'"></th:block>
+  </p>
+  <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/email/ltft-approved-tpd/v1.0.2.html
+++ b/src/main/resources/templates/email/ltft-approved-tpd/v1.0.2.html
@@ -33,7 +33,7 @@
     <li>Name: <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span></li>
     <li>GMC registration no: <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block></li>
   </ul>
-  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte})}"></div>
+  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte}, ${var?.get('reasons')})}"></div>
   <p>If you have any questions about this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
     <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Submitted - Enquiries - ${subjectRefs}|)}"></th:block>
   </th:block>

--- a/src/main/resources/templates/email/ltft-approved-tpd/v1.0.2.html
+++ b/src/main/resources/templates/email/ltft-approved-tpd/v1.0.2.html
@@ -33,7 +33,7 @@
     <li>Name: <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span></li>
     <li>GMC registration no: <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block></li>
   </ul>
-  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte}, ${var?.get('reasons')})}"></div>
+  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte}, ${var?.reasons})}"></div>
   <p>If you have any questions about this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
     <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Submitted - Enquiries - ${subjectRefs}|)}"></th:block>
   </th:block>

--- a/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.2.html
+++ b/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.2.html
@@ -34,7 +34,7 @@
     <li>Name: <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span></li>
     <li>GMC registration no: <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block></li>
   </ul>
-  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte})}"></div>
+  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte}, ${var?.get('reasons')})}"></div>
   <p>If you have any questions about this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
     <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Submitted - Enquiries - ${subjectRefs}|)}"></th:block>
   </th:block>

--- a/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.2.html
+++ b/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.2.html
@@ -34,7 +34,7 @@
     <li>Name: <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span></li>
     <li>GMC registration no: <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block></li>
   </ul>
-  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte}, ${var?.get('reasons')})}"></div>
+  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte}, ${var?.reasons})}"></div>
   <p>If you have any questions about this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
     <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Submitted - Enquiries - ${subjectRefs}|)}"></th:block>
   </th:block>

--- a/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.2.html
+++ b/src/main/resources/templates/email/ltft-submitted-tpd/v1.0.2.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>LTFT Submitted</title>
+</head>
+<body>
+<h1>Email Message</h1>
+<h2>Subject</h2>
+<th:block th:fragment="subject">
+  Notification for Changing hours (LTFT) Application Submission received from <th:block th:text="${not #strings.isEmpty(familyName)} ? |Dr ${familyName}| : _">Doctor</th:block> (<th:block th:text="${not #strings.isEmpty(var?.formRef)} ? ${var.formRef} : 'unknown form reference'"></th:block>)
+</th:block><h2>Content</h2>
+<th:block th:fragment="content" th:with="subjectRefs = |GMC: ${not #strings.isEmpty(var?.personalDetails?.gmcNumber) ? var.personalDetails.gmcNumber : 'unknown'}, LTFT Ref No: ${not #strings.isEmpty(var?.formRef) ? var.formRef : 'unknown'}|">
+  <div th:replace="fragments/retry/v1.0.0 :: retry(${originallySentOn})"></div>
+  <div style="text-align:right"><img style="margin-right:25px; height:100px" src='https://trainee.tis.nhs.uk/nhse-logo.png' alt="NHS England logo"/></div>
+  <p>Dear <span th:text="${not #strings.isEmpty(var?.discussions?.tpdName)} ? |${var.discussions.tpdName}| : _">Training Programme Director</span>,</p>
+  <p>
+    An application to change working hours (LTFT) has been submitted for the Resident Doctor below.
+  </p>
+  <p>
+    You are receiving this notification because your details were included in the application as part of the discussion about the proposed change.
+  </p>
+  <p>
+    <b>Summary:</b> <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span
+    > has applied to change their working hours from <b><span th:text="${not #strings.isEmpty(var?.programmeMembership?.wte)} ? ${var.programmeMembership.wte} : 'unknown'"></span
+    > WTE to <span th:text="${not #strings.isEmpty(var?.change?.wte)} ? ${var.change.wte} : 'unknown'"></span
+    > WTE starting <span th:text="${not #strings.isEmpty(var?.change?.startDate)} ? ${#temporals.format(var.change.startDate, 'd MMMM yyyy')} : 'unknown'"></span
+    ></b>.
+  </p>
+  <p>
+    <b>Resident Doctor</b>
+  </p>
+  <ul>
+    <li>Name: <span th:text="${not #strings.isEmpty(title)} ? ${title} : 'Dr'"></span> <span th:text="${not #strings.isEmpty(givenName)} ? ${givenName} : _"></span> <span th:text="${not #strings.isEmpty(familyName)} ? ${familyName} : _"></span></li>
+    <li>GMC registration no: <th:block th:text="${not #strings.isEmpty(var?.personalDetails?.gmcNumber)} ? ${var.personalDetails.gmcNumber} : 'unknown'"></th:block></li>
+  </ul>
+  <div th:replace="~{fragments/ltft-summary-tpd/v1.0.0 :: ltftSummaryTpd(${var?.programmeMembership?.name}, ${var?.programmeMembership?.startDate}, ${var?.programmeMembership?.wte}, ${var?.change?.startDate}, ${var?.change?.cctDate}, ${var?.change?.wte})}"></div>
+  <p>If you have any questions about this application, <th:block th:with="contact = ${contacts?.get('LTFT_SUPPORT')}">
+    <th:block th:replace="~{fragments/link/v1.0.0 :: link(${contact?.contact}, ${contact?.type}, 'please click on the following link for Local Office Support. ', ${contact?.contact}, '', 'please contact your <strong>Local Office Support team.</strong>', |Ltft Submitted - Enquiries - ${subjectRefs}|)}"></th:block>
+  </th:block>
+  </p>
+  <p>
+    Kind Regards,
+  </p>
+  <p>
+    <th:block th:text="${not #strings.isEmpty(var?.programmeMembership?.managingDeanery)} ? |NHS England - ${var.programmeMembership.managingDeanery}| : 'Your Local Office'"></th:block>
+  </p>
+  <div th:replace="fragments/disclaimer/v1.0.0 :: body"></div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/ltft-summary-tpd/v1.0.0.html
+++ b/src/main/resources/templates/fragments/ltft-summary-tpd/v1.0.0.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>LTFT summary</title>
+</head>
+<body>
+<div th:fragment="ltftSummaryTpd(programme, startDate, currentWte, changeStartDate, changeCctDate, newWte)">
+  <p><b>Current programme details</b></p>
+  <ul>
+    <li>Programme: <th:block th:text="${not #strings.isEmpty(programme)} ? ${programme} : 'unknown'"></th:block></li>
+    <li>Programme start date: <th:block th:text="${startDate}? ${#temporals.format(startDate, 'd MMMM yyyy')} : _">unknown</th:block></li>
+    <li>Current working hours: <th:block th:text="${not #strings.isEmpty(currentWte)} ? ${currentWte} : 'unknown'"></th:block> WTE</li>
+  </ul>
+  <p><b>Proposed change</b></p>
+  <ul>
+    <li>New working hours: <th:block th:text="${not #strings.isEmpty(newWte)} ? ${newWte} : 'unknown'"></th:block> WTE</li>
+    <li>Effective from: <th:block th:text="${startDate}? ${#temporals.format(changeStartDate, 'd MMMM yyyy')} : _">unknown</th:block></li>
+    <li>Reason for change: TODO</li>
+  </ul>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/ltft-summary-tpd/v1.0.0.html
+++ b/src/main/resources/templates/fragments/ltft-summary-tpd/v1.0.0.html
@@ -5,7 +5,7 @@
   <title>LTFT summary</title>
 </head>
 <body>
-<div th:fragment="ltftSummaryTpd(programme, startDate, currentWte, changeStartDate, changeCctDate, newWte)">
+<div th:fragment="ltftSummaryTpd(programme, startDate, currentWte, changeStartDate, changeCctDate, newWte, reasons)">
   <p><b>Current programme details</b></p>
   <ul>
     <li>Programme: <th:block th:text="${not #strings.isEmpty(programme)} ? ${programme} : 'unknown'"></th:block></li>
@@ -16,7 +16,12 @@
   <ul>
     <li>New working hours: <th:block th:text="${not #strings.isEmpty(newWte)} ? ${newWte} : 'unknown'"></th:block> WTE</li>
     <li>Effective from: <th:block th:text="${startDate}? ${#temporals.format(changeStartDate, 'd MMMM yyyy')} : _">unknown</th:block></li>
-    <li>Reason for change: TODO</li>
+    <li>Reason(s) for change:
+      <ul th:if="${reasons != null and reasons.selected != null}">
+        <li th:each="reason : ${reasons.selected}"><th:block th:text="${reason}"></th:block
+        ><th:block th:if="${reason == 'Other' and reasons.otherDetail != null and not #strings.isEmpty(reasons.otherDetail)}" th:text="': ' + ${reasons.otherDetail}"></th:block></li>
+      </ul>
+    </li>
   </ul>
 </div>
 </body>

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerIntegrationTest.java
@@ -836,9 +836,9 @@ class LtftListenerIntegrationTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', textBlock = """
-      APPROVED  | LTFT_APPROVED_TPD  | v1.0.1
+      APPROVED  | LTFT_APPROVED_TPD  | v1.0.2
       REJECTED  | LTFT_REJECTED_TPD  | v1.0.0
-      SUBMITTED | LTFT_SUBMITTED_TPD | v1.0.1
+      SUBMITTED | LTFT_SUBMITTED_TPD | v1.0.2
       """)
   void shouldStoreTpdNotificationHistoryWhenMessageSent(String state, NotificationType type,
       String expectedVersion) throws JsonProcessingException {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/event/LtftListenerIntegrationTest.java
@@ -719,6 +719,14 @@ class LtftListenerIntegrationTest {
             "wte": 0.5,
             "cctDate": "2027-06-05"
           },
+          "reasons": {
+            "selected": [
+            "Training / career development",
+            "Non-medical development"
+            ],
+            "otherDetail": "",
+            "supportingInformation": "some supporting information"
+          },
           "status": {
             "current" : {
               "state": "%s",
@@ -796,6 +804,14 @@ class LtftListenerIntegrationTest {
             "startDate": "2025-04-03",
             "wte": 0.5,
             "cctDate": "2027-06-05"
+          },
+          "reasons": {
+            "selected": [
+            "Training / career development",
+            "Other"
+            ],
+            "otherDetail": "I just need a break from training",
+            "supportingInformation": "some supporting information"
           },
           "status": {
             "current" : {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -245,7 +245,7 @@ class EmailServiceIntegrationTest {
     variables.put("modifiedByName", "modified by name");
     variables.put("formName", "form name");
     variables.put("discussions", Map.of("tpdName", "TPD name"));
-    variables.put("programmeMembership", Map.of("startDate", "2024-01-01",
+    variables.put("programmeMembership", Map.of("startDate", LocalDate.parse("2024-01-01"),
             "name", "PM name", "wte", 1.0, "managingDeanery", "MD name"));
     variables.put("personalDetails", Map.of("gmcNumber", "1234567"));
     variables.put("change", Map.of("startDate", LocalDate.parse("2024-01-01"), "wte", 0.5,

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/EmailServiceIntegrationTest.java
@@ -58,6 +58,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -250,6 +251,7 @@ class EmailServiceIntegrationTest {
     variables.put("personalDetails", Map.of("gmcNumber", "1234567"));
     variables.put("change", Map.of("startDate", LocalDate.parse("2024-01-01"), "wte", 0.5,
         "cctDate", LocalDate.parse("2024-01-01")));
+    variables.put("reasons", Map.of("selected", List.of("reason 1", "reason 2")));
     variables.put("stateDetail", Map.of("reason", "some reason", "message", "some message"));
     variables.put("modifiedBy", Map.of("name", "modified by name", "role", "modified by role"));
 

--- a/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
@@ -5,30 +5,29 @@
   <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Mr TPD</span>,</p>
-<p>We would like to inform you that we have approved Changing hours (LTFT) application for Dr Gilliam, 1234567 on 4 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the approved application:</p>
-<table style="width:100%" border="1">
-  <tr>
-    <th>Programme</th>
-    <td>General Practice</td>
-  </tr>
-  <tr>
-    <th>Start Date</th>
-    <td>3 April 2025</td>
-  </tr>
-  <tr>
-    <th>Anticipated End Date</th>
-    <td>5 June 2027</td>
-  </tr>
-  <tr>
-    <th>Current WTE %</th>
-    <td>1.0</td>
-  </tr>
-  <tr>
-    <th>New WTE %</th>
-    <td>0.5</td>
-  </tr>
-</table>
-<p>If you have any queries regarding this application, please click on the following link for Local Office Support. <a href="mailto:LTFT_SUPPORT@example.com?subject=Ltft Approved - Enquiries - GMC: 1234567, LTFT Ref No: ltft_47165_001" target="_blank">LTFT_SUPPORT@example.com</a></p>
+<p>An application to change working hours (LTFT) has been approved for the Resident Doctor below.</p>
+<p>You are receiving this notification because your details were included in the application as part of the discussion about the proposed change.</p>
+<p><b>Summary:</b> <span>Dr</span> <span>Anthony</span> <span>Gilliam</span> applied to change their working hours from <b><span>1.0</span> WTE to <span>0.5</span> WTE starting <span>3 April 2025</span></b>. This has been approved.</p>
+<p><b>Resident Doctor</b></p>
+<ul>
+  <li>Name: <span>Dr</span> <span>Anthony</span> <span>Gilliam</span></li>
+  <li>GMC registration no: 1234567</li>
+</ul>
+<div>
+  <p><b>Current programme details</b></p>
+  <ul>
+    <li>Programme: General Practice</li>
+    <li>Programme start date: 3 January 2025</li>
+    <li>Current working hours: 1.0 WTE</li>
+  </ul>
+  <p><b>Proposed change</b></p>
+  <ul>
+    <li>New working hours: 0.5 WTE</li>
+    <li>Effective from: 3 April 2025</li>
+    <li>Reason for change: TODO</li>
+  </ul>
+</div>
+<p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="mailto:LTFT_SUPPORT@example.com?subject=Ltft Submitted - Enquiries - GMC: 1234567, LTFT Ref No: ltft_47165_001" target="_blank">LTFT_SUPPORT@example.com</a></p>
 <p>Kind Regards,</p>
 <p>NHS England - North West</p>
 <hr>

--- a/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-email-contacts.html
@@ -24,7 +24,12 @@
   <ul>
     <li>New working hours: 0.5 WTE</li>
     <li>Effective from: 3 April 2025</li>
-    <li>Reason for change: TODO</li>
+    <li>Reason(s) for change:
+      <ul>
+        <li>Training / career development</li>
+        <li>Other: I just need a break from training</li>
+      </ul>
+    </li>
   </ul>
 </div>
 <p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="mailto:LTFT_SUPPORT@example.com?subject=Ltft Submitted - Enquiries - GMC: 1234567, LTFT Ref No: ltft_47165_001" target="_blank">LTFT_SUPPORT@example.com</a></p>

--- a/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
 <div style="text-align:right">
-    <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
+  <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Mr TPD</span>,</p>
 <p>An application to change working hours (LTFT) has been approved for the Resident Doctor below.</p>
@@ -24,7 +24,12 @@
     <ul>
         <li>New working hours: 0.5 WTE</li>
         <li>Effective from: 3 April 2025</li>
-        <li>Reason for change: TODO</li>
+        <li>Reason(s) for change:
+        <ul>
+            <li>Training / career development</li>
+            <li>Non-medical development</li>
+        </ul>
+        </li>
     </ul>
 </div>
 <p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="https://test/LTFT_SUPPORT" target="_blank">https://test/LTFT_SUPPORT</a></p>

--- a/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-approved-tpd-full-url-contacts.html
@@ -2,33 +2,32 @@
 <head></head>
 <body>
 <div style="text-align:right">
-  <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
+    <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Mr TPD</span>,</p>
-<p>We would like to inform you that we have approved Changing hours (LTFT) application for Dr Gilliam, 1234567 on 4 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the approved application:</p>
-<table style="width:100%" border="1">
-  <tr>
-    <th>Programme</th>
-    <td>General Practice</td>
-  </tr>
-  <tr>
-    <th>Start Date</th>
-    <td>3 April 2025</td>
-  </tr>
-  <tr>
-    <th>Anticipated End Date</th>
-    <td>5 June 2027</td>
-  </tr>
-  <tr>
-    <th>Current WTE %</th>
-    <td>1.0</td>
-  </tr>
-  <tr>
-    <th>New WTE %</th>
-    <td>0.5</td>
-  </tr>
-</table>
-<p>If you have any queries regarding this application, please click on the following link for Local Office Support. <a href="https://test/LTFT_SUPPORT" target="_blank">https://test/LTFT_SUPPORT</a></p>
+<p>An application to change working hours (LTFT) has been approved for the Resident Doctor below.</p>
+<p>You are receiving this notification because your details were included in the application as part of the discussion about the proposed change.</p>
+<p><b>Summary:</b> <span>Dr</span> <span>Anthony</span> <span>Gilliam</span> applied to change their working hours from <b><span>1.0</span> WTE to <span>0.5</span> WTE starting <span>3 April 2025</span></b>. This has been approved.</p>
+<p><b>Resident Doctor</b></p>
+<ul>
+    <li>Name: <span>Dr</span> <span>Anthony</span> <span>Gilliam</span></li>
+    <li>GMC registration no: 1234567</li>
+</ul>
+<div>
+    <p><b>Current programme details</b></p>
+    <ul>
+        <li>Programme: General Practice</li>
+        <li>Programme start date: 3 January 2025</li>
+        <li>Current working hours: 1.0 WTE</li>
+    </ul>
+    <p><b>Proposed change</b></p>
+    <ul>
+        <li>New working hours: 0.5 WTE</li>
+        <li>Effective from: 3 April 2025</li>
+        <li>Reason for change: TODO</li>
+    </ul>
+</div>
+<p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="https://test/LTFT_SUPPORT" target="_blank">https://test/LTFT_SUPPORT</a></p>
 <p>Kind Regards,</p>
 <p>NHS England - North West</p>
 <hr>

--- a/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
@@ -5,30 +5,29 @@
   <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Mr TPD</span>,</p>
-<p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 4 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
-<table style="width:100%" border="1">
-  <tr>
-    <th>Programme</th>
-    <td>General Practice</td>
-  </tr>
-  <tr>
-    <th>Start Date</th>
-    <td>3 April 2025</td>
-  </tr>
-  <tr>
-    <th>Anticipated End Date</th>
-    <td>5 June 2027</td>
-  </tr>
-  <tr>
-    <th>Current WTE %</th>
-    <td>1.0</td>
-  </tr>
-  <tr>
-    <th>New WTE %</th>
-    <td>0.5</td>
-  </tr>
-</table>
-<p>If you have any queries regarding this application, please click on the following link for Local Office Support. <a href="mailto:LTFT_SUPPORT@example.com?subject=Ltft Submitted - Enquiries - GMC: 1234567, LTFT Ref No: ltft_47165_001" target="_blank">LTFT_SUPPORT@example.com</a></p>
+<p>An application to change working hours (LTFT) has been submitted for the Resident Doctor below.</p>
+<p>You are receiving this notification because your details were included in the application as part of the discussion about the proposed change.</p>
+<p><b>Summary:</b> <span>Dr</span> <span>Anthony</span> <span>Gilliam</span> has applied to change their working hours from <b><span>1.0</span> WTE to <span>0.5</span> WTE starting <span>3 April 2025</span></b>.</p>
+<p><b>Resident Doctor</b></p>
+<ul>
+  <li>Name: <span>Dr</span> <span>Anthony</span> <span>Gilliam</span></li>
+  <li>GMC registration no: 1234567</li>
+</ul>
+<div>
+  <p><b>Current programme details</b></p>
+  <ul>
+    <li>Programme: General Practice</li>
+    <li>Programme start date: 3 January 2025</li>
+    <li>Current working hours: 1.0 WTE</li>
+  </ul>
+  <p><b>Proposed change</b></p>
+  <ul>
+    <li>New working hours: 0.5 WTE</li>
+    <li>Effective from: 3 April 2025</li>
+    <li>Reason for change: TODO</li>
+  </ul>
+</div>
+<p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="mailto:LTFT_SUPPORT@example.com?subject=Ltft Submitted - Enquiries - GMC: 1234567, LTFT Ref No: ltft_47165_001" target="_blank">LTFT_SUPPORT@example.com</a></p>
 <p>Kind Regards,</p>
 <p>NHS England - North West</p>
 <hr>

--- a/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-email-contacts.html
@@ -24,7 +24,12 @@
   <ul>
     <li>New working hours: 0.5 WTE</li>
     <li>Effective from: 3 April 2025</li>
-    <li>Reason for change: TODO</li>
+    <li>Reason(s) for change:
+      <ul>
+        <li>Training / career development</li>
+        <li>Other: I just need a break from training</li>
+      </ul>
+    </li>
   </ul>
 </div>
 <p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="mailto:LTFT_SUPPORT@example.com?subject=Ltft Submitted - Enquiries - GMC: 1234567, LTFT Ref No: ltft_47165_001" target="_blank">LTFT_SUPPORT@example.com</a></p>

--- a/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
@@ -5,30 +5,29 @@
   <img style="margin-right:25px; height:100px" src="https://trainee.tis.nhs.uk/nhse-logo.png" alt="NHS England logo">
 </div>
 <p>Dear <span>Mr TPD</span>,</p>
-<p>We would like to inform you that we have received Changing hours (LTFT) application for Dr Gilliam, 1234567 on 4 May 2026. Your details were provided in the application as you have been part of discussions for the proposed hours. Please see below summary of the application:</p>
-<table style="width:100%" border="1">
-  <tr>
-    <th>Programme</th>
-    <td>General Practice</td>
-  </tr>
-  <tr>
-    <th>Start Date</th>
-    <td>3 April 2025</td>
-  </tr>
-  <tr>
-    <th>Anticipated End Date</th>
-    <td>5 June 2027</td>
-  </tr>
-  <tr>
-    <th>Current WTE %</th>
-    <td>1.0</td>
-  </tr>
-  <tr>
-    <th>New WTE %</th>
-    <td>0.5</td>
-  </tr>
-</table>
-<p>If you have any queries regarding this application, please click on the following link for Local Office Support. <a href="https://test/LTFT_SUPPORT" target="_blank">https://test/LTFT_SUPPORT</a></p>
+<p>An application to change working hours (LTFT) has been submitted for the Resident Doctor below.</p>
+<p>You are receiving this notification because your details were included in the application as part of the discussion about the proposed change.</p>
+<p><b>Summary:</b> <span>Dr</span> <span>Anthony</span> <span>Gilliam</span> has applied to change their working hours from <b><span>1.0</span> WTE to <span>0.5</span> WTE starting <span>3 April 2025</span></b>.</p>
+<p><b>Resident Doctor</b></p>
+<ul>
+  <li>Name: <span>Dr</span> <span>Anthony</span> <span>Gilliam</span></li>
+  <li>GMC registration no: 1234567</li>
+</ul>
+<div>
+  <p><b>Current programme details</b></p>
+  <ul>
+    <li>Programme: General Practice</li>
+    <li>Programme start date: 3 January 2025</li>
+    <li>Current working hours: 1.0 WTE</li>
+  </ul>
+  <p><b>Proposed change</b></p>
+  <ul>
+    <li>New working hours: 0.5 WTE</li>
+    <li>Effective from: 3 April 2025</li>
+    <li>Reason for change: TODO</li>
+  </ul>
+</div>
+<p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="https://test/LTFT_SUPPORT" target="_blank">https://test/LTFT_SUPPORT</a></p>
 <p>Kind Regards,</p>
 <p>NHS England - North West</p>
 <hr>

--- a/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
+++ b/src/test/resources/email/ltft-submitted-tpd-full-url-contacts.html
@@ -24,7 +24,12 @@
   <ul>
     <li>New working hours: 0.5 WTE</li>
     <li>Effective from: 3 April 2025</li>
-    <li>Reason for change: TODO</li>
+    <li>Reason(s) for change:
+      <ul>
+        <li>Training / career development</li>
+        <li>Non-medical development</li>
+      </ul>
+    </li>
   </ul>
 </div>
 <p>If you have any questions about this application, please click on the following link for Local Office Support. <a href="https://test/LTFT_SUPPORT" target="_blank">https://test/LTFT_SUPPORT</a></p>


### PR DESCRIPTION
Only submitted and approved, not rejected.

Trainee LTFT notifications left as-is.

Reasons section now included, as well as 'Other: [other detail]' logic. Examples on https://hee-tis.atlassian.net/browse/TIS21-8329

TIS21-8329