### PR TITLE
fix: remove cruft from URLs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "3.8.5"
+version = "3.8.6"
 
 configurations {
   compileOnly {

--- a/src/main/resources/templates/in-app/day-one-foundation/v1.0.0.html
+++ b/src/main/resources/templates/in-app/day-one-foundation/v1.0.0.html
@@ -28,7 +28,7 @@
         and Designated body (<span th:text="${not #strings.isEmpty(designatedBody)} ? ${designatedBody} : _">designated body missing</span>) via your GMC Online account on the day you start your new Training programme.
       </p>
       <p>
-        Please go to your <a href="https://gbr01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gmc-uk.org%2Fgmc-online-dashboard&data=05%7C02%7Cnazia.akhtar20%40nhs.net%7Cef03ee51fa0545a5b35e08dcbc4a7567%7C37c354b285b047f5b22207b48d774ee3%7C0%7C0%7C638592275182280352%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=LzFNfdmdmSCG%2BLG%2Fzl7K%2FolrnQygSB2wLGjWbZEcZg4%3D&reserved=0" th:target="_blank">
+        Please go to your <a href="https://www.gmc-uk.org/gmc-online-dashboard" th:target="_blank">
         GMC Online sign in page</a> and log in using your GMC reference number. Once you have logged in go to ‘My Revalidation’ click ‘Add Designated Body’ and enter <span th:text="${not #strings.isEmpty(designatedBody)} ? ${designatedBody} : _"> your designated body name</span> as your designated body.
       </p>
       <p>

--- a/src/main/resources/templates/in-app/day-one/v1.1.0.html
+++ b/src/main/resources/templates/in-app/day-one/v1.1.0.html
@@ -28,7 +28,7 @@
         and Designated body (<span th:text="${not #strings.isEmpty(designatedBody)} ? ${designatedBody} : _">designated body missing</span>) via your GMC Online account on the day you start your new Training programme.
       </p>
       <p>
-        Please go to your <a href="https://gbr01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.gmc-uk.org%2Fgmc-online-dashboard&data=05%7C02%7Cnazia.akhtar20%40nhs.net%7Cef03ee51fa0545a5b35e08dcbc4a7567%7C37c354b285b047f5b22207b48d774ee3%7C0%7C0%7C638592275182280352%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=LzFNfdmdmSCG%2BLG%2Fzl7K%2FolrnQygSB2wLGjWbZEcZg4%3D&reserved=0" th:target="_blank">
+        Please go to your <a href="https://www.gmc-uk.org/gmc-online-dashboard" th:target="_blank">
         GMC Online sign in page</a> and log in using your GMC reference number. Once you have logged in go to ‘My Revalidation’ click ‘Add Designated Body’ and enter <span th:text="${not #strings.isEmpty(designatedBody)} ? ${designatedBody} : _"> your designated body name</span> as your designated body.
       </p>
       <p>


### PR DESCRIPTION
In in-app notifications for GMC dashboard. No version bump on templates because 'possibly not a real change?' - but can be persuaded otherwise.

NO-TICKET