### PR TITLE
fix: retry blocked email notifications 2026

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "3.8.6"
+version = "3.9.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures2026.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures2026.java
@@ -1,0 +1,193 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static java.time.ZoneOffset.UTC;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.COJ_CONFIRMATION;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.EMAIL_UPDATED_NEW;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.EMAIL_UPDATED_OLD;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_SUBMITTED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.FORM_UPDATED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.LTFT_APPROVED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.LTFT_SUBMITTED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PLACEMENT_UPDATED_WEEK_12_FOUNDATION;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_CREATED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_POG_MONTH_12;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.PROGRAMME_UPDATED_WEEK_12;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.service.EmailService;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+import uk.nhs.tis.trainee.notifications.service.NotificationService;
+
+/**
+ * Resend email notifications that failed on the 13th and 14th May 2026.
+ */
+@Slf4j
+@ChangeUnit(id = "resendGoogleMailFailures2026", order = "12")
+public class ResendGoogleMailFailures2026 {
+
+  private static final long WINDOW = Duration.ofDays(1).getSeconds();
+
+  private static final Set<NotificationType> INSTANT_NOTIFICATIONS = Set.of(
+      COJ_CONFIRMATION,
+      EMAIL_UPDATED_NEW,
+      EMAIL_UPDATED_OLD,
+      FORM_SUBMITTED,
+      FORM_UPDATED,
+      LTFT_APPROVED,
+      LTFT_SUBMITTED
+  );
+
+  private static final Set<NotificationType> SCHEDULE_NOTIFICATIONS = Set.of(
+      PLACEMENT_UPDATED_WEEK_12,
+      PLACEMENT_UPDATED_WEEK_12_FOUNDATION,
+      PROGRAMME_CREATED,
+      PROGRAMME_POG_MONTH_12,
+      PROGRAMME_UPDATED_WEEK_12
+  );
+
+  private final MongoTemplate mongoTemplate;
+  private final EmailService emailService;
+  private final HistoryService historyService;
+  private final NotificationService notificationService;
+
+  /**
+   * Construct the migrator.
+   *
+   * @param mongoTemplate The mongo template to use for accessing failed records.
+   */
+  public ResendGoogleMailFailures2026(MongoTemplate mongoTemplate, EmailService emailService,
+      HistoryService historyService,
+      NotificationService notificationService) {
+    this.mongoTemplate = mongoTemplate;
+    this.emailService = emailService;
+    this.historyService = historyService;
+    this.notificationService = notificationService;
+  }
+
+  /**
+   * Resend the failed Google email notifications.
+   */
+  @Execution
+  public void migrate() {
+    Query query = new Query()
+        .addCriteria(Criteria.where("recipient.type").is(EMAIL))
+        .addCriteria(Criteria.where("recipient.contact")
+            .regex(Pattern.compile("^.+@(gmail|googlemail)\\.com$", CASE_INSENSITIVE)))
+        .addCriteria(Criteria.where("status").is(FAILED))
+        .addCriteria(Criteria.where("statusDetail").is("Bounce: Transient - General"))
+        .addCriteria(Criteria.where("sentAt")
+            .gte(LocalDate.of(2026, 5, 13).atStartOfDay(UTC).toInstant())
+            .lt(LocalDate.of(2026, 5, 15).atStartOfDay(UTC).toInstant())
+        );
+
+    List<History> failures = mongoTemplate.find(query, History.class);
+    int total = failures.size();
+    log.info("Found {} qualifying failure(s).", total);
+    int current = 1;
+
+    for (History failure : failures) {
+      log.info("Progress: {}/{}.", current++, total);
+      boolean success;
+
+      NotificationType type = failure.type();
+      if (INSTANT_NOTIFICATIONS.contains(type)) {
+        success = sendEmail(failure);
+      } else if (SCHEDULE_NOTIFICATIONS.contains(type)) {
+        success = scheduleEmail(failure);
+      } else {
+        log.warn("Skipping unexpected failed notification type {}.", type);
+        continue;
+      }
+
+      if (success) {
+        historyService.deleteHistoryForTrainee(failure.id(), failure.recipient().id());
+      }
+    }
+  }
+
+  /**
+   * Retry sending the failed email.
+   *
+   * @param failure The failed notification history.
+   * @return Whether the notification was successfully sent.
+   */
+  private boolean sendEmail(History failure) {
+    try {
+      emailService.resendMessage(failure, failure.recipient().contact());
+      return true;
+    } catch (Exception e) {
+      log.error("Failed to send notification retry.", e);
+      return false;
+    }
+  }
+
+  /**
+   * Schedule retrying to send the failed email.
+   *
+   * @param failure The failed notification history.
+   * @return Whether the notification was successfully scheduled.
+   */
+  private boolean scheduleEmail(History failure) {
+    Map<String, Object> templateVariables = failure.template().variables();
+    String jobId = "%s-%s".formatted(failure.type(), failure.tisReference().id());
+
+    try {
+      notificationService.scheduleNotification(jobId, templateVariables, Date.from(Instant.now()),
+          WINDOW);
+      return true;
+    } catch (Exception e) {
+      log.error("Failed to schedule notification retry.", e);
+      return false;
+    }
+  }
+
+  /**
+   * Do not attempt rollback, the collection should be left as-is.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn(
+        "Rollback requested but not available for 'ResendGoogleMailFailures' migration.");
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures2026IntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures2026IntegrationTest.java
@@ -1,0 +1,184 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static uk.nhs.tis.trainee.notifications.TestContainerConfiguration.MONGODB;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.FAILED;
+import static uk.nhs.tis.trainee.notifications.model.NotificationType.WELCOME;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.MessageType;
+import uk.nhs.tis.trainee.notifications.model.NotificationStatus;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers(disabledWithoutDocker = true)
+class ResendGoogleMailFailures2026IntegrationTest {
+
+  private static final String LOG_MESSAGE = "Found 2 qualifying failure(s).";
+
+  private static final Logger log = (Logger) LoggerFactory.getLogger(
+      ResendGoogleMailFailures2026.class);
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer MONGODB_CONTAINER = new MongoDBContainer(MONGODB);
+
+  @MockitoSpyBean
+  private MongoTemplate mongoTemplate;
+
+  @MockitoBean
+  private SqsTemplate sqsTemplate;
+
+  private ResendGoogleMailFailures2026 migrator;
+  private List<ILoggingEvent> logsList;
+
+  @BeforeEach
+  void setUp() {
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    log.addAppender(listAppender);
+    logsList = listAppender.list;
+
+    mongoTemplate.dropCollection(History.class);
+    migrator = new ResendGoogleMailFailures2026(mongoTemplate, null, null, null);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = MessageType.class, mode = EXCLUDE, names = "EMAIL")
+  void shouldFindByRecipientType(MessageType type) {
+    createFailure(null, null, null, null, null);
+    createFailure(EMAIL, null, null, null, null);
+    createFailure(type, null, null, null, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @Test
+  void shouldFindByRecipientContact() {
+    createFailure(null, null, null, null, null);
+    createFailure(null, ".@gmail.com", null, null, null);
+    createFailure(null, ".@GMAIL.COM", null, null, null);
+    createFailure(null, ".@googlemail.com", null, null, null);
+    createFailure(null, ".@GOOGLEMAIL.COM", null, null, null);
+    createFailure(null, ".@example.com", null, null, null);
+    createFailure(null, ".@EXAMPLE.COM", null, null, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is("Found 5 qualifying failure(s)."));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationStatus.class, mode = EXCLUDE, names = "FAILED")
+  void shouldFindByStatus(NotificationStatus status) {
+    createFailure(null, null, null, null, null);
+    createFailure(null, null, FAILED, null, null);
+    createFailure(null, null, status, null, null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @Test
+  void shouldFindByStatusDetail() {
+    createFailure(null, null, null, null, null);
+    createFailure(null, null, null, "Bounce: Transient - General", null);
+    createFailure(null, null, null, "Some other status detail", null);
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  @Test
+  void shouldFindBySentAt() {
+    createFailure(null, null, null, null, Instant.parse("2026-05-12T23:59:59Z"));
+    createFailure(null, null, null, null, Instant.parse("2026-05-13T00:00:00Z"));
+    createFailure(null, null, null, null, Instant.parse("2026-05-14T23:59:59Z"));
+    createFailure(null, null, null, null, Instant.parse("2026-05-15T00:00:00Z"));
+
+    migrator.migrate();
+
+    String formattedMessage = logsList.get(0).getFormattedMessage();
+    assertThat("Unexpected log message.", formattedMessage, is(LOG_MESSAGE));
+  }
+
+  /**
+   * Create and persist a failure, uses valid defaults for null parameters.
+   *
+   * @param type         The message type.
+   * @param contact      The contact email address.
+   * @param status       The history status.
+   * @param statusDetail The status detail text.
+   * @param sentAt       The sent-at timestamp.
+   */
+  private void createFailure(@Nullable MessageType type, @Nullable String contact,
+      @Nullable NotificationStatus status, @Nullable String statusDetail,
+      @Nullable Instant sentAt) {
+    History history = History.builder()
+        .id(ObjectId.get())
+        .type(WELCOME)
+        .recipient(new RecipientInfo(UUID.randomUUID().toString(), type != null ? type : EMAIL,
+            contact != null ? contact : "_@gmail.com"))
+        .status(status != null ? status : FAILED)
+        .statusDetail(statusDetail != null ? statusDetail : "Bounce: Transient - General")
+        .sentAt(sentAt != null ? sentAt : Instant.parse("2026-05-13T12:00:00Z"))
+        .build();
+    mongoTemplate.save(history);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures2026Test.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/migration/ResendGoogleMailFailures2026Test.java
@@ -1,0 +1,178 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.notifications.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.tis.trainee.notifications.model.MessageType.EMAIL;
+import static uk.nhs.tis.trainee.notifications.model.TisReferenceType.PLACEMENT;
+
+import jakarta.mail.MessagingException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import uk.nhs.tis.trainee.notifications.matcher.DateCloseTo;
+import uk.nhs.tis.trainee.notifications.model.History;
+import uk.nhs.tis.trainee.notifications.model.History.RecipientInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TemplateInfo;
+import uk.nhs.tis.trainee.notifications.model.History.TisReferenceInfo;
+import uk.nhs.tis.trainee.notifications.model.NotificationType;
+import uk.nhs.tis.trainee.notifications.service.EmailService;
+import uk.nhs.tis.trainee.notifications.service.HistoryService;
+import uk.nhs.tis.trainee.notifications.service.NotificationService;
+
+class ResendGoogleMailFailures2026Test {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_EMAIL = "trainee@example.com";
+  private static final String REFERENCE_ID = UUID.randomUUID().toString();
+
+  private MongoTemplate mongoTemplate;
+
+  private EmailService emailService;
+
+  private HistoryService historyService;
+
+  private NotificationService notificationService;
+
+  private ResendGoogleMailFailures2026 migrator;
+
+  @BeforeEach
+  void setUp() {
+    mongoTemplate = mock(MongoTemplate.class);
+    emailService = mock(EmailService.class);
+    historyService = mock(HistoryService.class);
+    notificationService = mock(NotificationService.class);
+    migrator = new ResendGoogleMailFailures2026(mongoTemplate, emailService, historyService,
+        notificationService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationType.class, names = {
+      "COJ_CONFIRMATION", "EMAIL_UPDATED_NEW", "EMAIL_UPDATED_OLD", "FORM_SUBMITTED",
+      "FORM_UPDATED", "LTFT_APPROVED", "LTFT_SUBMITTED"})
+  void shouldMigrateInstantEmails(NotificationType type) throws MessagingException {
+    ObjectId historyId = ObjectId.get();
+    History failure = History.builder()
+        .id(historyId)
+        .type(type)
+        .recipient(new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_EMAIL))
+        .build();
+    when(mongoTemplate.find(any(), eq(History.class))).thenReturn(List.of(failure));
+
+    migrator.migrate();
+
+    verify(emailService).resendMessage(failure, TRAINEE_EMAIL);
+    verify(historyService).deleteHistoryForTrainee(historyId, TRAINEE_ID);
+    verifyNoInteractions(notificationService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationType.class, names = {
+      "PLACEMENT_UPDATED_WEEK_12", "PLACEMENT_UPDATED_WEEK_12_FOUNDATION", "PROGRAMME_CREATED",
+      "PROGRAMME_POG_MONTH_12", "PROGRAMME_UPDATED_WEEK_12"})
+  void shouldMigrateScheduledEmails(NotificationType type) {
+    ObjectId historyId = ObjectId.get();
+    History failure = History.builder()
+        .id(historyId)
+        .type(type)
+        .tisReference(new TisReferenceInfo(PLACEMENT, REFERENCE_ID))
+        .recipient(new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_EMAIL))
+        .template(new TemplateInfo("template-name", "v1.2.3", Map.of(
+            "key1", "value1",
+            "key2", "value2"
+        )))
+        .build();
+    when(mongoTemplate.find(any(), eq(History.class))).thenReturn(List.of(failure));
+
+    migrator.migrate();
+
+    String jobId = type + "-" + REFERENCE_ID;
+
+    ArgumentCaptor<Map<String, Object>> jobDataCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Date> whenCaptor = ArgumentCaptor.captor();
+    verify(notificationService).scheduleNotification(eq(jobId), jobDataCaptor.capture(),
+        whenCaptor.capture(), eq(86400L));
+
+    Map<String, Object> jobData = jobDataCaptor.getValue();
+    assertThat("Unexpected job data count.", jobData.keySet(), hasSize(2));
+    assertThat("Unexpected job data.", jobData.get("key1"), is("value1"));
+    assertThat("Unexpected job data.", jobData.get("key2"), is("value2"));
+
+    assertThat("Unexpected send date.", whenCaptor.getValue(),
+        DateCloseTo.closeTo(Instant.now().getEpochSecond(), 1));
+
+    verify(historyService).deleteHistoryForTrainee(historyId, TRAINEE_ID);
+    verifyNoInteractions(emailService);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationType.class, mode = EXCLUDE, names = {
+      "COJ_CONFIRMATION", "EMAIL_UPDATED_NEW", "EMAIL_UPDATED_OLD", "FORM_SUBMITTED",
+      "FORM_UPDATED", "LTFT_APPROVED", "LTFT_SUBMITTED", "PLACEMENT_UPDATED_WEEK_12",
+      "PLACEMENT_UPDATED_WEEK_12_FOUNDATION", "PROGRAMME_CREATED", "PROGRAMME_POG_MONTH_12",
+      "PROGRAMME_UPDATED_WEEK_12"})
+  void shouldNotMigrateUnsupportedTypes(NotificationType type) {
+    History failure = History.builder()
+        .id(ObjectId.get())
+        .type(type)
+        .recipient(new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_EMAIL))
+        .build();
+    when(mongoTemplate.find(any(), eq(History.class))).thenReturn(List.of(failure));
+
+    Mockito.clearInvocations(mongoTemplate);
+    migrator.migrate();
+
+    verifyNoInteractions(emailService);
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(historyService);
+  }
+
+  @Test
+  void rollback() {
+    Mockito.clearInvocations(mongoTemplate);
+    migrator.rollback();
+
+    verifyNoInteractions(mongoTemplate);
+    verifyNoInteractions(emailService);
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(historyService);
+  }
+}


### PR DESCRIPTION
Google Mail blocked the majority of our emails sent to gmail and googlemail addresses due to a sudden spike in sends. This has left 5556 failed emails which need to be retried.

Create a migrator to re-schedule the failed emails, spread over a 24 hour period to hopefully avoid any automated blocks.

TIS21-8632