### PR TITLE
fix: prevent non-onboarded trainees from POG notifications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "3.9.0"
+version = "3.9.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipService.java
@@ -84,6 +84,7 @@ public class ProgrammeMembershipService {
 
   public static final List<String> INCLUDE_CURRICULUM_SUBTYPES
       = List.of("MEDICAL_CURRICULUM", "MEDICAL_SPR", "AFT");
+  // dental trainees will have DENTAL_CURRICULUM or DENTAL_POST_CCST, which are excluded for now.
 
   public static final String FOUNDATION_CURRICULUM_SUBTYPE = "AFT";
   public static final String FOUNDATION_SPECIALTY = "FOUNDATION";
@@ -208,24 +209,27 @@ public class ProgrammeMembershipService {
     Map<NotificationType, History> notificationsAlreadySent = null;
 
     if (!isExcluded) {
-      notificationsAlreadySent = getLatestNotificationsSent(programmeMembership.getPersonId(),
-          programmeMembership.getTisId());
-      createDirectProgrammeNotifications(programmeMembership, notificationsAlreadySent);
-      createInAppNotifications(programmeMembership, notificationsAlreadySent);
-    }
-
-    if (!isFoundationProgramme(programmeMembership)) {
-      // For now, only create direct programme POG notifications for non-foundation.
-      boolean isExcludedPog = pmUtils.isExcludedPog(programmeMembership);
-      log.info("Programme membership {}: excluded POG {}.", programmeMembership.getTisId(),
-          isExcludedPog);
-      if (!isExcludedPog) {
-        if (notificationsAlreadySent == null) {
-          //getLatestNotificationsSent is expensive, so only call it if we need to
-          notificationsAlreadySent = getLatestNotificationsSent(programmeMembership.getPersonId(),
-              programmeMembership.getTisId());
+      if (!pmUtils.hasStarted(programmeMembership)) {
+        log.info("Programme membership {} has not started yet, setting up normal notifications.",
+            programmeMembership.getTisId());
+        notificationsAlreadySent = getLatestNotificationsSent(programmeMembership.getPersonId(),
+            programmeMembership.getTisId());
+        createDirectProgrammeNotifications(programmeMembership, notificationsAlreadySent);
+        createInAppNotifications(programmeMembership, notificationsAlreadySent);
+      }
+      if (!isFoundationProgramme(programmeMembership)) {
+        // For now, only create direct programme POG notifications for non-foundation.
+        boolean isExcludedPog = pmUtils.isExcludedPog(programmeMembership);
+        log.info("Programme membership {}: excluded POG {}.", programmeMembership.getTisId(),
+            isExcludedPog);
+        if (!isExcludedPog) {
+          if (notificationsAlreadySent == null) {
+            //getLatestNotificationsSent is expensive, so only call it if we need to
+            notificationsAlreadySent = getLatestNotificationsSent(programmeMembership.getPersonId(),
+                programmeMembership.getTisId());
+          }
+          createDirectProgrammePogNotifications(programmeMembership, notificationsAlreadySent);
         }
-        createDirectProgrammePogNotifications(programmeMembership, notificationsAlreadySent);
       }
     }
   }

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
@@ -271,8 +271,8 @@ public class ProgrammeMembershipUtils {
    * Determines whether a programme membership has started or not, based on the start date.
    *
    * @param programmeMembership the Programme membership.
-   * @return true if the programme membership has started, i.e. the start date is in the past or
-   * not set, false if the start date is in the future.
+   * @return true if the programme membership has started, i.e. the start date is before today or
+   * not set, false if the start date is today or in the future.
    */
   public boolean hasStarted(ProgrammeMembership programmeMembership) {
     LocalDate startDate = programmeMembership.getStartDate();

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtils.java
@@ -253,10 +253,6 @@ public class ProgrammeMembershipUtils {
    * @return true if the programme membership is excluded.
    */
   public boolean isExcluded(ProgrammeMembership programmeMembership) {
-    LocalDate startDate = programmeMembership.getStartDate();
-    if (startDate == null || startDate.isBefore(LocalDate.now(timezone))) {
-      return true;
-    }
 
     List<Curriculum> curricula = programmeMembership.getCurricula();
     if (curricula == null) {
@@ -269,6 +265,19 @@ public class ProgrammeMembershipUtils {
         .anyMatch(INCLUDE_CURRICULUM_SUBTYPES::contains);
 
     return !hasMedicalSubType;
+  }
+
+  /**
+   * Determines whether a programme membership has started or not, based on the start date.
+   *
+   * @param programmeMembership the Programme membership.
+   * @return true if the programme membership has started, i.e. the start date is in the past or
+   * not set, false if the start date is in the future.
+   */
+  public boolean hasStarted(ProgrammeMembership programmeMembership) {
+    LocalDate startDate = programmeMembership.getStartDate();
+    return startDate == null
+        || startDate.isBefore(LocalDate.now(timezone));
   }
 
   /**

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipServiceTest.java
@@ -878,6 +878,28 @@ class ProgrammeMembershipServiceTest {
   @ParameterizedTest
   @EnumSource(value = NotificationType.class,
       names = {"PROGRAMME_POG_MONTH_12", "PROGRAMME_POG_MONTH_6"})
+  void shouldNotCreateDirectProgrammePogNotificationsIfCurriculumSubtypeExcluded(
+      NotificationType pogType) {
+    when(historyService.findAllHistoryForTrainee(PERSON_ID)).thenReturn(new ArrayList<>());
+
+    ProgrammeMembership programmeMembership = getDefaultProgrammeMembership();
+    // Replace the default curriculum with one that has an excluded subtype (DENTAL_CURRICULUM)
+    // but is otherwise POG-eligible, to confirm the subtype exclusion is the reason it is skipped.
+    Curriculum dentalCurriculum = new Curriculum(CURRICULUM_NAME, "DENTAL_CURRICULUM",
+        "specialty", false, CURRICULUM_END_DATE, true);
+    programmeMembership.setCurricula(List.of(dentalCurriculum));
+
+    service.addNotifications(programmeMembership);
+
+    String jobId = pogType + "-" + TIS_ID;
+    verify(notificationService, never()).executeNow(eq(jobId), anyMap());
+    verify(notificationService, never())
+        .scheduleNotification(eq(jobId), anyMap(), any(), anyLong());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = NotificationType.class,
+      names = {"PROGRAMME_POG_MONTH_12", "PROGRAMME_POG_MONTH_6"})
   void shouldNotSchedulePogNotificationIfNotExcludedButShouldScheduleIsFalse(
       NotificationType pogType) {
     // Arrange: eligible for POG, but shouldSchedulePogNotification returns false

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtilsTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ProgrammeMembershipUtilsTest.java
@@ -158,20 +158,20 @@ class ProgrammeMembershipUtilsTest {
   }
 
   @Test
-  void shouldExcludePmThatHasNoStartDate() {
+  void shouldBeAlreadyStartedPmThatHasNoStartDate() {
     Curriculum theCurriculum = new Curriculum(CURRICULUM_NAME, MEDICAL_CURRICULUM_1,
         "INCLUDED_SPECIALTY_1", false,
         CURRICULUM_END_DATE, null);
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setCurricula(List.of(theCurriculum, IGNORED_CURRICULUM));
 
-    boolean isExcluded = service.isExcluded(programmeMembership);
+    boolean hasStarted = service.hasStarted(programmeMembership);
 
-    assertThat("Unexpected excluded value.", isExcluded, is(true));
+    assertThat("Unexpected hasStarted value.", hasStarted, is(true));
   }
 
   @Test
-  void shouldExcludePmThatIsNotFuture() {
+  void shouldBeAlreadyStartedPmThatIsNotFuture() {
     Curriculum theCurriculum = new Curriculum(CURRICULUM_NAME, MEDICAL_CURRICULUM_1,
         "INCLUDED_SPECIALTY_1", false,
         CURRICULUM_END_DATE, null);
@@ -179,9 +179,23 @@ class ProgrammeMembershipUtilsTest {
     programmeMembership.setStartDate(LocalDate.now().minusYears(1));
     programmeMembership.setCurricula(List.of(theCurriculum, IGNORED_CURRICULUM));
 
-    boolean isExcluded = service.isExcluded(programmeMembership);
+    boolean hasStarted = service.hasStarted(programmeMembership);
 
-    assertThat("Unexpected excluded value.", isExcluded, is(true));
+    assertThat("Unexpected hasStarted value.", hasStarted, is(true));
+  }
+
+  @Test
+  void shouldNotBeAlreadyStartedPmThatIsFuture() {
+    Curriculum theCurriculum = new Curriculum(CURRICULUM_NAME, MEDICAL_CURRICULUM_1,
+        "INCLUDED_SPECIALTY_1", false,
+        CURRICULUM_END_DATE, null);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setStartDate(LocalDate.now().plusDays(1));
+    programmeMembership.setCurricula(List.of(theCurriculum, IGNORED_CURRICULUM));
+
+    boolean hasStarted = service.hasStarted(programmeMembership);
+
+    assertThat("Unexpected hasStarted value.", hasStarted, is(false));
   }
 
   @Test


### PR DESCRIPTION
Wrapping the POG notifications in the isExcluded check is ok because
(1) the isFoundation checks curriculum subtype AFT, which is not excluded
(2) the start date check is moved out of the isExcluded check, since the isExcludedPog refers to CCT date not start date

TIS21-8669