### PR TITLE
feat: update notifications when email changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "3.10.0"
+version = "3.11.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/model/History.java
@@ -55,6 +55,7 @@ public record History(
     NotificationType type,
     @With
     RecipientInfo recipient,
+    @With
     TemplateInfo template,
     List<StoredFile> attachments,
     Instant sentAt,

--- a/src/main/java/uk/nhs/tis/trainee/notifications/repository/HistoryRepository.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/repository/HistoryRepository.java
@@ -79,6 +79,22 @@ public interface HistoryRepository extends
   List<History> findAllByRecipient_IdAndStatus(String recipientId, String status);
 
   /**
+   * Find all scheduled notifications for the given recipient, ordered by sentAt descending.
+   * A notification is considered scheduled if it has SCHEDULED status (email) or a future sentAt
+   * timestamp (in-app).
+   *
+   * @param recipientId The ID of the recipient to get the history for.
+   * @param now         The current timestamp, used to identify future sentAt values.
+   * @return The found history, empty if none found.
+   */
+  @Query(value = "{ 'recipient.id': ?0,"
+      + " '$or': [ { 'status': 'SCHEDULED' }, { 'sentAt': { '$gt': ?1 } } ] }",
+      sort = "{ 'sentAt': -1 }")
+  // Note: Spring Data only derives sorting from the method name when the query is derived, not when
+  // it is explicitly defined with @Query, hence the sort in the @Query annotation.
+  List<History> findAllScheduledByRecipientIdOrderBySentAtDesc(String recipientId, Instant now);
+
+  /**
    * Remove history Notifications by ID and recipientId.
    *
    * @param id          The ID of the history record.

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsService.java
@@ -57,6 +57,9 @@ public class ContactDetailsService {
       return;
     }
 
+    // Update email on all scheduled notifications for the trainee.
+    historyService.updateScheduledNotificationEmail(traineeId, contactDetails.getEmail());
+
     List<History> failedMessages
         = historyService.findAllFailedForTrainee(traineeId);
     List<History> onesToResend = failedMessages.stream()

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -371,6 +371,10 @@ public class HistoryService {
    * @param newEmail  The new email address.
    */
   public void updateScheduledNotificationEmail(String traineeId, String newEmail) {
+    if (traineeId == null || newEmail == null) {
+      log.warn("Cannot update scheduled notification emails: traineeId or newEmail is null.");
+      return;
+    }
     List<History> scheduledNotifications =
         repository.findAllScheduledByRecipientIdOrderBySentAtDesc(traineeId, Instant.now());
 

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -33,6 +33,7 @@ import static uk.nhs.tis.trainee.notifications.model.NotificationStatus.UNREAD;
 
 import java.time.Instant;
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -352,15 +353,74 @@ public class HistoryService {
    */
   public List<History> findAllScheduledForTrainee(
       String traineeId, TisReferenceType tisReferenceType, String refId) {
-    List<History> history = repository.findAllByRecipient_IdOrderBySentAtDesc(traineeId);
+    List<History> history
+        = repository.findAllScheduledByRecipientIdOrderBySentAtDesc(traineeId, Instant.now());
 
     return history.stream()
-        // In-app notifications scheduled by future send date,
-        // while email notification scheduled by SCHEDULED status
-        .filter(h -> (h.sentAt().isAfter(Instant.now())) || (h.status().equals(SCHEDULED)))
         .filter(h -> h.tisReference().id().equals(refId)
             && h.tisReference().type().equals(tisReferenceType))
         .toList();
+  }
+
+  /**
+   * Find all scheduled notifications for the given Trainee from DB. Email notifications are
+   * identified by SCHEDULED status, and in-app notifications by a future sentAt timestamp.
+   *
+   * @param traineeId The ID of the trainee to get notifications for.
+   * @return The found notifications, empty if none found.
+   */
+  public List<History> findAllScheduledForTrainee(String traineeId) {
+    return repository.findAllScheduledByRecipientIdOrderBySentAtDesc(traineeId, Instant.now());
+  }
+
+  /**
+   * Update the email address on all scheduled notifications for the given trainee. This updates
+   * both the recipient contact email (for EMAIL type notifications) and the template variable
+   * "email" if present.
+   *
+   * @param traineeId The ID of the trainee whose notifications should be updated.
+   * @param newEmail  The new email address.
+   */
+  public void updateScheduledNotificationEmail(String traineeId, String newEmail) {
+    List<History> scheduledNotifications = findAllScheduledForTrainee(traineeId);
+
+    log.info("Found {} scheduled notifications for trainee {} to update email.",
+        scheduledNotifications.size(), traineeId);
+
+    for (History h : scheduledNotifications) {
+      boolean needsUpdate = false;
+      History updated = h;
+
+      // Update recipient.contact for email notifications.
+      if (h.recipient().type() == EMAIL
+          && (h.recipient().contact() == null
+          || !h.recipient().contact().equalsIgnoreCase(newEmail))) {
+        History.RecipientInfo newRecipient = new History.RecipientInfo(
+            h.recipient().id(), EMAIL, newEmail);
+        updated = updated.withRecipient(newRecipient);
+        needsUpdate = true;
+      }
+
+      // Update template.variables.email if it exists.
+      if (h.template() != null && h.template().variables() != null
+          && h.template().variables().containsKey("email")) {
+        Object existingEmail = h.template().variables().get("email");
+        if (!newEmail.equalsIgnoreCase(String.valueOf(existingEmail))) {
+          Map<String, Object> updatedVars = new HashMap<>(h.template().variables());
+          updatedVars.put("email", newEmail);
+          History.TemplateInfo newTemplate = new History.TemplateInfo(
+              updated.template().name(), updated.template().version(), updatedVars);
+          updated = updated.withTemplate(newTemplate);
+          needsUpdate = true;
+        }
+      }
+
+      if (needsUpdate) {
+        log.info("Updating email for scheduled notification {} for trainee {}.",
+            h.id(), traineeId);
+        save(updated);
+      }
+    }
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
+++ b/src/main/java/uk/nhs/tis/trainee/notifications/service/HistoryService.java
@@ -363,17 +363,6 @@ public class HistoryService {
   }
 
   /**
-   * Find all scheduled notifications for the given Trainee from DB. Email notifications are
-   * identified by SCHEDULED status, and in-app notifications by a future sentAt timestamp.
-   *
-   * @param traineeId The ID of the trainee to get notifications for.
-   * @return The found notifications, empty if none found.
-   */
-  public List<History> findAllScheduledForTrainee(String traineeId) {
-    return repository.findAllScheduledByRecipientIdOrderBySentAtDesc(traineeId, Instant.now());
-  }
-
-  /**
    * Update the email address on all scheduled notifications for the given trainee. This updates
    * both the recipient contact email (for EMAIL type notifications) and the template variable
    * "email" if present.
@@ -382,7 +371,8 @@ public class HistoryService {
    * @param newEmail  The new email address.
    */
   public void updateScheduledNotificationEmail(String traineeId, String newEmail) {
-    List<History> scheduledNotifications = findAllScheduledForTrainee(traineeId);
+    List<History> scheduledNotifications =
+        repository.findAllScheduledByRecipientIdOrderBySentAtDesc(traineeId, Instant.now());
 
     log.info("Found {} scheduled notifications for trainee {} to update email.",
         scheduledNotifications.size(), traineeId);

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/ContactDetailsServiceTest.java
@@ -84,6 +84,20 @@ class ContactDetailsServiceTest {
     service.updateContactDetails(updatedContactDetails);
 
     verifyNoInteractions(emailService);
+    verifyNoInteractions(historyService);
+  }
+
+  @Test
+  void shouldUpdateScheduledNotificationEmailsWhenEmailIsUpdated() {
+    when(historyService.findAllFailedForTrainee(TRAINEE_ID)).thenReturn(List.of());
+
+    ContactDetails updatedContactDetails = new ContactDetails();
+    updatedContactDetails.setEmail(TRAINEE_CONTACT);
+    updatedContactDetails.setTisId(TRAINEE_ID);
+
+    service.updateContactDetails(updatedContactDetails);
+
+    verify(historyService).updateScheduledNotificationEmail(TRAINEE_ID, TRAINEE_CONTACT);
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -963,54 +963,6 @@ class HistoryServiceIntegrationTest {
   }
 
   @Test
-  void shouldFindAllScheduledForTraineeWithoutReferenceParams() {
-    RecipientInfo emailRecipient = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
-    RecipientInfo inAppRecipient = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
-        TEMPLATE_VARIABLES);
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
-
-    // Scheduled email notification (status = SCHEDULED)
-    History scheduledEmail = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
-        emailRecipient, templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
-
-    // In-app notification with future sentAt
-    Instant futureTime = Instant.now().plus(Duration.ofDays(7)).truncatedTo(ChronoUnit.MILLIS);
-    History futureInApp = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
-        inAppRecipient, templateInfo, null, futureTime, null, UNREAD, null, null));
-
-    // Sent email notification (should NOT be included)
-    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, emailRecipient,
-        templateInfo, null, SENT_AT, null, SENT, null, null));
-
-    // Failed email notification (should NOT be included)
-    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, emailRecipient,
-        templateInfo, null, SENT_AT, null, FAILED, null, null));
-
-    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
-
-    assertThat("Unexpected scheduled count.", result.size(), is(2));
-    List<ObjectId> ids = result.stream().map(History::id).toList();
-    assertThat("Unexpected scheduled IDs.", ids, hasItems(scheduledEmail.id(), futureInApp.id()));
-  }
-
-  @Test
-  void shouldNotFindScheduledForOtherTrainee() {
-    String otherTraineeId = "other-trainee";
-    RecipientInfo otherRecipient = new RecipientInfo(otherTraineeId, EMAIL, "other@test.com");
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
-        TEMPLATE_VARIABLES);
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
-
-    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, otherRecipient,
-        templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
-
-    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
-
-    assertThat("Unexpected scheduled count.", result.size(), is(0));
-  }
-
-  @Test
   void shouldUpdateScheduledEmailNotificationRecipientContact() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -966,10 +966,10 @@ class HistoryServiceIntegrationTest {
   void shouldUpdateScheduledEmailNotificationRecipientContact() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
         Map.of("key1", "value1"));
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
         templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
@@ -988,10 +988,10 @@ class HistoryServiceIntegrationTest {
   void shouldUpdateScheduledNotificationTemplateVariablesEmail() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail, "familyName", "Smith");
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
         templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
@@ -1013,10 +1013,10 @@ class HistoryServiceIntegrationTest {
   void shouldNotUpdateNonScheduledNotificationsWhenUpdatingEmail() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail);
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     // Sent notification should not be updated
     History sentHistory = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
@@ -1051,10 +1051,10 @@ class HistoryServiceIntegrationTest {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
     String otherTraineeId = "other-trainee";
-    RecipientInfo otherRecipient = new RecipientInfo(otherTraineeId, EMAIL, oldEmail);
+    final RecipientInfo otherRecipient = new RecipientInfo(otherTraineeId, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail);
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, otherRecipient,
         templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
@@ -1073,11 +1073,11 @@ class HistoryServiceIntegrationTest {
   void shouldUpdateMultipleScheduledNotificationsForTrainee() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail, "key1", "value1");
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    TisReferenceInfo tisReferenceInfo1 = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
-    TisReferenceInfo tisReferenceInfo2 = new TisReferenceInfo(TIS_REFERENCE_TYPE,
+    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    final TisReferenceInfo tisReferenceInfo1 = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    final TisReferenceInfo tisReferenceInfo2 = new TisReferenceInfo(TIS_REFERENCE_TYPE,
         TIS_REFERENCE_ID_2);
 
     service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo,

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -962,6 +962,191 @@ class HistoryServiceIntegrationTest {
         afterMoveTo.size(), is(0));
   }
 
+  @Test
+  void shouldFindAllScheduledForTraineeWithoutReferenceParams() {
+    RecipientInfo emailRecipient = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    RecipientInfo inAppRecipient = new RecipientInfo(TRAINEE_ID, IN_APP, TRAINEE_CONTACT);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    // Scheduled email notification (status = SCHEDULED)
+    History scheduledEmail = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
+        emailRecipient, templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+
+    // In-app notification with future sentAt
+    Instant futureTime = Instant.now().plus(Duration.ofDays(7)).truncatedTo(ChronoUnit.MILLIS);
+    History futureInApp = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
+        inAppRecipient, templateInfo, null, futureTime, null, UNREAD, null, null));
+
+    // Sent email notification (should NOT be included)
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, emailRecipient,
+        templateInfo, null, SENT_AT, null, SENT, null, null));
+
+    // Failed email notification (should NOT be included)
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, emailRecipient,
+        templateInfo, null, SENT_AT, null, FAILED, null, null));
+
+    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected scheduled count.", result.size(), is(2));
+    List<ObjectId> ids = result.stream().map(History::id).toList();
+    assertThat("Unexpected scheduled IDs.", ids, hasItems(scheduledEmail.id(), futureInApp.id()));
+  }
+
+  @Test
+  void shouldNotFindScheduledForOtherTrainee() {
+    String otherTraineeId = "other-trainee";
+    RecipientInfo otherRecipient = new RecipientInfo(otherTraineeId, EMAIL, "other@test.com");
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, otherRecipient,
+        templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+
+    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected scheduled count.", result.size(), is(0));
+  }
+
+  @Test
+  void shouldUpdateScheduledEmailNotificationRecipientContact() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        Map.of("key1", "value1"));
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
+        templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    List<History> allHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
+    assertThat("Unexpected history count.", allHistory.size(), is(1));
+    assertThat("Unexpected recipient email.", allHistory.get(0).recipient().contact(),
+        is(newEmail));
+    assertThat("Unexpected recipient id.", allHistory.get(0).recipient().id(), is(TRAINEE_ID));
+    assertThat("Unexpected recipient type.", allHistory.get(0).recipient().type(), is(EMAIL));
+  }
+
+  @Test
+  void shouldUpdateScheduledNotificationTemplateVariablesEmail() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    Map<String, Object> variables = Map.of("email", oldEmail, "familyName", "Smith");
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
+        templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    List<History> allHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
+    assertThat("Unexpected history count.", allHistory.size(), is(1));
+
+    History updated = allHistory.get(0);
+    assertThat("Unexpected recipient email.", updated.recipient().contact(), is(newEmail));
+    assertThat("Unexpected template email variable.",
+        updated.template().variables().get("email"), is(newEmail));
+    assertThat("Unexpected template familyName variable.",
+        updated.template().variables().get("familyName"), is("Smith"));
+  }
+
+  @Test
+  void shouldNotUpdateNonScheduledNotificationsWhenUpdatingEmail() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    Map<String, Object> variables = Map.of("email", oldEmail);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    // Sent notification should not be updated
+    History sentHistory = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
+        recipientInfo, templateInfo, null, SENT_AT, null, SENT, null, null));
+
+    // Scheduled notification should be updated
+    History scheduledHistory = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
+        recipientInfo, templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    List<History> allHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
+    assertThat("Unexpected history count.", allHistory.size(), is(2));
+
+    History sentResult = allHistory.stream()
+        .filter(h -> h.id().equals(sentHistory.id())).findFirst().orElseThrow();
+    assertThat("Sent notification email should not change.",
+        sentResult.recipient().contact(), is(oldEmail));
+    assertThat("Sent notification template email should not change.",
+        sentResult.template().variables().get("email"), is(oldEmail));
+
+    History scheduledResult = allHistory.stream()
+        .filter(h -> h.id().equals(scheduledHistory.id())).findFirst().orElseThrow();
+    assertThat("Scheduled notification email should change.",
+        scheduledResult.recipient().contact(), is(newEmail));
+    assertThat("Scheduled notification template email should change.",
+        scheduledResult.template().variables().get("email"), is(newEmail));
+  }
+
+  @Test
+  void shouldNotUpdateScheduledNotificationsForOtherTrainees() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    String otherTraineeId = "other-trainee";
+    RecipientInfo otherRecipient = new RecipientInfo(otherTraineeId, EMAIL, oldEmail);
+    Map<String, Object> variables = Map.of("email", oldEmail);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    service.save(new History(null, tisReferenceInfo, FORM_UPDATED, otherRecipient,
+        templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    List<History> otherHistory = service.findAllHistoryForTrainee(otherTraineeId);
+    assertThat("Unexpected history count.", otherHistory.size(), is(1));
+    assertThat("Other trainee email should not change.",
+        otherHistory.get(0).recipient().contact(), is(oldEmail));
+    assertThat("Other trainee template email should not change.",
+        otherHistory.get(0).template().variables().get("email"), is(oldEmail));
+  }
+
+  @Test
+  void shouldUpdateMultipleScheduledNotificationsForTrainee() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    Map<String, Object> variables = Map.of("email", oldEmail, "key1", "value1");
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo1 = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo2 = new TisReferenceInfo(TIS_REFERENCE_TYPE,
+        TIS_REFERENCE_ID_2);
+
+    service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo,
+        templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+    service.save(new History(null, tisReferenceInfo2, PROGRAMME_DAY_ONE, recipientInfo,
+        templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    List<History> allHistory = service.findAllHistoryForTrainee(TRAINEE_ID);
+    assertThat("Unexpected history count.", allHistory.size(), is(2));
+
+    for (History h : allHistory) {
+      assertThat("Unexpected recipient email.", h.recipient().contact(), is(newEmail));
+      assertThat("Unexpected template email variable.",
+          h.template().variables().get("email"), is(newEmail));
+      assertThat("Non-email variable should be unchanged.",
+          h.template().variables().get("key1"), is("value1"));
+    }
+  }
+
   /**
    * Helper method to create a basic History object for testing.
    */

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceIntegrationTest.java
@@ -966,10 +966,10 @@ class HistoryServiceIntegrationTest {
   void shouldUpdateScheduledEmailNotificationRecipientContact() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
-    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
         Map.of("key1", "value1"));
-    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
         templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
@@ -988,10 +988,10 @@ class HistoryServiceIntegrationTest {
   void shouldUpdateScheduledNotificationTemplateVariablesEmail() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail, "familyName", "Smith");
-    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, recipientInfo,
         templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
@@ -1013,10 +1013,10 @@ class HistoryServiceIntegrationTest {
   void shouldNotUpdateNonScheduledNotificationsWhenUpdatingEmail() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail);
-    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     // Sent notification should not be updated
     History sentHistory = service.save(new History(null, tisReferenceInfo, FORM_UPDATED,
@@ -1051,10 +1051,10 @@ class HistoryServiceIntegrationTest {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
     String otherTraineeId = "other-trainee";
-    final RecipientInfo otherRecipient = new RecipientInfo(otherTraineeId, EMAIL, oldEmail);
+    RecipientInfo otherRecipient = new RecipientInfo(otherTraineeId, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail);
-    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    final TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
     service.save(new History(null, tisReferenceInfo, FORM_UPDATED, otherRecipient,
         templateInfo, null, SENT_AT, null, SCHEDULED, null, null));
@@ -1073,11 +1073,11 @@ class HistoryServiceIntegrationTest {
   void shouldUpdateMultipleScheduledNotificationsForTrainee() {
     String oldEmail = "old@example.com";
     String newEmail = "new@example.com";
-    final RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
     Map<String, Object> variables = Map.of("email", oldEmail, "key1", "value1");
-    final TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
-    final TisReferenceInfo tisReferenceInfo1 = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
-    final TisReferenceInfo tisReferenceInfo2 = new TisReferenceInfo(TIS_REFERENCE_TYPE,
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo1 = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TisReferenceInfo tisReferenceInfo2 = new TisReferenceInfo(TIS_REFERENCE_TYPE,
         TIS_REFERENCE_ID_2);
 
     service.save(new History(null, tisReferenceInfo1, FORM_UPDATED, recipientInfo,

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -1006,7 +1006,9 @@ class HistoryServiceTest {
 
   @Test
   void shouldFindNoHistoryForTraineeWhenScheduledInAppNotificationsNotExist() {
-    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(eq(TRAINEE_ID), any(Instant.class))).thenReturn(List.of());
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of());
 
     List<History> history = service.findAllScheduledForTrainee(
         TRAINEE_ID, TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
@@ -1024,29 +1026,31 @@ class HistoryServiceTest {
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
     TisReferenceInfo otherReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, "other-id");
 
-    // Matching reference
     ObjectId id1 = ObjectId.get();
-    History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, null, Instant.MAX, Instant.MIN, SCHEDULED, null, null);
+    History history1 = new History(id1, otherReferenceInfo, notificationType, recipientInfo,
+        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
 
-    // Different reference (should be filtered out by service)
     ObjectId id2 = ObjectId.get();
-    History history2 = new History(id2, otherReferenceInfo, notificationType, recipientInfo,
-        templateInfo, null, Instant.MAX, Instant.MIN, SCHEDULED, null, null);
+    History history2 = new History(id2, tisReferenceInfo, notificationType, recipientInfo,
+        templateInfo, null, Instant.MIN, Instant.MIN, SENT, null, null);
+
+    ObjectId id3 = ObjectId.get();
+    History history3 = new History(id3, tisReferenceInfo, notificationType, recipientInfo,
+        templateInfo, null, Instant.MAX, Instant.MIN, SENT, null, null);
 
     when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
         eq(TRAINEE_ID), any(Instant.class)))
-        .thenReturn(List.of(history1, history2));
+        .thenReturn(List.of(history3, history2, history1));
 
     when(templateService.process(any(), any(), anyMap())).thenReturn("");
 
     List<History> history = service.findAllScheduledForTrainee(
         TRAINEE_ID, TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
 
-    assertThat("Unexpected history count.", history.size(), is(1));
+    assertThat("Unexpected history count.", history.size(), is(2));
 
     History returnedHistory1 = history.get(0);
-    assertThat("Unexpected history id.", returnedHistory1.id(), is(id1));
+    assertThat("Unexpected history id.", returnedHistory1.id(), is(id3));
     TisReferenceInfo referenceInfo2 = history.get(0).tisReference();
     assertThat("Unexpected history TIS reference type.", referenceInfo2.type(),
         is(TIS_REFERENCE_TYPE));

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -61,6 +61,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1005,7 +1006,7 @@ class HistoryServiceTest {
 
   @Test
   void shouldFindNoHistoryForTraineeWhenScheduledInAppNotificationsNotExist() {
-    when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(List.of());
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(eq(TRAINEE_ID), any(Instant.class))).thenReturn(List.of());
 
     List<History> history = service.findAllScheduledForTrainee(
         TRAINEE_ID, TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
@@ -1021,22 +1022,21 @@ class HistoryServiceTest {
     TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
         TEMPLATE_VARIABLES);
     TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+    TisReferenceInfo otherReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, "other-id");
 
+    // Matching reference
     ObjectId id1 = ObjectId.get();
     History history1 = new History(id1, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, null, Instant.MIN, Instant.MAX, SENT, null, null);
+        templateInfo, null, Instant.MAX, Instant.MIN, SCHEDULED, null, null);
 
+    // Different reference (should be filtered out by service)
     ObjectId id2 = ObjectId.get();
-    Instant timeNow = NOW;
-    History history2 = new History(id2, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, null, timeNow, Instant.MIN, SENT, null, null);
+    History history2 = new History(id2, otherReferenceInfo, notificationType, recipientInfo,
+        templateInfo, null, Instant.MAX, Instant.MIN, SCHEDULED, null, null);
 
-    ObjectId id3 = ObjectId.get();
-    History history3 = new History(id3, tisReferenceInfo, notificationType, recipientInfo,
-        templateInfo, null, Instant.MAX, Instant.MIN, SENT, null, null);
-
-    when(repository.findAllByRecipient_IdOrderBySentAtDesc(TRAINEE_ID)).thenReturn(
-        List.of(history3, history2, history1));
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(history1, history2));
 
     when(templateService.process(any(), any(), anyMap())).thenReturn("");
 
@@ -1046,7 +1046,7 @@ class HistoryServiceTest {
     assertThat("Unexpected history count.", history.size(), is(1));
 
     History returnedHistory1 = history.get(0);
-    assertThat("Unexpected history id.", returnedHistory1.id(), is(id3));
+    assertThat("Unexpected history id.", returnedHistory1.id(), is(id1));
     TisReferenceInfo referenceInfo2 = history.get(0).tisReference();
     assertThat("Unexpected history TIS reference type.", referenceInfo2.type(),
         is(TIS_REFERENCE_TYPE));
@@ -1105,6 +1105,270 @@ class HistoryServiceTest {
     assertThat("Unexpected failed history read at.", failed1.readAt(), is(Instant.MAX));
     assertThat("Unexpected failed history status.", failed1.status(), is(FAILED));
     assertThat("Unexpected failed history last retry.", failed1.lastRetry(), is(Instant.MAX));
+  }
+
+  @Test
+  void shouldFindAllScheduledForTraineeIncludingScheduledStatusAndFutureSentAt() {
+    RecipientInfo emailRecipient = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    RecipientInfo inAppRecipient = new RecipientInfo(TRAINEE_ID, IN_APP, null);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        TEMPLATE_VARIABLES);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    // Scheduled email notification (status = SCHEDULED)
+    ObjectId id1 = ObjectId.get();
+    History scheduledEmail = new History(id1, tisReferenceInfo, PROGRAMME_CREATED, emailRecipient,
+        templateInfo, null, Instant.MIN, null, SCHEDULED, null, null);
+
+    // In-app notification with future sentAt
+    ObjectId id2 = ObjectId.get();
+    Instant futureTime = Instant.now().plus(Duration.ofDays(7));
+    History futureInApp = new History(id2, tisReferenceInfo, PROGRAMME_CREATED, inAppRecipient,
+        templateInfo, null, futureTime, null, UNREAD, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(scheduledEmail, futureInApp));
+
+    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected scheduled count.", result.size(), is(2));
+    assertThat("Unexpected scheduled notification.", result, hasItem(scheduledEmail));
+    assertThat("Unexpected scheduled notification.", result, hasItem(futureInApp));
+  }
+
+  @Test
+  void shouldFindNoScheduledForTraineeWhenNoneExist() {
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of());
+
+    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
+
+    assertThat("Unexpected scheduled count.", result.size(), is(0));
+  }
+
+  @Test
+  void shouldUpdateRecipientEmailForScheduledEmailNotification() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        Map.of("key1", "value1"));
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    History scheduledEmail = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        templateInfo, null, Instant.MIN, null, SCHEDULED, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(scheduledEmail));
+    when(repository.save(any(History.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(repository).save(historyCaptor.capture());
+
+    History saved = historyCaptor.getValue();
+    assertThat("Unexpected recipient email.", saved.recipient().contact(), is(newEmail));
+    assertThat("Unexpected recipient id.", saved.recipient().id(), is(TRAINEE_ID));
+    assertThat("Unexpected recipient type.", saved.recipient().type(), is(EMAIL));
+  }
+
+  @Test
+  void shouldUpdateTemplateVariablesEmailForScheduledNotification() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, oldEmail);
+    Map<String, Object> variables = new HashMap<>(Map.of("email", oldEmail, "key1", "value1"));
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    History scheduledEmail = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        templateInfo, null, Instant.MIN, null, SCHEDULED, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(scheduledEmail));
+    when(repository.save(any(History.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(repository).save(historyCaptor.capture());
+
+    History saved = historyCaptor.getValue();
+    assertThat("Unexpected recipient email.", saved.recipient().contact(), is(newEmail));
+    assertThat("Unexpected template email variable.", saved.template().variables().get("email"),
+        is(newEmail));
+    assertThat("Unexpected template non-email variable.",
+        saved.template().variables().get("key1"), is("value1"));
+  }
+
+  @Test
+  void shouldNotUpdateScheduledNotificationWhenEmailAlreadyMatches() {
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
+    Map<String, Object> variables = new HashMap<>(Map.of("email", TRAINEE_CONTACT));
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    History scheduledEmail = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        templateInfo, null, Instant.MIN, null, SCHEDULED, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(scheduledEmail));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, TRAINEE_CONTACT);
+
+    verify(repository, never()).save(any(History.class));
+  }
+
+  @Test
+  void shouldNotUpdateRecipientEmailForInAppScheduledNotification() {
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, null);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        Map.of("key1", "value1"));
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    Instant futureTime = Instant.now().plus(Duration.ofDays(7));
+    History futureInApp = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        templateInfo, null, futureTime, null, UNREAD, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(futureInApp));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    // In-app notification without "email" template variable should not be saved
+    verify(repository, never()).save(any(History.class));
+  }
+
+  @Test
+  void shouldUpdateTemplateVariablesEmailForInAppScheduledNotification() {
+    String oldEmail = "old@example.com";
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, IN_APP, null);
+    Map<String, Object> variables = new HashMap<>(Map.of("email", oldEmail));
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, variables);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    Instant futureTime = Instant.now().plus(Duration.ofDays(7));
+    History futureInApp = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        templateInfo, null, futureTime, null, UNREAD, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(futureInApp));
+    when(repository.save(any(History.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(repository).save(historyCaptor.capture());
+
+    History saved = historyCaptor.getValue();
+    assertThat("Unexpected recipient type.", saved.recipient().type(), is(IN_APP));
+    assertThat("Unexpected template email variable.", saved.template().variables().get("email"),
+        is(newEmail));
+  }
+
+  @Test
+  void shouldUpdateRecipientEmailForScheduledEmailNotificationWhenContactIsNull() {
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, null);
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
+        Map.of("key1", "value1"));
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    History scheduledEmail = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        templateInfo, null, Instant.MIN, null, SCHEDULED, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(scheduledEmail));
+    when(repository.save(any(History.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(repository).save(historyCaptor.capture());
+
+    History saved = historyCaptor.getValue();
+    assertThat("Unexpected recipient email.", saved.recipient().contact(), is(newEmail));
+    assertThat("Unexpected recipient id.", saved.recipient().id(), is(TRAINEE_ID));
+    assertThat("Unexpected recipient type.", saved.recipient().type(), is(EMAIL));
+  }
+
+  @Test
+  void shouldNotUpdateTemplateEmailWhenTemplateIsNull() {
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, "old@example.com");
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    History scheduledEmail = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        null, null, Instant.MIN, null, SCHEDULED, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(scheduledEmail));
+    when(repository.save(any(History.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(repository).save(historyCaptor.capture());
+
+    History saved = historyCaptor.getValue();
+    assertThat("Unexpected recipient email.", saved.recipient().contact(), is(newEmail));
+    assertThat("Unexpected template.", saved.template(), nullValue());
+  }
+
+  @Test
+  void shouldNotUpdateTemplateEmailWhenTemplateVariablesAreNull() {
+    String newEmail = "new@example.com";
+    RecipientInfo recipientInfo = new RecipientInfo(TRAINEE_ID, EMAIL, "old@example.com");
+    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION, null);
+    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
+
+    ObjectId id = ObjectId.get();
+    History scheduledEmail = new History(id, tisReferenceInfo, PROGRAMME_CREATED, recipientInfo,
+        templateInfo, null, Instant.MIN, null, SCHEDULED, null, null);
+
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of(scheduledEmail));
+    when(repository.save(any(History.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, newEmail);
+
+    ArgumentCaptor<History> historyCaptor = ArgumentCaptor.forClass(History.class);
+    verify(repository).save(historyCaptor.capture());
+
+    History saved = historyCaptor.getValue();
+    assertThat("Unexpected recipient email.", saved.recipient().contact(), is(newEmail));
+    assertThat("Unexpected template variables.", saved.template().variables(), nullValue());
+  }
+
+  @Test
+  void shouldNotUpdateScheduledNotificationWhenNoScheduledNotificationsExist() {
+    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
+        eq(TRAINEE_ID), any(Instant.class)))
+        .thenReturn(List.of());
+
+    service.updateScheduledNotificationEmail(TRAINEE_ID, "new@example.com");
+
+    verify(repository, never()).save(any(History.class));
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -1107,46 +1107,6 @@ class HistoryServiceTest {
     assertThat("Unexpected failed history last retry.", failed1.lastRetry(), is(Instant.MAX));
   }
 
-  @Test
-  void shouldFindAllScheduledForTraineeIncludingScheduledStatusAndFutureSentAt() {
-    RecipientInfo emailRecipient = new RecipientInfo(TRAINEE_ID, EMAIL, TRAINEE_CONTACT);
-    RecipientInfo inAppRecipient = new RecipientInfo(TRAINEE_ID, IN_APP, null);
-    TemplateInfo templateInfo = new TemplateInfo(TEMPLATE_NAME, TEMPLATE_VERSION,
-        TEMPLATE_VARIABLES);
-    TisReferenceInfo tisReferenceInfo = new TisReferenceInfo(TIS_REFERENCE_TYPE, TIS_REFERENCE_ID);
-
-    // Scheduled email notification (status = SCHEDULED)
-    ObjectId id1 = ObjectId.get();
-    History scheduledEmail = new History(id1, tisReferenceInfo, PROGRAMME_CREATED, emailRecipient,
-        templateInfo, null, Instant.MIN, null, SCHEDULED, null, null);
-
-    // In-app notification with future sentAt
-    ObjectId id2 = ObjectId.get();
-    Instant futureTime = Instant.now().plus(Duration.ofDays(7));
-    History futureInApp = new History(id2, tisReferenceInfo, PROGRAMME_CREATED, inAppRecipient,
-        templateInfo, null, futureTime, null, UNREAD, null, null);
-
-    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
-        eq(TRAINEE_ID), any(Instant.class)))
-        .thenReturn(List.of(scheduledEmail, futureInApp));
-
-    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
-
-    assertThat("Unexpected scheduled count.", result.size(), is(2));
-    assertThat("Unexpected scheduled notification.", result, hasItem(scheduledEmail));
-    assertThat("Unexpected scheduled notification.", result, hasItem(futureInApp));
-  }
-
-  @Test
-  void shouldFindNoScheduledForTraineeWhenNoneExist() {
-    when(repository.findAllScheduledByRecipientIdOrderBySentAtDesc(
-        eq(TRAINEE_ID), any(Instant.class)))
-        .thenReturn(List.of());
-
-    List<History> result = service.findAllScheduledForTrainee(TRAINEE_ID);
-
-    assertThat("Unexpected scheduled count.", result.size(), is(0));
-  }
 
   @Test
   void shouldUpdateRecipientEmailForScheduledEmailNotification() {

--- a/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/notifications/service/HistoryServiceTest.java
@@ -1336,6 +1336,20 @@ class HistoryServiceTest {
   }
 
   @Test
+  void shouldNotUpdateScheduledNotificationWhenTraineeIdIsNull() {
+    service.updateScheduledNotificationEmail(null, "new@example.com");
+
+    verifyNoInteractions(repository);
+  }
+
+  @Test
+  void shouldNotUpdateScheduledNotificationWhenNewEmailIsNull() {
+    service.updateScheduledNotificationEmail(TRAINEE_ID, null);
+
+    verifyNoInteractions(repository);
+  }
+
+  @Test
   void shouldDeleteHistoryForTrainee() {
 
     service.deleteHistoryForTrainee(HISTORY_ID, TRAINEE_ID);


### PR DESCRIPTION
NOTe: also implemented suggestion from @DorisWongNHS :  'Will also need to update the email in the notification’s content template.variables.email if there is any, so when the email sent out, the content is up-to-date and there won’t be confusion. Example: trainee received notification say they don’t have a TSS account with the old email.'

TIS21-8600